### PR TITLE
Fix(oscal): Guard catalog + profile loaders against deep-nesting RecursionError (CWE-674)

### DIFF
--- a/packages/evidentia-core/src/evidentia_core/catalogs/loader.py
+++ b/packages/evidentia-core/src/evidentia_core/catalogs/loader.py
@@ -38,6 +38,14 @@ logger = logging.getLogger(__name__)
 # Path to bundled data directory
 DATA_DIR = Path(__file__).parent / "data"
 
+# CWE-674 guard: the OSCAL control/part trees are recursive, so a
+# pathologically deep document could exhaust Python's recursion limit
+# (RecursionError — a type the fuzz harnesses do not allowlist). Real
+# catalogs nest ~2-4 levels; 100 is generous yet well under the interpreter
+# default (~1000), so the recursive parsers raise a clean ValueError before
+# the stack is exhausted.
+_MAX_NEST_DEPTH = 100
+
 
 def _load_catalog_data(catalog_path: Path) -> dict[str, Any]:
     """Read a catalog file and return its parsed dict.
@@ -58,27 +66,37 @@ def _load_catalog_data(catalog_path: Path) -> dict[str, Any]:
     """
     suffix = catalog_path.suffix.lower()
     text = catalog_path.read_text(encoding="utf-8")
-    if suffix in (".yaml", ".yml"):
-        data = yaml.safe_load(text)
-    elif suffix == ".json":
-        data = json.loads(text)
-    else:
-        # v0.10.4 P2 polish: when the suffix is empty (operator
-        # drag-and-drop or scripted file with no extension), the
-        # default {suffix!r} = '' is opaque. Name the case explicitly
-        # and tell the operator the fix — rename to .yaml / .yml /
-        # .json — so the error is self-resolving.
-        if suffix == "":
+    try:
+        if suffix in (".yaml", ".yml"):
+            data = yaml.safe_load(text)
+        elif suffix == ".json":
+            data = json.loads(text)
+        else:
+            # v0.10.4 P2 polish: when the suffix is empty (operator
+            # drag-and-drop or scripted file with no extension), the
+            # default {suffix!r} = '' is opaque. Name the case explicitly
+            # and tell the operator the fix — rename to .yaml / .yml /
+            # .json — so the error is self-resolving.
+            if suffix == "":
+                raise ValueError(
+                    f"Catalog file {catalog_path.name} has no file "
+                    f"extension; expected .json, .yaml, or .yml. Rename "
+                    f"the file (e.g. mv {catalog_path.name} "
+                    f"{catalog_path.name}.yaml) and retry."
+                )
             raise ValueError(
-                f"Catalog file {catalog_path.name} has no file "
-                f"extension; expected .json, .yaml, or .yml. Rename "
-                f"the file (e.g. mv {catalog_path.name} "
-                f"{catalog_path.name}.yaml) and retry."
+                f"Unsupported catalog file extension {suffix!r} for "
+                f"{catalog_path.name}; expected .json, .yaml, or .yml"
             )
+    except RecursionError as exc:
+        # CWE-674: a pathologically deeply-nested document exhausts the JSON /
+        # YAML parser's recursion limit. Convert to the module's typed
+        # ValueError rather than leaking RecursionError — defense-in-depth
+        # alongside the CWE-248 structural guards. (A coverage-guided fuzzer is
+        # unlikely to build the depth, but the class is real.)
         raise ValueError(
-            f"Unsupported catalog file extension {suffix!r} for "
-            f"{catalog_path.name}; expected .json, .yaml, or .yml"
-        )
+            f"Catalog file {catalog_path.name} is nested too deeply to parse"
+        ) from exc
     if not isinstance(data, dict):
         raise ValueError(
             f"{suffix} catalog {catalog_path.name} top-level must be a "
@@ -177,7 +195,9 @@ def load_oscal_catalog(catalog_path: Path) -> ControlCatalog:
     return catalog
 
 
-def _parse_oscal_control(oscal_control: dict[str, Any], family: str) -> CatalogControl:
+def _parse_oscal_control(
+    oscal_control: dict[str, Any], family: str, _depth: int = 0
+) -> CatalogControl:
     """Parse a single OSCAL control into a CatalogControl.
 
     Shared by :func:`load_oscal_catalog` and the OSCAL profile resolver, so
@@ -186,7 +206,15 @@ def _parse_oscal_control(oscal_control: dict[str, Any], family: str) -> CatalogC
     string-only operations (``.upper()`` on ``id``, ``.replace().upper()``
     on a link ``href``) coerce via :func:`str` first — a non-string ``id``
     or ``href`` would otherwise raise an uncaught ``AttributeError``.
+
+    ``_depth`` tracks enhancement (sub-control) nesting; beyond
+    :data:`_MAX_NEST_DEPTH` it raises ``ValueError`` rather than recursing into
+    a ``RecursionError`` (CWE-674).
     """
+    if _depth > _MAX_NEST_DEPTH:
+        raise ValueError(
+            f"control nesting exceeds the maximum depth ({_MAX_NEST_DEPTH})"
+        )
     oscal_control = _require_mapping(oscal_control, "control")
     control_id = str(oscal_control.get("id", "")).upper()
     title = oscal_control.get("title", "")
@@ -209,7 +237,7 @@ def _parse_oscal_control(oscal_control: dict[str, Any], family: str) -> CatalogC
     for sub_control in _iter_mappings(
         oscal_control.get("controls", []), "control.controls"
     ):
-        enhancement = _parse_oscal_control(sub_control, family)
+        enhancement = _parse_oscal_control(sub_control, family, _depth + 1)
         enhancements.append(enhancement)
 
     # Extract priority from properties
@@ -264,12 +292,21 @@ def _parse_oscal_control(oscal_control: dict[str, Any], family: str) -> CatalogC
     )
 
 
-def _extract_prose(part: dict[str, Any]) -> str:
-    """Recursively extract prose text from an OSCAL part."""
+def _extract_prose(part: dict[str, Any], _depth: int = 0) -> str:
+    """Recursively extract prose text from an OSCAL part.
+
+    ``_depth`` guards the part-nesting recursion against a CWE-674
+    ``RecursionError`` on a pathologically deep document (see
+    :data:`_MAX_NEST_DEPTH`).
+    """
+    if _depth > _MAX_NEST_DEPTH:
+        raise ValueError(
+            f"part nesting exceeds the maximum depth ({_MAX_NEST_DEPTH})"
+        )
     part = _require_mapping(part, "part")
     prose: str = str(part.get("prose", ""))
     for sub_part in _iter_mappings(part.get("parts", []), "part.parts"):
-        sub_prose = _extract_prose(sub_part)
+        sub_prose = _extract_prose(sub_part, _depth + 1)
         if sub_prose:
             prose += "\n" + sub_prose
     return prose.strip()

--- a/packages/evidentia-core/src/evidentia_core/oscal/profile.py
+++ b/packages/evidentia-core/src/evidentia_core/oscal/profile.py
@@ -54,7 +54,14 @@ class ProfileResolutionError(Exception):
 def _load_oscal_json(path: Path) -> dict[str, Any]:
     """Load and return the top-level JSON object of an OSCAL file."""
     with open(path, encoding="utf-8") as f:
-        data = json.load(f)
+        try:
+            data = json.load(f)
+        except RecursionError as exc:
+            # CWE-674: a pathologically deeply-nested JSON document exhausts
+            # json's recursion limit. Convert to the module's typed error.
+            raise ProfileResolutionError(
+                f"OSCAL file {path} is nested too deeply to parse"
+            ) from exc
     if not isinstance(data, dict):
         raise ProfileResolutionError(
             f"OSCAL file {path} must contain a JSON object at top level"
@@ -433,15 +440,17 @@ def resolve_profile(
         # Already the module's typed error (e.g. from _load_source_catalog's
         # explicit guards) — propagate unchanged.
         raise
-    except (ValueError, OSError, AttributeError) as exc:
+    except (ValueError, OSError, AttributeError, RecursionError) as exc:
         # resolve_profile traverses arbitrary, untrusted OSCAL structure via
         # many ``.get(...)`` calls and path operations across _resolve_href /
         # _collect_included_ids / _apply_set_parameters / _apply_alter. A
         # malformed-but-valid-JSON profile can put a non-object where an
         # object is expected (→ AttributeError), an unusable path in an href
-        # (→ OSError), or trip a structural guard (→ ValueError). Convert this
-        # whole malformed-input family to the declared ProfileResolutionError
-        # so a bad profile is a clean rejection, never an uncaught-exception
+        # (→ OSError), trip a structural guard (→ ValueError), or chain
+        # fragment hrefs / nest deeply enough to exhaust the stack
+        # (→ RecursionError, CWE-674). Convert this whole malformed-input
+        # family to the declared ProfileResolutionError so a bad profile is a
+        # clean rejection, never an uncaught-exception
         # denial-of-service (CWE-248; fuzz-found in fuzz_oscal_profile).
         # Genuinely unexpected error types still propagate.
         raise ProfileResolutionError(

--- a/tests/unit/test_oscal/test_malformed_input_robustness.py
+++ b/tests/unit/test_oscal/test_malformed_input_robustness.py
@@ -273,3 +273,59 @@ def test_valid_profile_still_resolves(tmp_path: Path) -> None:
     profile_path = _write(tmp_path, "profile.json", VALID_PROFILE)
     resolved = resolve_profile(profile_path)
     assert resolved.control_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# CWE-674 — deeply-nested input raises a clean typed error, never RecursionError.
+# Built as raw strings (json.dumps would itself recurse and RecursionError).
+# ---------------------------------------------------------------------------
+
+
+def _deep_control_chain(depth: int) -> str:
+    """Raw JSON for a `depth`-deep nested-control catalog."""
+    body = '{"id": "c", "controls": [' * depth + '{"id": "c"}' + "]}" * depth
+    return '{"catalog": {"groups": [{"controls": [' + body + "]}]}}"
+
+
+def _deep_part_chain(depth: int) -> str:
+    """Raw JSON for a catalog whose single control has `depth`-deep parts."""
+    parts = '{"name": "statement", "parts": [' * depth + '{"name": "p"}' + "]}" * depth
+    return (
+        '{"catalog": {"groups": [{"controls": [{"id": "c", "parts": ['
+        + parts
+        + "]}]}]}}"
+    )
+
+
+def test_deeply_nested_controls_raise_clean_error(tmp_path: Path) -> None:
+    """Control nesting past the depth limit -> ValueError, not RecursionError."""
+    path = tmp_path / "catalog.json"
+    path.write_text(_deep_control_chain(150), encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_oscal_catalog(path)
+
+
+def test_deeply_nested_parts_raise_clean_error(tmp_path: Path) -> None:
+    """Part nesting past the depth limit -> ValueError, not RecursionError."""
+    path = tmp_path / "catalog.json"
+    path.write_text(_deep_part_chain(150), encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_oscal_catalog(path)
+
+
+def test_deeply_nested_json_raises_clean_error(tmp_path: Path) -> None:
+    """A pathologically deep JSON document -> clean error, not RecursionError."""
+    path = tmp_path / "catalog.json"
+    # 6000-deep arrays exceed json's recursion limit; the loader converts the
+    # RecursionError (or rejects the non-mapping) -> ValueError either way.
+    path.write_text("[" * 6000 + "]" * 6000, encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_oscal_catalog(path)
+
+
+def test_deeply_nested_profile_source_raises_clean_error(tmp_path: Path) -> None:
+    """A profile whose source catalog over-nests -> ProfileResolutionError."""
+    (tmp_path / "catalog.json").write_text(_deep_control_chain(150), encoding="utf-8")
+    profile_path = _write(tmp_path, "profile.json", VALID_PROFILE)
+    with pytest.raises(ProfileResolutionError):
+        resolve_profile(profile_path)


### PR DESCRIPTION
Defense-in-depth follow-up to the fuzz-found CWE-248 fixes. The OSCAL control
and part trees are recursive, so a pathologically deep document could exhaust
Python's recursion limit -- a RecursionError, which the fuzz harnesses do not
allowlist. The coverage-guided fuzzer is unlikely to BUILD that depth (depth
adds no new coverage), so it hasn't surfaced it, but the class is real. Close
it:

- `_load_catalog_data` / `_load_oscal_json`: wrap the json/yaml parse and
  convert a parser RecursionError to the module's typed ValueError /
  ProfileResolutionError.
- `_parse_oscal_control` + `_extract_prose` (the two recursive parsers, shared
  by both load paths): track a `_depth` and raise a clean ValueError beyond
  `_MAX_NEST_DEPTH` (100 -- real catalogs nest ~2-4, well under the interpreter
  default) rather than recursing into a RecursionError.
- `resolve_profile`'s boundary now also converts RecursionError (from
  fragment-href chains / apply-recursion) to ProfileResolutionError.

Tests (test_malformed_input_robustness.py): deeply-nested controls, parts, raw
JSON, and a deep profile source each raise a clean typed error, never
RecursionError -- built as raw strings since json.dumps would itself recurse.
282 robustness cases pass; 591 catalog/oscal/api regression pass; mypy + ruff
(--no-cache) clean.
