### PR TITLE
Ci(smoke): Drop unneeded pip-upgrade; document the intentional unpinned install

### DIFF
--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -79,7 +79,10 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv /tmp/smoke-base
-          /tmp/smoke-base/bin/pip install --quiet --upgrade pip
+          # Intentionally UNPINNED: a post-publish smoke test must install the
+          # just-published artifact exactly as a real consumer does — hashes
+          # are unknowable here and pinning would defeat the test's purpose.
+          # The runner's bundled pip is current, so no `--upgrade pip` needed.
           /tmp/smoke-base/bin/pip install "evidentia==${VERSION}"
           OUT="$(/tmp/smoke-base/bin/evidentia version)"
           echo "$OUT"
@@ -92,7 +95,8 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv /tmp/smoke-extras
-          /tmp/smoke-extras/bin/pip install --quiet --upgrade pip
+          # Intentionally UNPINNED (see the base-install step): install the live
+          # published extras exactly as a consumer would.
           /tmp/smoke-extras/bin/pip install "evidentia[ai,api,collectors,mcp]==${VERSION}"
           OUT="$(/tmp/smoke-extras/bin/evidentia version)"
           echo "$OUT"


### PR DESCRIPTION
OpenSSF Scorecard's PinnedDependenciesID flagged 4 `pip install` lines in the
new post-publish-smoke workflow (#104). Two were `pip install --upgrade pip` —
unnecessary (the runner's bundled pip is current), so removed: those alerts
resolve on the next Scorecard scan. The other two install the just-published
artifact (`evidentia==<version>` + extras) and are UNPINNABLE by design — a
post-publish smoke test must install exactly what a consumer installs, with no
hashes. Documented that intent inline; those two alerts are dismissed with the
same rationale (consistent with the repo's prior ephemeral-install dismissals).

actionlint clean; strict workflow-permissions audit passes.
