### PR TITLE
Ci(pre-push): Add fast ruff lint to the pre-push gate (shift-left from CI)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,6 +37,9 @@
 #                                  if it changed in the working tree)
 #  11. check_doc_counts           (README at-a-glance counts ==
 #                                  code-derived truth; v0.10.12 Wave 0)
+#  12. check_ruff                 (`ruff check . --no-cache` — fast lint
+#                                  shifted left from CI so a cached-pass lint
+#                                  break is caught pre-push, not in the queue)
 #
 # All checks run before the hook exits, so the operator sees every
 # failure at once.
@@ -68,6 +71,15 @@ run_py() {
         uv run python "$@"
     else
         python "$@"
+    fi
+}
+
+# Like run_py, but for the ruff CLI (uv-resolved, with a plain-ruff fallback).
+run_ruff() {
+    if command -v uv >/dev/null 2>&1; then
+        uv run ruff "$@"
+    else
+        ruff "$@"
     fi
 }
 
@@ -322,6 +334,13 @@ run_check "check_readme_regen" check_readme_regen || true
 #     source). Pure-filesystem; always runs.
 run_check "check_doc_counts" \
     run_py "${REPO_ROOT}/scripts/check_doc_counts.py" || true
+
+# 12. ruff lint — shifted left from CI-only. `--no-cache` so the gate matches
+#     CI's fresh runner exactly: a *cached* pass can mask a lint break (e.g. an
+#     unused `# noqa` for a non-enabled rule → RUF100) that CI then catches,
+#     causing avoidable merge-queue churn. ruff is fast (~1-2s), so it fits the
+#     "fast checks pre-push, heavyweight (pytest/mypy) in CI" gate design.
+run_check "check_ruff" run_ruff check . --no-cache || true
 
 # ---------------------------------------------------------------------------
 # Verdict.


### PR DESCRIPTION
The pre-push gate runs only fast staleness / security / consistency checks;
lint (ruff) was CI-only. That is exactly why #101's unused-`# noqa` (RUF100)
passed the local gate but failed the CI `ruff` job, blocking the merge queue
until a follow-up push. Add ruff as check #12 so a lint break is caught
pre-push, not in the queue.

`--no-cache` so the gate matches CI's fresh runner exactly — a *cached* local
ruff pass can mask a lint break the fresh CI run then catches. ruff is fast
(~1-2s), so it fits the gate's "fast checks pre-push, heavyweight (pytest /
mypy) in CI" design; nothing slow is added.

(Pre-existing, out of scope: docs/pre-push-gate.md still says "seven blocking
checks" while the hook now has 12 — a doc-drift that predates this change.)
