### PR TITLE
Ci(concurrency): Keep push-on-main + merge_group runs from cancelling (green checks)

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -25,7 +25,10 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel only on PR iteration (rapid re-pushes to a PR supersede each other).
+  # push:[main] + merge_group MUST run to a green conclusion so every main commit
+  # earns its own completed check (no misleading cancelled-run noise on rapid merges).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   consistency:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -56,7 +56,10 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel only on PR iteration (rapid re-pushes to a PR supersede each other).
+  # push:[main] + merge_group MUST run to a green conclusion so every main commit
+  # earns its own completed check (no misleading cancelled-run noise on rapid merges).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -30,7 +30,10 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel only on PR iteration (rapid re-pushes to a PR supersede each other).
+  # push:[main] + merge_group MUST run to a green conclusion so every main commit
+  # earns its own completed check (no misleading cancelled-run noise on rapid merges).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   gitleaks:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,10 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel only on PR iteration (rapid re-pushes to a PR supersede each other).
+  # push:[main] + merge_group MUST run to a green conclusion so every main commit
+  # earns its own completed check (no misleading cancelled-run noise on rapid merges).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # v0.10.11: gate-fidelity backstop. The collector SSRF guard must fire


### PR DESCRIPTION
## What
Make `cancel-in-progress` evaluate `true` only for `pull_request` events in the four required-check workflows (`test`, `consistency`, `container-build`, `secret-scan`).

## Why
These used `cancel-in-progress: true` with group `${{ github.workflow }}-${{ github.ref }}`. On rapid back-to-back `main` merges, two `push:[main]` runs share the group `<wf>-refs/heads/main` and cancel each other — leaving a misleading cancelled run (red ✗) on a healthy `main` commit even though the `merge_group` gate already passed all-green. That ✗ reads as broken CI on the public commit list.

## Effect
- PR iteration still supersedes old runs (the cost saving is preserved).
- `push:[main]` and `merge_group` now always run to a green conclusion — every `main` commit earns its own completed required check.
- No test or gate is skipped or weakened.

## Validation
- All four workflow YAMLs parse clean.
- Diff is 4 lines (one `cancel-in-progress` per workflow) plus explanatory comments.
