### PR TITLE
chore: post-audit hardening (SECURITY.md + dependabot.yml + cross-references)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -71,9 +71,11 @@ the v0.7.0 collector pattern + v0.7.1 AI generator pattern:
   (772 lines covering sync + async + batch + retry + air-gap +
   GenerationContext). Mock LLM via `unittest.mock.patch` of
   `instructor.Instructor.chat.completions.create`.
-- **Mypy strict**: `--strict` against all 6 packages; expect
-  `Success: no issues found in 98 source files` (count grows with
-  new modules).
+- **Mypy**: CI runs `--strict-optional` against the 5 in-tree
+  src directories; expect `Success: no issues found in 86 source
+  files` (count grows with new modules). `--strict` mode reveals
+  additional findings from third-party type stubs that aren't
+  blocking; not gated.
 - **Ruff**: lint-clean is required; format-on-save is the default.
 - **Three OS matrix**: tests pass on Ubuntu / Windows / macOS via CI
   (`tests.yml`). Local Windows shows 8 environmental skips (GnuPG
@@ -94,7 +96,7 @@ the v0.7.0 collector pattern + v0.7.1 AI generator pattern:
 
 ## Release / publishing discipline — read carefully
 
-**Allen owns publish authority. Cursor must NEVER**:
+**The maintainer owns publish authority. Cursor must NEVER**:
 
 1. Suggest `git push` (any remote) without prefacing it as
    "irreversible — needs explicit approval".
@@ -113,25 +115,23 @@ the v0.7.0 collector pattern + v0.7.1 AI generator pattern:
    policy (only `main` deploys).
 
 Local edits + local commits are OK. Surfacing irreversible commands
-for Allen to run is OK. Running them is NOT.
+for the maintainer to run is OK. Running them is NOT.
 
 ## Commit-attribution discipline
 
-Commits authored by Allen Byrd
-`<125306425+allenfbyrd@users.noreply.github.com>`. **Never include**:
+The repository maintains human-only attribution in git metadata.
+**Never include**:
 
-- `Co-Authored-By: Claude` or other Claude/AI co-author trailers
-- `🤖 Generated with [Claude Code]` or similar attribution footers
-- Any reference to the Cursor or Claude Code CLI tool in commit
-  metadata
+- `Co-Authored-By:` trailers naming AI assistants (Claude, Copilot,
+  any model)
+- `🤖 Generated with` or similar AI-attribution footers
+- Any reference to the AI editor / CLI tool in commit metadata
 
 The README's "AI assistance" acknowledgment section is the right
 place to credit AI tools (acknowledgment in content, not attribution
-in git metadata). The contributor widget on GitHub stays human.
+in git metadata). The contributor widget on GitHub stays human-only.
 
 ## Commit-decomposition rubric
-
-Per `~/.claude/skills/pre-release-review/SKILL.md` Step 5:
 
 1. Each commit is buildable on its own (no broken-bisect commits).
 2. Group by dependency depth, not file path. Foundation primitives
@@ -155,10 +155,7 @@ Per `~/.claude/skills/pre-release-review/SKILL.md` Step 5:
   reverting to the default `width=80` — that re-introduces the
   whitespace-only false positives.
 
-## Cross-link to Allen's global memory
+## When in doubt
 
-The project's CLAUDE.md / Cursor patterns + global publishing-authority
-protocol live in `~/.claude/CLAUDE.md` (Allen's private global
-instructions). Cursor cannot read that path, but its rules are
-mirrored above. When in doubt, defer to Allen's explicit instruction
-for any unfamiliar command, especially anything irreversible.
+Defer to the maintainer's explicit instruction for any unfamiliar
+command, especially anything irreversible.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,98 @@
+# Dependabot configuration for Evidentia.
+#
+# Security updates run regardless of this file (GitHub auto-detects
+# manifests for security advisories). This file enables and configures
+# regular VERSION updates — periodic non-security bumps that keep deps
+# current.
+#
+# Conventions:
+#   - Weekly cadence (Monday 06:00 ET) — single batch to triage at the
+#     start of the week, not a daily drip.
+#   - Grouped updates (one PR per group, not per package) — turns ~10
+#     individual PRs into ~3 reviewable batches.
+#   - Per-ecosystem open-PR cap so the queue can't run away.
+#   - Conventional-commit prefixes so release-automation tooling parses
+#     the bump-type correctly.
+#
+# Security update PRs are NEVER grouped (see `applies-to: version-updates`
+# scope on each group below) — each advisory deserves its own PR with a
+# clear advisory reference, per the v0.7.2 supply-chain follow-up
+# pattern (commit 8baa93d).
+
+version: 2
+updates:
+
+  # ---------------------------------------------------------------------
+  # Python (uv workspace — covers all 7 pyproject.toml files via uv.lock)
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python:uv"
+    groups:
+      python-runtime:
+        applies-to: version-updates
+        dependency-type: "production"
+      python-dev:
+        applies-to: version-updates
+        dependency-type: "development"
+
+  # ---------------------------------------------------------------------
+  # Frontend (npm — packages/evidentia-ui)
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directory: "/packages/evidentia-ui"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      npm-runtime:
+        applies-to: version-updates
+        dependency-type: "production"
+      npm-dev:
+        applies-to: version-updates
+        dependency-type: "development"
+
+  # ---------------------------------------------------------------------
+  # GitHub Actions (workflow files in .github/workflows/)
+  # ---------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,8 @@ silently dropped malformed catalog files).
 
 **965 tests passing** (8 environmental skips on local Windows for
 GnuPG entropy + Sigstore CI-OIDC; full suite passes on Linux CI per
-the v0.7.1 baseline). mypy strict clean (98 source files); ruff lint
-clean.
+the v0.7.1 baseline). mypy clean against the CI gate
+(`--strict-optional` over 86 source files); ruff lint clean.
 
 This release also adds a `.local/` per-developer scratch directory
 to `.gitignore` for working notes and drafts not ready to share. The
@@ -105,15 +105,10 @@ polish + DOC6 pre-commit hooks + DOC7 dev container).
   doctor), 16 pre-canned tasks (uv sync, pytest, mypy, ruff, build,
   twine check, pre-release gate composite, evidentia doctor, serve,
   + 4 frontend tasks).
-- **`.cursorrules`** — Cursor AI guardrails encoding the Evidentia
-  quality-bar patterns (typed exception hierarchy, `@with_retry`,
-  `BLIND_SPOTS`, audit logger, network_guard, secret scrubber,
-  no-shortened-imports), testing patterns, frontend patterns
-  (Radix primitives for WCAG, TanStack Query, Zustand), release /
-  publishing-authority discipline (Cursor must NEVER suggest
-  irreversible commands), commit-attribution discipline (no
-  `Co-Authored-By: Claude` trailers ever), commit-decomposition
-  rubric. Mirrors the publicly-safe parts of `~/.claude/CLAUDE.md`.
+- **`.cursorrules`** — Cursor AI guardrails encoding project
+  conventions (typed exception hierarchy, audit logger, network
+  guard, secret scrubber, commit-attribution, publishing-authority
+  discipline). Inline-enforcement sister to CONTRIBUTING.md.
 - **`.editorconfig`** — cross-editor consistency for any IDE that
   honors EditorConfig: utf-8, LF, trim trailing whitespace, final
   newline, 4-space indent for Python, 2-space for JS/TS/YAML, tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet on the v0.7.3 development branch._
+Post-v0.7.2 hardening (operational + policy; no source changes):
+
+### Added
+
+- **`SECURITY.md`** — vulnerability disclosure policy at the repo
+  root (rendered under the GitHub Security tab + linked from the
+  "Report a vulnerability" affordance). Documents the GitHub
+  Private Vulnerability Reporting flow (preferred channel) +
+  email backup, required-info checklist for reports, SLA
+  (3 business days initial / 10 business days triage), supported
+  versions (single-supported-patch policy with explicit
+  deprecation reasons for older patches that carry vulnerable
+  transitive dep ranges), 90-day disclosure timeline with
+  documented flexibility (shorter for upstream-fix-then-bump per
+  v0.7.2 commit `8baa93d`, longer for architectural fixes by
+  mutual agreement), in/out of scope (explicitly out: AWS
+  canonical-example placeholders in test fixtures, Tier-C
+  placeholder catalog text, third-party deps), supply-chain
+  provenance verification command (`pypi-attestations verify
+  pypi`).
+- **`.github/dependabot.yml`** — weekly grouped version-update
+  PRs across uv (Python — covers all 7 pyproject.toml files via
+  uv.lock), npm (frontend), and github-actions ecosystems.
+  Single Monday-06:00-ET batch (no daily drip), grouped by
+  production/development split, per-ecosystem open-PR caps
+  (5/5/3). Conventional-commit prefixes (`chore(deps)`,
+  `chore(deps-dev)`, `chore(actions)`). Security update PRs
+  remain ungrouped (groups scoped via `applies-to:
+  version-updates`) so each advisory still gets its own PR with
+  clear references, per the v0.7.2 supply-chain follow-up
+  pattern.
+- **README.md `## Security` section** — points at SECURITY.md +
+  summarizes supply-chain provenance.
+- **CONTRIBUTING.md `## Reporting security issues` section** —
+  routes security reports to SECURITY.md; warns against using
+  the bug-report template for vulnerabilities.
+
+### Changed
+
+- **GitHub repo settings (operational, not in source)** —
+  branch protection on `main` (required status checks: pytest x
+  3 OS + ruff + mypy + frontend; `enforce_admins: false`;
+  `allow_force_pushes: false`; `allow_deletions: false`).
+  Dependabot security updates + Dependabot malware alerts +
+  automatic dependency submission enabled. CodeQL default-config
+  analysis enabled. Secret-scanning non-provider patterns +
+  validity checks deferred — currently unavailable on
+  personal-account public repositories.
 
 ## [0.7.2] - 2026-04-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,13 @@ Python 3.12+ and [uv](https://docs.astral.sh/uv/) 0.4+ are required.
 - [ ] New third-party dependencies are justified in the PR description
 - [ ] The PR description explains the "why", not just the "what"
 
+## Reporting security issues
+
+**Security issues do not belong in public bug reports.** See
+[`SECURITY.md`](SECURITY.md) for the private vulnerability
+disclosure process — GitHub Private Vulnerability Reporting is
+the preferred channel; email is documented as a backup.
+
 ## Reporting bugs and proposing features
 
 Use the GitHub issue templates:
@@ -85,7 +92,9 @@ Use the GitHub issue templates:
 - **Bug report** — for something that doesn't work as documented
 - **Feature request** — for new functionality or behavior changes
 
-For questions, use GitHub Discussions rather than issues.
+For questions, use GitHub Discussions rather than issues. For
+**security issues, see the section above** — never use the bug
+report template for vulnerabilities.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -787,6 +787,23 @@ Phases 1, 1.5, 2 (Jira + AWS + GitHub), and Accessible GRC (v0.4.x web UI
 
 ---
 
+## Security
+
+Please **do not open a public GitHub issue** for security concerns.
+See [`SECURITY.md`](SECURITY.md) for the disclosure process —
+GitHub Private Vulnerability Reporting is the preferred channel;
+email is documented as a backup. The policy also covers the
+supported-version table, scope, disclosure timeline, and
+supply-chain provenance verification.
+
+Every release ships with cryptographic provenance: PEP 740
+attestations on every wheel + sdist (Sigstore + Rekor), CycloneDX
+1.6 SBOM attached to each [GitHub
+Release](https://github.com/allenfbyrd/evidentia/releases).
+Verification command in [`SECURITY.md`](SECURITY.md).
+
+---
+
 ## License
 
 [Apache License 2.0](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,24 +37,36 @@ the full coordination window.
 
 ## Supported versions
 
-Evidentia is pre-1.0 and ships from a single supported release line.
-Security patches land on the latest minor; older minors do not
-receive backports.
+Evidentia is pre-1.0 and ships from a **single supported patch
+release**, not a minor-line. The latest patch is the only version
+guaranteed to be free of disclosed advisories — older patches in the
+same minor are deprecated as soon as a successor ships, even if the
+deprecation reason is "carries pinned dep ranges that allow
+installation of upstream-vulnerable transitive versions" rather than
+a vulnerability in Evidentia's own code.
 
-| Version | Status | Security patches |
-|---------|--------|------------------|
-| `0.7.x` | **Supported** | ✅ landed in next patch |
-| `0.6.x` | Deprecated | ❌ — upgrade to `0.7.x` |
-| `0.5.x` and earlier | Unsupported | ❌ — upgrade to `0.7.x` |
-| Legacy `controlbridge*` packages | Yanked from PyPI | ❌ — every version yanked; upgrade path documented in [`RENAMED.md`](RENAMED.md) |
+| Version | Status | Reason |
+|---------|--------|--------|
+| **`0.7.2`** | ✅ **Supported** | Latest patch. Pin floors raised past the v0.7.2 supply-chain follow-up advisories ([commit `8baa93d`](https://github.com/allenfbyrd/evidentia/commit/8baa93d)). |
+| `0.7.1` | ❌ Deprecated | Pinned `litellm>=1.83.0` (allows install of vulnerable 1.83.0–1.83.6 — see [GHSA-r75f-5x8p-qvmc](https://github.com/advisories/GHSA-r75f-5x8p-qvmc) CRITICAL, [GHSA-xqmj-j6mv-4862](https://github.com/advisories/GHSA-xqmj-j6mv-4862) HIGH, [GHSA-v4p8-mg3p-g94g](https://github.com/advisories/GHSA-v4p8-mg3p-g94g) HIGH) and `python-multipart>=0.0.9` (allows vulnerable 0.0.9–0.0.25 — [CVE-2026-40347](https://nvd.nist.gov/vuln/detail/CVE-2026-40347)). Upgrade to `0.7.2`. |
+| `0.7.0` | ❌ Deprecated | Same pin-floor exposure as `0.7.1` plus the AI-features hardening that landed in `0.7.1`. Upgrade to `0.7.2`. |
+| `0.6.x` | ❌ Deprecated | Predates the `enterprise-grade` supply-chain hardening (Sigstore signing, PEP 740 attestations, OIDC publisher) that landed in `0.7.0`. Upgrade to `0.7.2`. |
+| `0.5.x` and earlier | ❌ Unsupported | Pre-rename codebase + missing AI-features hardening + missing supply-chain hardening. Upgrade to `0.7.2`. |
+| Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](RENAMED.md). |
 
-When v0.8.0 ships, v0.7.x moves to maintenance mode (security-only
-patches for one minor cycle, then deprecation). The exact deprecation
-timeline will be documented in the v0.8.0 release notes and in
-[`docs/release-checklist.md`](docs/release-checklist.md).
+**Read this strictly**: an older patch — even `0.7.1` shipped less
+than 24 hours before `0.7.2` — is deprecated the moment a successor
+ships if disclosed advisories make the older patch's resolved
+dependency tree exploitable. Pre-1.0, there are no backports. The
+single supported patch is always the answer.
 
-Once v1.0 ships, the supported-version policy will tighten to
-explicit semver guarantees (latest minor of each supported major).
+When `v0.8.0` ships, the same single-supported-patch policy applies
+to `0.8.x`. `v0.7.2` will move to a brief maintenance window
+(security-only patches for the period documented in the v0.8.0
+release notes), then deprecation.
+
+Once `v1.0` ships, the supported-version policy will tighten to
+explicit semver guarantees (latest patch of each supported minor).
 
 ## Disclosure timeline
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,163 @@
+# Security policy
+
+Thanks for taking the time to report a security concern. Evidentia
+takes its supply-chain posture seriously — see the per-release
+hardening in [`docs/enterprise-grade.md`](docs/enterprise-grade.md)
+and the supply-chain provenance section of every release on
+[GitHub Releases](https://github.com/allenfbyrd/evidentia/releases).
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security concerns.**
+
+Two private channels:
+
+1. **Preferred — GitHub Private Vulnerability Reporting**:
+   <https://github.com/allenfbyrd/evidentia/security/advisories/new>.
+   This routes through GitHub's coordinated-disclosure flow (private
+   discussion thread, advisory drafting, optional CVE assignment).
+2. **Backup — email**: `allen@allenfbyrd.com` with subject
+   `[SECURITY] Evidentia <one-line summary>`. Please use this only
+   if GitHub Private Vulnerability Reporting is unavailable.
+
+Please include:
+
+- Affected version(s) (`pip show evidentia` output is fine).
+- Reproduction steps or a proof-of-concept (minimal is fine —
+  willingness to engage matters more than polish).
+- Your assessment of impact (data exposed, code execution,
+  authentication bypass, etc.).
+- Any suggested mitigation if you have one.
+- Whether you'd like credit in the advisory (default: yes, with
+  the name/handle you specify; no, if you prefer anonymous).
+
+Initial acknowledgment within **3 business days**. Triage assessment
+within **10 business days**. See **Disclosure timeline** below for
+the full coordination window.
+
+## Supported versions
+
+Evidentia is pre-1.0 and ships from a single supported release line.
+Security patches land on the latest minor; older minors do not
+receive backports.
+
+| Version | Status | Security patches |
+|---------|--------|------------------|
+| `0.7.x` | **Supported** | ✅ landed in next patch |
+| `0.6.x` | Deprecated | ❌ — upgrade to `0.7.x` |
+| `0.5.x` and earlier | Unsupported | ❌ — upgrade to `0.7.x` |
+| Legacy `controlbridge*` packages | Yanked from PyPI | ❌ — every version yanked; upgrade path documented in [`RENAMED.md`](RENAMED.md) |
+
+When v0.8.0 ships, v0.7.x moves to maintenance mode (security-only
+patches for one minor cycle, then deprecation). The exact deprecation
+timeline will be documented in the v0.8.0 release notes and in
+[`docs/release-checklist.md`](docs/release-checklist.md).
+
+Once v1.0 ships, the supported-version policy will tighten to
+explicit semver guarantees (latest minor of each supported major).
+
+## Disclosure timeline
+
+Standard coordinated-disclosure window: **90 days from initial report
+to public disclosure**. The window can shorten or lengthen by mutual
+agreement — for example:
+
+- **Shorter**: if the upstream library has already published a fix
+  and we just need to bump our pin, we can ship + disclose within
+  days. The v0.7.2 supply-chain follow-up
+  ([commit 8baa93d](https://github.com/allenfbyrd/evidentia/commit/8baa93d))
+  is the canonical pattern: 4 disclosed advisories in upstream
+  packages → bumped pins → shipped + documented within hours of
+  internal alerts firing.
+- **Longer**: if the fix requires architectural changes, we'll
+  request a window extension in the private discussion thread and
+  agree on a target date.
+
+After fix lands and is published to PyPI, the GitHub Security
+Advisory is published and (if applicable) a CVE is requested.
+Reporters are credited unless they opt out.
+
+## Scope
+
+In scope:
+
+- Code in this repository (`packages/evidentia*/src/...`,
+  `packages/evidentia-ui/src/...`, `scripts/...`).
+- Build + release infrastructure (`.github/workflows/*.yml`).
+- Distribution surface (PyPI packages `evidentia`, `evidentia-core`,
+  `evidentia-collectors`, `evidentia-ai`, `evidentia-api`,
+  `evidentia-integrations`).
+- The composite GitHub Action
+  (`.github/actions/gap-analysis/action.yml`).
+- The bundled framework catalogs and crosswalk mappings
+  (`packages/evidentia-core/src/evidentia_core/catalogs/data/`)
+  insofar as a maliciously-crafted catalog could cause harm at
+  load time.
+
+Out of scope:
+
+- **Vulnerabilities in third-party dependencies**. Report those to
+  the upstream maintainer. Once a fix is published upstream, our
+  Dependabot configuration
+  ([`.github/dependabot.yml`](.github/dependabot.yml)) opens an
+  auto-PR within the next weekly cycle, or sooner for critical
+  advisories. Recent example:
+  [PR #8](https://github.com/allenfbyrd/evidentia/pull/8) closed
+  4 upstream advisories within hours of disclosure.
+- **AWS canonical-example placeholders** in test files
+  (`AKIAIOSFODNN7EXAMPLE`, `ASIAIOSFODNN7EXAMPLE` —
+  [AWS-published](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html)
+  literals that are never valid credentials). These are
+  intentional test fixtures for the secret-scrubber's own unit
+  tests.
+- **Tier-C placeholder catalog text** (catalogs with the
+  `placeholder: true` flag). Authoritative control text for these
+  frameworks is copyrighted and not bundled; the placeholder text
+  is intentionally non-authoritative. Use
+  `evidentia catalog import` to load your licensed copy.
+- **Findings against unsupported versions** (see Supported versions
+  table above). If a vulnerability exists in `0.6.x` but not in
+  `0.7.x`, the remediation is to upgrade.
+- **Self-XSS, social engineering, or attacks requiring physical
+  access to the user's machine.**
+- **Theoretical issues without a reproducible exploit path**
+  (e.g., "function X uses crypto algorithm Y which has theoretical
+  weaknesses").
+
+If you're unsure whether something is in scope, report it anyway.
+We'd rather triage and decline than miss a real issue.
+
+## Supply-chain provenance
+
+Every Evidentia release ships with cryptographic provenance:
+
+- **PEP 740 attestations** on every wheel + sdist, signed via the
+  GitHub Actions OIDC identity (Sigstore + Rekor public
+  transparency log).
+- **CycloneDX 1.6 SBOM** generated from `uv.lock`, attached to
+  every GitHub Release.
+- **Sigstore/Rekor signing** of every OSCAL Assessment Results
+  document (or GPG `.asc` signatures in air-gap mode).
+
+Verify a release wheel:
+
+```bash
+pip install pypi-attestations
+pypi-attestations verify pypi \
+  --repository https://github.com/allenfbyrd/evidentia \
+  "pypi:evidentia-0.7.2-py3-none-any.whl"
+```
+
+If verification fails, **stop and report immediately** via the
+private channels above — a verification failure on a published
+artifact is itself a security incident.
+
+## Acknowledgments
+
+Coordinated security reports — once disclosed and fixed — are
+credited in the corresponding release notes and in the GitHub
+Security Advisory. If you'd like a place on a future
+`SECURITY-HALL-OF-FAME.md`-style page, that's planned for v0.8.x;
+for now, recognition is in-release-only.
+
+Thank you in advance for helping keep Evidentia and its users safe.


### PR DESCRIPTION
Operational + policy changes following the v0.7.2 public-surface audit. No source-code changes; this PR adds repo-level discipline that the audit flagged as gaps.

## Summary

Three new files + cross-references in three existing files:

| File | Purpose |
|---|---|
| `SECURITY.md` (new, root) | Vulnerability disclosure policy. Renders under the GitHub Security tab + linked from the "Report a vulnerability" affordance. |
| `.github/dependabot.yml` (new) | Weekly grouped version-update PRs across uv, npm, github-actions ecosystems. |
| `CHANGELOG.md` | `[Unreleased]` populated with this PR's additions + the operational settings landed alongside it (branch protection, Dependabot toggles, CodeQL). |
| `README.md` | New `## Security` section pointing at SECURITY.md + supply-chain provenance summary. |
| `CONTRIBUTING.md` | New `## Reporting security issues` section routing security reports to SECURITY.md. |
| `SECURITY.md` (continued) | Supported-versions table tightened from "0.7.x supported" to "0.7.2 only" — older patches deprecated due to pinned dep ranges that allow installation of upstream-vulnerable transitive versions (4 GHSAs cited inline). |

## SECURITY.md highlights

- Reporting channels: GitHub Private Vulnerability Reporting (preferred) + email backup. SLA: 3 business days initial / 10 business days triage.
- Supported versions: single-supported-patch policy. `0.7.2` only; `0.7.0`/`0.7.1` deprecated with explicit CVE references; `0.6.x` deprecated; `0.5.x` and earlier unsupported; legacy `controlbridge*` packages yanked.
- Disclosure timeline: 90-day standard with documented flexibility (shorter for upstream-fix-then-bump per v0.7.2 commit `8baa93d`; longer for architectural fixes by mutual agreement).
- In/out of scope: explicit list including out-of-scope AWS canonical-example placeholders in test fixtures (with link to AWS docs) and Tier-C placeholder catalog text.
- Supply-chain provenance: PEP 740 + CycloneDX SBOM + Sigstore. Verify command included. Notes that a verify FAILURE is itself a security incident.

## .github/dependabot.yml highlights

- Three ecosystems: `uv` (Python — covers all 7 pyproject.toml files via uv.lock), `npm` (frontend — packages/evidentia-ui), `github-actions` (workflow files).
- Weekly cadence (Monday 06:00 ET) — single batch to triage at the start of the week, not a daily drip.
- Grouped by production/development split — turns ~10 individual PRs into ~3 reviewable batches per ecosystem.
- Per-ecosystem open-PR caps (5/5/3) so the queue can't run away.
- Conventional-commit prefixes (`chore(deps)`, `chore(deps-dev)`, `chore(actions)`).
- Security update PRs remain ungrouped (groups scoped via `applies-to: version-updates`) so each advisory still gets its own PR with clear references — the v0.7.2 supply-chain follow-up pattern (commit `8baa93d`) is the canonical example.

## Operational changes (landed before this PR opens)

| Change | Status |
|---|---|
| Branch protection on `main` (6 required status checks; `enforce_admins: false`; `allow_force_pushes: false`; `allow_deletions: false`) | ✅ Live (this PR is the first to merge through it) |
| Dependabot security updates | ✅ Enabled |
| Dependabot malware alerts | ✅ Enabled |
| Automatic dependency submission | ✅ Enabled |
| CodeQL default-config analysis | ✅ Enabled |
| Secret-scanning non-provider patterns | ⏸️ Deferred — currently unavailable on personal-account public repositories |
| Secret-scanning validity checks | ⏸️ Deferred — currently unavailable on personal-account public repositories |

## Tests

This PR has no source changes. CI runs anyway through the new branch protection (6 required checks: pytest x 3 OS + ruff + mypy + frontend). Expect all green.

## Supersedes

None — this is net-new content following the v0.7.2 supply-chain follow-up (commit `8baa93d`, PR #8).