### PR TITLE
Ci(gate): Run the pre-push gate with --all-extras to match CI (gate fidelity)

### DIFF
--- a/scripts/run_gate_suite.py
+++ b/scripts/run_gate_suite.py
@@ -150,7 +150,16 @@ def checks_for_scope(scope: str) -> tuple[Check, ...]:
 
 def _run_check(check: Check) -> int:
     """Shell out to one check via ``uv run``; return its exit code."""
-    cmd = ["uv", "run", *check.argv]
+    # Gate fidelity: resolve every check against the SAME --all-extras
+    # --all-packages environment CI uses (test.yml's pytest / mypy / osv jobs
+    # sync ``--all-extras --all-packages``). Without this, the local pre-push
+    # gate ran pytest in the default no-extras env, so the collector-SSRF tests
+    # that import optional DB/cloud drivers (snowflake / databricks / psycopg)
+    # failed locally with ModuleNotFoundError while passing in CI — a false-red
+    # that erodes trust in the gate. One environment definition, used locally
+    # AND in CI, so "passes locally" and "passes in CI" cannot mean two
+    # different things.
+    cmd = ["uv", "run", "--all-extras", "--all-packages", *check.argv]
     print(f"\n--- {check.name} ---")
     print(f"$ {' '.join(cmd)}")
     proc = subprocess.run(cmd, check=False)


### PR DESCRIPTION
Closes the local↔CI gate-fidelity gap surfaced by this cycle's Dependabot PRs. `scripts/run_gate_suite.py` shelled each check via plain `uv run` (default no-extras env); CI's pytest/mypy/osv jobs sync `--all-extras --all-packages`. So the collector-SSRF tests that import optional DB/cloud drivers (snowflake/databricks/psycopg) passed in CI but failed the local gate with ModuleNotFoundError — a false-red that forced a logged bypass on #94. Now every check runs via `uv run --all-extras --all-packages`, so the local gate and CI resolve the SAME environment. Validated end-to-end: this branch pushed with the pre-push gate PASSING green and NO bypass (the same scenario that previously needed one). The labcoat research that motivated this is captured in docs/engineering-practices.md Lesson 7.