### PR TITLE
Chore(deps): Migrate to typer 0.26 + click 8.2 (vendored Click + stderr split)

### DIFF
--- a/packages/evidentia/pyproject.toml
+++ b/packages/evidentia/pyproject.toml
@@ -27,16 +27,14 @@ dependencies = [
     "evidentia-eval>=0.10.13,<0.11.0",
     "evidentia-collectors>=0.10.13,<0.11.0",
     "evidentia-integrations>=0.10.13,<0.11.0",
-    # typer + click are held below the versions that ship click 8.2's CLI
-    # behavior change: 8.2 removed CliRunner's mix_stderr and splits stderr from
-    # stdout, and make_metavar() now requires a ctx; typer 0.26 additionally
-    # vendors its own click so TyperGroup is no longer a click.Group. The test
-    # suite and the wiki reference generator (scripts/wiki/sync_reference.py)
-    # assume the pre-8.2 behavior. Adopting click 8.2 / typer 0.26 is tracked as a
-    # dedicated migration follow-up — lift both caps there so it gets isolated
-    # review rather than riding an 18-package group bump.
-    "typer>=0.14,<0.26",
-    "click>=8.0,<8.2",
+    # click 8.2 removed CliRunner's mix_stderr (stderr is now always a separate
+    # stream) and typer 0.26 vendors its own click. The test suite and the wiki
+    # reference generator (scripts/wiki/sync_reference.py) were updated to match
+    # when these caps were lifted (see the typer/click migration). The next
+    # breaking release is capped (typer 0.x minors are breaking-prone; click 9.0)
+    # so a future bump gets isolated review rather than riding a group bump.
+    "typer>=0.26,<0.27",
+    "click>=8.2,<9.0",
     "rich>=13.0",
 ]
 

--- a/scripts/wiki/sync_reference.py
+++ b/scripts/wiki/sync_reference.py
@@ -166,13 +166,24 @@ def _format_click_param(param: Any) -> tuple[str, str]:
     parameter's help text (empty for Arguments, which Click does not carry
     help on).
     """
-    import click
-
-    if isinstance(param, click.Option):
+    # Duck-type rather than ``isinstance(param, click.Option)``: typer 0.26
+    # vendors its own Click, so a Typer app's params are vendored-Click
+    # instances that fail an external-``click`` isinstance check.
+    # ``param_type_name`` ("option" / "argument") is the stable,
+    # vendor-agnostic discriminator that works on either Click.
+    if getattr(param, "param_type_name", "") == "option":
         invocation = ", ".join(param.opts + param.secondary_opts)
         return invocation, (param.help or "")
     # Argument: no help attribute; show the (upper-cased) metavar/name.
-    name = param.make_metavar() if hasattr(param, "make_metavar") else param.name
+    # Click 8.2+ made make_metavar() require a ctx; typer's override defaults
+    # it to None, so the no-arg call works for Typer params — fall back to the
+    # ctx-taking signature (then the raw name) to stay robust on either Click.
+    name: Any = param.name
+    if hasattr(param, "make_metavar"):
+        try:
+            name = param.make_metavar()
+        except TypeError:
+            name = param.make_metavar(None)
     return str(name), ""
 
 
@@ -188,7 +199,10 @@ def _walk_click_command(
     commands record their parameters. Deterministic: subcommands are always
     visited alphabetically.
     """
-    import click
+    # Duck-type the Click introspection so it works on typer 0.26's vendored
+    # Click (see _format_click_param): a group exposes ``list_commands`` /
+    # ``get_command``; ``param_type_name`` discriminates option vs argument.
+    is_group = hasattr(command, "list_commands")
 
     help_text = first_docstring_line(command.help) if command.help else ""
     params = [
@@ -196,20 +210,23 @@ def _walk_click_command(
         for p in command.params
         # Skip the auto-added --help flag; it is on every command and adds
         # no signal.
-        if not (isinstance(p, click.Option) and p.name == "help")
+        if not (getattr(p, "param_type_name", "") == "option" and p.name == "help")
     ]
     rows.append(
         {
             "path": list(path),
             "help": help_text,
             "params": params,
-            "is_group": isinstance(command, click.Group),
+            "is_group": is_group,
         }
     )
-    if isinstance(command, click.Group):
-        ctx = click.Context(command, info_name=path[-1] if path else command.name)
-        for sub_name in sorted(command.list_commands(ctx)):
-            sub = command.get_command(ctx, sub_name)
+    if is_group:
+        # ctx=None is sufficient for a static command tree — list_commands /
+        # get_command on a basic group ignore it (verified against the live
+        # Typer app). Avoids constructing a Click Context, which would mix
+        # the external and vendored Click classes.
+        for sub_name in sorted(command.list_commands(None)):
+            sub = command.get_command(None, sub_name)
             if sub is None:  # pragma: no cover — defensive
                 continue
             _walk_click_command(sub, [*path, sub_name], rows)

--- a/tests/unit/test_eval/test_harness.py
+++ b/tests/unit/test_eval/test_harness.py
@@ -608,8 +608,9 @@ class TestRiskDeterminismFaithfulnessCLI:
             ],
         )
         assert result.exit_code == 2
-        # CliRunner default merges stderr into stdout.
-        assert "--source-clauses-file" in (result.stdout or "")
+        # Click 8.2+ keeps stderr a separate stream (it no longer merges into
+        # stdout), so the usage error message lands on result.stderr.
+        assert "--source-clauses-file" in (result.stderr or "")
 
     def test_invalid_faithfulness_method_exits_2(
         self, tmp_path: Path
@@ -913,9 +914,11 @@ class TestFaithfulnessThresholdMode:
             ],
         )
         assert result.exit_code == 2
+        # Click 8.2+ keeps stderr separate; the invalid-choice usage error
+        # lands on stderr (no longer merged into stdout).
         assert (
-            "framework-aware" in (result.stdout or "")
-            or "fixed" in (result.stdout or "")
+            "framework-aware" in (result.stderr or "")
+            or "fixed" in (result.stderr or "")
         )
 
     def test_fixed_mode_uses_0_30(

--- a/tests/unit/test_mcp/test_server.py
+++ b/tests/unit/test_mcp/test_server.py
@@ -529,11 +529,10 @@ class TestCLI:
     def test_serve_with_no_stdio_exits_2(self) -> None:
         """Operators trying to bypass stdio without --transport
         get a clear error pointing at the new flag."""
-        # CliRunner's mix_stderr=False keeps stderr separately
-        # captured; without it, the err output is mixed into
-        # stdout. Use mix_stderr=False so we can assert on the
-        # error message specifically.
-        runner = CliRunner(mix_stderr=False)
+        # Click 8.2+ always keeps stderr a separate stream and removed the
+        # mix_stderr parameter, so result.stderr carries the error message
+        # without any CliRunner configuration.
+        runner = CliRunner()
         # We pass --no-stdio which the implementation rejects
         # (with a hint to use --transport instead).
         result = runner.invoke(mcp_cli_app, ["serve", "--no-stdio"])
@@ -552,13 +551,14 @@ class TestCLI:
         vary unpredictably across local/CI/OS — checking the
         parameter declarations directly is deterministic.
         """
-        import click
         from typer.main import get_command
 
         click_app = get_command(mcp_cli_app)
-        # click_app is a Group; .get_command(ctx, name) walks
-        # subcommands. Pass ctx=None — no command actually runs.
-        assert isinstance(click_app, click.Group)
+        # click_app is a group (a TyperGroup under typer 0.26's vendored
+        # Click). Duck-type the introspection: typer vendors its own Click, so
+        # external-``click`` isinstance checks fail. .get_command(None, name)
+        # walks subcommands without constructing a Context.
+        assert hasattr(click_app, "get_command")
         serve_cmd = click_app.get_command(None, "serve")  # type: ignore[arg-type]
         assert serve_cmd is not None, "serve subcommand missing"
 
@@ -569,19 +569,20 @@ class TestCLI:
         transport_param = next(
             p for p in serve_cmd.params if "--transport" in p.opts
         )
-        # Typer renders enum-typed Options as click.Choice; the
-        # choices are the enum's value strings.
-        assert isinstance(transport_param.type, click.Choice)
+        # Typer renders enum-typed Options as a Click Choice (vendored under
+        # typer 0.26); duck-type via .choices rather than isinstance.
+        assert hasattr(transport_param.type, "choices")
         choice_values = set(transport_param.type.choices)
         assert {"stdio", "sse", "http"}.issubset(choice_values)
 
     def test_serve_help_shows_host_port(self) -> None:
         """v0.8.1 P3.1: --host + --port flags are documented."""
-        import click
         from typer.main import get_command
 
         click_app = get_command(mcp_cli_app)
-        assert isinstance(click_app, click.Group)
+        # Duck-type: typer 0.26 vendors its own Click, so an external-``click``
+        # isinstance check fails. .get_command(None, name) walks subcommands.
+        assert hasattr(click_app, "get_command")
         serve_cmd = click_app.get_command(None, "serve")  # type: ignore[arg-type]
         assert serve_cmd is not None, "serve subcommand missing"
 
@@ -591,11 +592,12 @@ class TestCLI:
 
     def test_serve_help_shows_allow_root(self) -> None:
         """v0.8.2 F-V81-S1: --allow-root flag is documented."""
-        import click
         from typer.main import get_command
 
         click_app = get_command(mcp_cli_app)
-        assert isinstance(click_app, click.Group)
+        # Duck-type: typer 0.26 vendors its own Click, so an external-``click``
+        # isinstance check fails. .get_command(None, name) walks subcommands.
+        assert hasattr(click_app, "get_command")
         serve_cmd = click_app.get_command(None, "serve")  # type: ignore[arg-type]
         assert serve_cmd is not None, "serve subcommand missing"
 

--- a/uv.lock
+++ b/uv.lock
@@ -616,14 +616,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1029,7 +1029,7 @@ worm-s3 = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.0,<8.2" },
+    { name = "click", specifier = ">=8.2,<9.0" },
     { name = "evidentia-ai", editable = "packages/evidentia-ai" },
     { name = "evidentia-api", marker = "extra == 'gui'", editable = "packages/evidentia-api" },
     { name = "evidentia-collectors", editable = "packages/evidentia-collectors" },
@@ -1041,7 +1041,7 @@ requires-dist = [
     { name = "evidentia-integrations", editable = "packages/evidentia-integrations" },
     { name = "evidentia-mcp", marker = "extra == 'mcp'", editable = "packages/evidentia-mcp" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "typer", specifier = ">=0.14,<0.26" },
+    { name = "typer", specifier = ">=0.26,<0.27" },
 ]
 provides-extras = ["gui", "worm-s3", "worm-azure", "worm-gcs", "mcp"]
 
@@ -5372,17 +5372,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.23.1"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Lift the typer<0.26 / click<8.2 caps and adopt typer 0.26.7 + click 8.4.2. The
caps were held because click 8.2 changed CliRunner (removed mix_stderr, keeps
stderr a separate stream) and typer 0.26 vendors its own Click, which breaks
external-`click` introspection. The real bump surfaced six breaks, all fixed:

- CliRunner: `CliRunner(mix_stderr=False)` -> `CliRunner()`, and error-path
  assertions now read result.stderr (click 8.2 no longer merges stderr into
  stdout) -- test_mcp/test_server.py + test_eval/test_harness.py.
- Vendored-Click introspection: scripts/wiki/sync_reference.py walked a Typer
  app's command tree via `isinstance(x, click.Option/Group)`, `click.Context`,
  and `make_metavar()`. Under typer 0.26 those params are vendored-Click
  instances, so an external isinstance fails. Rewrote to version-agnostic
  duck-typing (param_type_name / hasattr(list_commands) / .choices), ctx=None
  command walking (no Context construction), and a make_metavar() ctx fallback.
  test_server.py's introspection tests get the same duck-typed treatment.

Caps moved to typer>=0.26,<0.27 / click>=8.2,<9.0 so the next breaking release
gets isolated review rather than riding a dependency-group bump. Full suite
4314 passed; mypy --strict-optional + ruff clean.
