### PR TITLE
Docs(governance): Add SbD pledge, SLSA Source-Track claim, GHSA + rollback runbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`docs/engineering-practices.md`** — a public account of the engineering safeguard stack (PR-flow + merge queue, atomic releases, SLSA provenance + cosign + SBOM + OIDC publishing, continuous fuzzing + Scorecard + CodeQL, verified docs) and the candid failure classes that shaped each safeguard.
+- **Security posture documents.** `docs/SECURE-BY-DESIGN-PLEDGE.md` (voluntary alignment with the CISA Secure by Design Pledge's seven goals), `docs/slsa-source-track.md` (an honest SLSA v1.2 Source Track self-assessment — the L3 technical controls are enforced and verifiable, the L4 two-party-review gap disclosed), `docs/runbooks/ghsa-cve-issuance.md` and `docs/runbooks/release-rollback.md` (maintainer runbooks for GHSA + CVE issuance via GitHub-as-CNA and for release rollback/yank per PEP 592), and a root `security-insights.yml` (OpenSSF Security Insights v2.2.0 manifest). All linked from `SECURITY.md`.
 
 ### Changed
 
 - **PR-flow + merge queue on `main`.** A repository ruleset now requires a pull request, the full set of status checks, and a squash merge queue, with an empty bypass list — no direct push to `main`, including by administrators. This reverses the prior direct-push model so the complete CI matrix gates every change *before* it lands, not after. Every workflow producing a required check gained a `merge_group` trigger (paths-filtered workflows do not run on `merge_group`, so the container smoke test instead always runs with a step-level relevance early-exit).
 - **Atomic release.** `release.yml` builds and validates all artifacts — wheels, SBOM, and the container image (built from the locally-built wheels, not the package index) — *before* the irreversible PyPI publish, then pushes the byte-identical validated image. This closes the post-publish container-build-failure class (the v0.10.12 packages-only release) and the index-propagation race. The Dockerfile is now multi-stage with an `INSTALL_SOURCE` build argument; the operator default (install from PyPI) is unchanged.
 - **The container smoke test is now a required check.** Restructured to run on every pull request with a relevance early-exit, so it reports success on changes that do not touch the container while still building whenever the Dockerfile or its inputs change — which is what lets it be required without blocking unrelated PRs.
+- **Required-check concurrency.** The four required-check workflows (`test`, `consistency`, `container-build`, `secret-scan`) now cancel in-progress runs only on `pull_request` events; `push:[main]` and `merge_group` runs always run to a green conclusion, so every `main` commit earns its own completed required check (no spurious cancelled runs on rapid back-to-back merges).
 
 ### Fixed
 
 - **Flake-resistance policy** (`docs/testing-flake-policy.md`) — bans wall-clock-timing assertions and treats a skipped or dead gate as a failure, after a Windows clock-granularity flake and a Hypothesis-deadline flake were eliminated.
+
+### Security
+
+- **npm registry-signature verification.** The frontend CI job runs `npm audit signatures` after `npm ci`, verifying installed UI tarballs against npm's registry signatures and maintainer Sigstore provenance — the JS/TS analogue of the Python side's PEP 740 attestations.
+- **Release-tag root-of-trust protection.** A server-side repository ruleset makes `refs/tags/v*` append-only (no force-move, no delete, signatures required), and GitHub Immutable Releases locks published release assets and tags — so the cosign certificate-identity binding on a signed tag cannot be silently broken after publish.
 
 ## [0.10.13] - 2026-06-23
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -179,6 +179,27 @@ If verification fails, **stop and report immediately** via the
 private channels above — a verification failure on a published
 artifact is itself a security incident.
 
+## Security posture documents
+
+Machine- and human-readable attestations of the project's security
+posture:
+
+- [`docs/SECURE-BY-DESIGN-PLEDGE.md`](docs/SECURE-BY-DESIGN-PLEDGE.md)
+  — voluntary self-assessed alignment with the CISA Secure by Design
+  Pledge's seven goals (an alignment statement, not a signatory claim).
+- [`docs/slsa-source-track.md`](docs/slsa-source-track.md) — honest SLSA
+  v1.2 Source Track self-assessment: the Source L3 technical controls are
+  enforced and independently verifiable; the L4 two-party-review gap is
+  disclosed (single maintainer).
+- [`docs/runbooks/ghsa-cve-issuance.md`](docs/runbooks/ghsa-cve-issuance.md)
+  — maintainer runbook for publishing a GitHub Security Advisory and
+  issuing a CVE via GitHub-as-CNA.
+- [`docs/runbooks/release-rollback.md`](docs/runbooks/release-rollback.md)
+  — release rollback / yank / recovery decision tree (PEP 592 yank
+  semantics; release tags are immutable server-side).
+- [`security-insights.yml`](security-insights.yml) — OpenSSF Security
+  Insights v2.2.0 manifest.
+
 ## Acknowledgments
 
 Coordinated security reports — once disclosed and fixed — are

--- a/docs/SECURE-BY-DESIGN-PLEDGE.md
+++ b/docs/SECURE-BY-DESIGN-PLEDGE.md
@@ -1,0 +1,336 @@
+# CISA Secure by Design Pledge — Alignment Statement (Evidentia)
+
+> **As of 2026-06-26** (UTC), [Polycentric-Labs/evidentia](https://github.com/Polycentric-Labs/evidentia)
+> publishes this voluntary **alignment** statement against the seven goals of
+> CISA's [Secure by Design Pledge](https://www.cisa.gov/securebydesign/pledge).
+> This is **not** a formal signatory claim, and it is a self-assessment — no
+> third-party audit has been conducted. See **Scope & honesty** at the end for
+> exactly what this document is and is not.
+
+## What this is — and what it is not
+
+CISA launched the **Secure by Design Pledge** at the **RSA Conference in May
+2024**. It is a **voluntary** pledge whose intended audience is **software
+manufacturers**, and it focuses on a manufacturer's **enterprise software
+products and services**. Signatories publicly commit to demonstrate measurable
+progress against seven goals, each within **one year** of signing.
+
+Evidentia is a **solo-maintainer, Apache-2.0 open-source Python project**
+(a GRC / compliance-as-code tool — a `uv` monorepo of 8 `evidentia-*` PyPI
+packages plus a React UI; single maintainer Allen Byrd / Polycentric Labs).
+It is **not** a corporate "software manufacturer" shipping an enterprise SaaS
+fleet, and it has **not signed** the pledge. Many of the pledge's metrics
+(fleet-wide MFA adoption, customer patch-installation rates, evidence of
+intrusions into a hosted service) presuppose a *vendor operating software on
+customers' behalf* — a shape Evidentia does not have.
+
+So this document is an **aspirational mapping**: for each of the seven goals it
+states the goal, maps it to Evidentia's *actual, verified* engineering practice
+with file-level evidence, and notes — plainly — where alignment is only partial
+or where the goal does not cleanly apply to a downloadable library. Every
+project-specific claim below was checked against the repository at the date
+above; anything that could not be verified is flagged rather than asserted.
+
+> The pledge goals are paraphrased below from CISA's published pledge text.
+> For the authoritative wording, consult the
+> [CISA Secure by Design Pledge](https://www.cisa.gov/securebydesign/pledge)
+> directly — that page is the source of truth, not this document.
+
+---
+
+## Goal 1 — Multi-factor authentication
+
+**The goal (CISA):** Within one year of signing, demonstrate actions that
+measurably increase the use of multi-factor authentication across the
+manufacturer's products.
+
+**How Evidentia aligns.** Evidentia ships **no authentication system of its
+own** — it is a library, CLI, and a *locally-run* REST/web console an operator
+hosts on their own infrastructure, not a multi-tenant product with end-user
+accounts. The relevant MFA surface is therefore the **development and release
+supply chain**, and there MFA *is* enforced:
+
+- The **GitHub organization `Polycentric-Labs` requires two-factor
+  authentication** for all members. Verified via the GitHub API:
+  `gh api orgs/Polycentric-Labs` returns `"two_factor_requirement_enabled":
+  true`.
+- Releases are **tag-driven and OIDC-signed** — wheels and sdists carry
+  **PEP 740 attestations** signed via the GitHub Actions OIDC identity
+  (Sigstore + Rekor), so publication authority is bound to the CI identity
+  rather than a long-lived, password-only PyPI token. (See `SECURITY.md`
+  → "Supply-chain provenance" and `docs/verification.md`.)
+
+**Gap note.** This is **org-level account 2FA** for the maintainer and CI
+identity — it is *not* application-level MFA in a shipped product, because
+Evidentia has no shipped product login to protect. The pledge's intent
+(end-users protected by MFA) does not map onto a downloadable tool; the honest
+analogue is "the accounts that can publish Evidentia are 2FA-gated," which is
+true and verified, and nothing more is claimed.
+
+---
+
+## Goal 2 — Default passwords
+
+**The goal (CISA):** Within one year of signing, demonstrate measurable
+progress toward reducing default passwords across the manufacturer's products.
+
+**How Evidentia aligns.** **Not applicable in the strong sense: Evidentia ships
+no default credentials.** There is no bundled admin account, no seeded
+password, and no "first-run" credential anywhere in the installable packages.
+The local REST API / web console is unauthenticated-by-design for
+single-operator localhost use and is documented as such — it does not create a
+default login that an operator must remember to change.
+
+Where the codebase *mentions* credentials, it is consuming the operator's own:
+
+- Collectors read credentials the operator supplies via **environment
+  variables** (e.g. the API's collector router exposes a read-only
+  `default_password_env_configured` boolean that reports *whether the operator
+  has set their own DB-password env var* — it neither stores nor ships a
+  password). Evidence: `packages/evidentia-api/src/evidentia_api/routers/collectors.py`.
+- Cloud-WORM retention uses the cloud SDK's **Application Default Credentials**
+  chain — the platform's own auth, not an Evidentia-shipped secret. Evidence:
+  `packages/evidentia-core/src/evidentia_core/retention/worm_gcs.py`.
+- "Default password" strings elsewhere are **framework control text** in the
+  bundled catalogs (e.g. CISA CPG "Changing Default Passwords",
+  NIST 800-53 control prose) — content Evidentia *measures compliance against*,
+  not credentials it uses.
+
+**Gap note.** None material. The goal is essentially satisfied by construction:
+there is nothing to reduce because nothing default-credentialed is shipped.
+
+---
+
+## Goal 3 — Reducing entire classes of vulnerability
+
+**The goal (CISA):** Within one year of signing, demonstrate actions that
+enable a significant, measurable reduction in the prevalence of one or more
+entire classes of vulnerability across the manufacturer's products.
+
+**How Evidentia aligns.** This is the goal where the project invests most
+heavily, with multiple *class-eliminating* controls (not per-instance fixes):
+
+- **Static analysis — CodeQL `security-extended` + a custom sanitizer pack.**
+  The advanced CodeQL setup runs the `security-extended` query suite across
+  Python, JavaScript/TypeScript, and GitHub Actions, *plus* a project-authored
+  QL pack that declares `evidentia_core.security.paths.validate_within` as a
+  sanitizer for the `py/path-injection` query — closing path-traversal
+  (CWE-22) false-positives at the analysis layer rather than dismissing alerts
+  one by one. Evidence: `.github/workflows/codeql.yml`,
+  `.github/codeql/codeql-config.yml`, `.github/codeql/python-sanitizers/`.
+- **SSRF guard (CWE-918), secure-by-default + anti-DNS-rebinding.** A single
+  reusable outbound-request chokepoint (`enforce_public_host`) refuses any host
+  that resolves to a private / loopback / link-local / reserved address,
+  **fails closed** on unresolvable hosts, and **pins the resolved public IPs**
+  so a low-TTL attacker DNS record cannot rebind to `169.254.169.254` or an
+  internal host at connection time. `block_private` defaults to `True`; the
+  opt-out is an explicit `--allow-private-ips` flag. Evidence:
+  `packages/evidentia-core/src/evidentia_core/network_guard.py`.
+- **Continuous fuzzing — ClusterFuzzLite + Atheris.** Coverage-guided fuzz
+  harnesses run on every PR (`cflite-pr`) and in batch (`cflite-batch`) against
+  the parser surfaces (catalog import, OSCAL profile/verify, OCSF ingest, gap
+  report, TPRM questionnaire). Evidence: `.clusterfuzzlite/`, `tests/fuzz/`,
+  `.github/workflows/cflite-pr.yml`, `.github/workflows/cflite-batch.yml`.
+- **Malformed-input robustness suite (parser-class invariant).** Hypothesis
+  property tests encode the same invariant the fuzz harnesses enforce — *a
+  parser fed arbitrary input may raise only its declared exception types* —
+  and run cross-platform under plain `pytest` (the harnesses are Linux/CI-only).
+  This converts "unexpected-exception-on-bad-input" from a per-bug whack-a-mole
+  into a *class*-level property. Evidence:
+  `tests/fuzz/test_parser_robustness.py`, `tests/property/`.
+- **Strict typing.** `mypy` runs with the Pydantic plugin and
+  `disallow_untyped_defs = true` project-wide (`pyproject.toml` `[tool.mypy]`),
+  and the local/CI gate invokes it with `--strict-optional` across all eight
+  source packages (`CLAUDE.md` gate list) — eliminating large classes of
+  `None`/type-confusion defects before runtime.
+- **Per-release threat model.** `docs/threat-model.md` walks the external-input
+  surfaces each release and maps each to a CWE (the doc references CWE-22, -918,
+  -502, -400, -770, -295, -319, -345, -362, and others). Its last full
+  deep-pass (2026-05-01) recorded **0 HIGH, 0 MEDIUM, 3 LOW** open findings.
+
+**Gap note.** "Measurable reduction *across products*" presumes a product
+fleet with telemetry. Evidentia's evidence is the *presence and CI-enforcement*
+of these class-level controls and the threat-model trend, not a longitudinal
+vulnerability-density metric across a customer base — there is no customer base
+to measure. The controls are real and gated in CI; the quantified-reduction
+framing is the part that does not transfer to a single open-source tool.
+
+---
+
+## Goal 4 — Security patches
+
+**The goal (CISA):** Within one year of signing, demonstrate actions that
+measurably increase the installation of security patches by customers.
+
+**How Evidentia aligns.** Evidentia cannot push updates to a user's machine
+(it is `pip install`'d / pulled as a container), so "increase installation by
+customers" is bounded by what a library author controls: **shipping patches
+fast, signed, and discoverable, with a clear support policy.**
+
+- **Tag-driven release pipeline.** A signed tag (`git tag -s vX.Y.Z`) fires
+  `release.yml`, which builds, signs (PEP 740 + Sigstore), generates the SBOM,
+  and publishes to PyPI + GHCR — so a fix becomes an installable, verifiable
+  release with minimal latency. Evidence: `.github/workflows/release.yml`,
+  `docs/release-checklist.md`.
+- **Dependabot across every ecosystem.** Automated dependency-update PRs for
+  `uv`, `npm`, `github-actions`, and `docker` (`.github/dependabot.yml`), so
+  upstream fixes flow into a new Evidentia patch quickly.
+- **`osv-scanner` supply-chain gate.** A single shared entry point
+  (`scripts/run_osv_scan.py`) generates the CycloneDX SBOM and scans it with
+  `osv-scanner` — run identically by CI (`test.yml`) and pre-tag by the release
+  checklist, reporting transitive *and* disputed advisories that Dependabot's
+  alert view can suppress. Evidence: `scripts/run_osv_scan.py`,
+  `.github/workflows/test.yml`, `osv-scanner.toml`.
+- **Documented support / EOL policy.** `EOL.md` defines a **single-supported-
+  patch** policy pre-1.0 (the latest patch is the only supported version; no
+  backports), transitioning to "latest patch of each supported minor" after
+  v1.0, plus a cessation-comms policy (OSPS-DO-05). `SECURITY.md` mirrors the
+  supported-versions table. This tells operators exactly which version carries
+  the fixes — the discoverability half of "install the patch."
+
+**Gap note.** A downloadable tool **cannot force installation** — there is no
+auto-update channel and no install-rate telemetry, so the "measurably increase
+installation" metric is genuinely out of reach. Alignment here is "fast, signed,
+clearly-supported patches that are easy to find and verify," not a patch-uptake
+number.
+
+---
+
+## Goal 5 — Vulnerability disclosure policy
+
+**The goal (CISA):** Publish a vulnerability disclosure policy (VDP) that
+authorizes good-faith security testing by members of the public and commits to
+not recommend or pursue legal action against good-faith researchers.
+
+**How Evidentia aligns — fully.** This goal maps cleanly and is met:
+
+- **`SECURITY.md`** publishes the policy: two private reporting channels
+  (preferred **GitHub Private Vulnerability Reporting**, email backup), a
+  **safe-harbor** section using CISA/FTC sample VDP language (no legal action,
+  CFAA authorization, DMCA waiver for good-faith research), explicit
+  **SLAs** (acknowledgment within 3 business days; triage within 10), a
+  **90-day coordinated-disclosure** window, and a defined in-scope/out-of-scope
+  surface.
+- **`.well-known/security.txt`** (RFC 9116) advertises the contact, the
+  advisory-intake URL, an encryption key, the canonical location, and a
+  `Policy:` pointer to `SECURITY.md`. Evidence:
+  `.well-known/security.txt` (with `Expires: 2027-05-26`).
+
+**Gap note.** None. This is the most direct fit of the seven.
+
+---
+
+## Goal 6 — CVEs (transparency in vulnerability reporting)
+
+**The goal (CISA):** Within one year of signing, demonstrate transparency in
+vulnerability reporting — issue CVEs in a timely manner for at least all
+critical/high-impact vulnerabilities that require customer action or show
+evidence of active exploitation, and include accurate CWE (and CPE) fields in
+every CVE record.
+
+**How Evidentia aligns.**
+
+- **CVE issuance is process-ready via GitHub-as-CNA.** GitHub is a CVE
+  Numbering Authority for any repository; a maintainer can request a CVE ID
+  through a repository security advisory and GitHub publishes it on advisory
+  release. Evidentia's `SECURITY.md` routes reports through **GitHub Private
+  Vulnerability Reporting**, which includes "optional CVE assignment," and the
+  disclosure timeline states a CVE "is requested" after a fix is published.
+  The path to *issue* a CVE is therefore in place and documented.
+- **CWE transparency is already practiced.** Every release ships a
+  `docs/security-review-vX.Y.Z.md` (37 such files at the date above, from
+  v0.7.7 through v0.10.12), and `docs/threat-model.md` carries explicit CWE
+  identifiers per surface (CWE-22, -918, -502, -400, -770, -295, -319, -345,
+  -362, and more). So the "accurate CWE in the record" discipline is already
+  exercised in the public security documentation.
+
+**Gap note (honest).** **No CVE has been issued for Evidentia to date** —
+verified: `gh api repos/Polycentric-Labs/evidentia/security-advisories`
+returns an empty list (length 0). That reflects that no qualifying vulnerability
+**in Evidentia's own code** has been disclosed, not a gap in willingness or
+machinery. Upstream-dependency advisories are handled by bumping pins and
+shipping a patch (see `SECURITY.md` scope) rather than by Evidentia issuing a
+CVE for someone else's code. The CPE half of the goal is not applicable until a
+first CVE exists. The honest statement is: *the process is ready and the CWE
+discipline is live; the issuance track record is empty because there has been
+nothing to issue.*
+
+---
+
+## Goal 7 — Evidence of intrusions
+
+**The goal (CISA):** Within one year of signing, demonstrate a measurable
+increase in customers' ability to gather evidence of cybersecurity intrusions
+affecting the manufacturer's products (e.g., via logging).
+
+**How Evidentia aligns.** Evidentia does not operate a hosted service, so it
+cannot detect intrusions *into* a Polycentric-Labs-run platform — there is
+none. What it *does* ship is operator-facing **audit-grade logging and
+tamper-evident evidence** that an operator can use to detect tampering with
+their own compliance evidence:
+
+- **Curated structured-audit event vocabulary** mapped to NIST 800-53 AU-3
+  (Content of Audit Records) and ECS categorization — a stable
+  `evidentia.<namespace>.<verb>` action registry so SIEM correlation survives
+  across releases. Evidence:
+  `packages/evidentia-core/src/evidentia_core/audit/events.py`,
+  `docs/log-schema.md`.
+- **Append-only / WORM evidence store.** The evidence store enforces
+  append-only semantics at the application layer (refuses to overwrite
+  `v<N>.json`), with an **optional cloud-WORM mirror** (S3 Object Lock / Azure
+  Immutable Blob / GCS Bucket Lock) for regulator-grade chain-of-custody
+  (FedRAMP AU-9/AU-11, HIPAA §164.312(b), SOX §404). Evidence:
+  `packages/evidentia-core/src/evidentia_core/evidence_store.py`,
+  `evidence_store_worm.py`, `audit/provenance.py`,
+  `docs/audit-chain-of-custody.md`, `docs/evidence-integrity.md`.
+- **Cryptographic provenance** on outputs (Sigstore/Rekor signing of OSCAL
+  Assessment Results; signed MCP output envelopes / CIMD) so an operator can
+  detect after-the-fact alteration of an evidence artifact. Evidence:
+  `SECURITY.md` → "Supply-chain provenance," `docs/evidence-integrity.md`.
+
+**Gap note (honest).** Because Evidentia runs **on the operator's own
+infrastructure and ships no hosted service**, it cannot itself meet the goal's
+"intrusions affecting the manufacturer's products" framing — there is no
+manufacturer-run product to be intruded upon, and no telemetry flows back to
+Polycentric Labs. The alignment is one level removed: Evidentia *gives its
+operators* the logging and tamper-evidence primitives the goal is about, for
+*their* environment. The "measurable increase" metric is theirs to observe, not
+the maintainer's.
+
+---
+
+## Scope & honesty
+
+- **This is a voluntary alignment statement, not a signatory claim.** Evidentia
+  has **not** signed the CISA Secure by Design Pledge and is not listed as a
+  signatory. Nothing here should be read as implying CISA endorsement or
+  participation.
+- **It is a self-assessment.** No third-party audit, attestation, or review of
+  this mapping has been performed. Claims are the maintainer's, grounded in the
+  cited files.
+- **Evidentia is not a "software manufacturer" in the pledge's sense.** It is a
+  solo-maintainer, Apache-2.0, downloadable open-source tool. Several pledge
+  metrics presuppose a vendor operating enterprise software on customers'
+  behalf (fleet-wide MFA adoption, customer patch-installation rates,
+  intrusion telemetry from a hosted service); those do not transfer, and this
+  document says so per goal rather than papering over the mismatch.
+- **Honest scorecard.** Cleanly met: **Goal 2** (no default credentials) and
+  **Goal 5** (published VDP + safe harbor). Strongly aligned by construction:
+  **Goal 3** (class-level controls — CodeQL + sanitizers, fuzzing, SSRF guard,
+  robustness suite, strict typing). Partially aligned / out-of-shape for a
+  downloadable tool: **Goal 1** (org/CI 2FA, not product MFA), **Goal 4** (fast
+  signed patches, but no install-rate lever), **Goal 6** (issuance ready + CWE
+  discipline live, but **zero CVEs issued to date**), **Goal 7** (operator-side
+  logging/WORM, but no hosted service to instrument).
+- **Accuracy commitment.** Every project-specific claim above was verified
+  against the repository and the GitHub API on **2026-06-26**. If any claim
+  drifts out of date (counts, support status, the empty-CVE state, the 2FA
+  setting), the cited file or `gh api` call is the source of truth — this
+  document is a snapshot.
+
+For the authoritative pledge text, see CISA's
+[Secure by Design Pledge](https://www.cisa.gov/securebydesign/pledge). For
+Evidentia's broader security posture, see
+[`SECURITY.md`](../SECURITY.md), [`docs/threat-model.md`](threat-model.md),
+[`docs/engineering-practices.md`](engineering-practices.md), and
+[`OSPS-CONFORMANCE.md`](../OSPS-CONFORMANCE.md).

--- a/docs/runbooks/ghsa-cve-issuance.md
+++ b/docs/runbooks/ghsa-cve-issuance.md
@@ -1,0 +1,354 @@
+# GHSA + CVE issuance runbook
+
+> Maintainer runbook for turning a confirmed vulnerability into a
+> **published GitHub Security Advisory (GHSA)** and an **issued CVE**
+> — using GitHub as the CVE Numbering Authority (CNA) for public
+> repositories. Evidentia does **not** need to become a CNA: GitHub is
+> already a CNA and is authorized to assign CVE identification numbers
+> for advisories on public repositories.
+>
+> This is a single-maintainer checklist meant to be followed under
+> pressure. It assumes the intake policy, SLAs, and safe-harbor terms
+> already published in [`SECURITY.md`](../../SECURITY.md). When this
+> runbook and `SECURITY.md` disagree, `SECURITY.md` is the published
+> policy of record — fix the drift, don't improvise.
+
+## Preconditions (verified state of this repo)
+
+- The repository `Polycentric-Labs/evidentia` is **public** and
+  **Apache-2.0** — the two conditions under which GitHub will assign a
+  CVE through the advisory flow.
+- **Private Vulnerability Reporting (PVR) is enabled**
+  (`gh api repos/Polycentric-Labs/evidentia/private-vulnerability-reporting`
+  returns `{"enabled":true}`), so researchers have a private intake
+  channel and `SECURITY.md` correctly lists it as the preferred path.
+- Dependabot alerts and secret scanning are enabled on the repo, so a
+  published, ecosystem-recognized advisory flows back to downstream
+  users automatically (see [Step 8](#step-8--post-publish-notification)).
+- GitHub **cannot** assign a CVE if the affected component is already
+  covered by another CNA. Evidentia's own packages are not, so the
+  GitHub-as-CNA path applies to a vulnerability in Evidentia's **own
+  code**. A vulnerability that lives in a *dependency* is out of scope
+  per `SECURITY.md` — report it upstream; do not request a CVE for it
+  here.
+
+## At a glance
+
+| Phase | Surface | Output |
+|---|---|---|
+| 1. Intake | PVR report / `[SECURITY]` email | A private report, acknowledged |
+| 2. Triage | Local + Security tab | In-scope decision, CVSS score, CWE id |
+| 3. Draft GHSA | Security → Advisories → New draft | Private draft with version ranges |
+| 4. Private fork | Advisory → temporary private fork | A patch PR, reviewed in private |
+| 5. Request CVE | Advisory → **Request CVE** | A reserved (still-private) CVE id |
+| 6. Ship the fix | Tag-driven release (`release.yml`) | Patched version on PyPI + GHCR |
+| 7. Publish GHSA | Advisory → **Publish advisory** | Public GHSA + CVE → MITRE/NVD |
+| 8. Notify | CHANGELOG, release notes, credits | Downstream + reporter informed |
+
+---
+
+## Step 1 — Intake
+
+1. **Confirm the channel.** Per `SECURITY.md`, reports arrive on one of
+   two private channels:
+   - **Preferred** — GitHub Private Vulnerability Reporting at
+     `https://github.com/Polycentric-Labs/evidentia/security/advisories/new`.
+   - **Backup** — email `allen@allenfbyrd.com`, subject
+     `[SECURITY] Evidentia <one-line summary>`.
+
+   If a report lands as a **public issue** by mistake, do not engage on
+   the thread. Minimize/redact it, ask the reporter to refile through
+   PVR, and continue privately.
+
+2. **Acknowledge within the SLA.** `SECURITY.md` commits to **initial
+   acknowledgment within 3 business days** and a **triage assessment
+   within 10 business days**. Send the acknowledgment from the private
+   thread (a PVR report already gives you one; an email gets a reply).
+
+3. **Start the clock.** The coordinated-disclosure window is **90 days
+   from initial report to public disclosure** per `SECURITY.md`, and it
+   can shorten or lengthen by mutual agreement (e.g., "upstream already
+   shipped a fix, just bump the pin" shortens to days; architectural
+   fixes lengthen by agreement in the private thread). Record the report
+   date and the target disclosure date in the private discussion.
+
+> An emailed report has no GitHub advisory object yet. The cleanest move
+> is to **open the draft advisory yourself** (Step 3) and add the
+> reporter as a collaborator/credit, so all coordination happens in one
+> private place.
+
+---
+
+## Step 2 — Triage, severity (CVSS), and CWE
+
+1. **Reproduce and scope.** Confirm the issue is real and reproducible,
+   and that it falls **in scope** per `SECURITY.md` (code under
+   `packages/evidentia*/src/...`, `packages/evidentia-ui/src/...`,
+   `scripts/...`, the release workflows, the published PyPI packages,
+   the composite Action, or a load-time harm from a crafted bundled
+   catalog). If it is a third-party dependency issue, a canonical AWS
+   example placeholder, Tier-C placeholder catalog text, an
+   unsupported-version-only issue, or a theoretical issue with no
+   exploit path, it is **out of scope** — decline with a clear reason
+   and point at the upstream/remediation path.
+
+2. **Identify affected and fixed versions.** Evidentia is pre-1.0 and
+   ships from a **single supported patch release** (`SECURITY.md` →
+   *Supported versions*). Determine the lowest affected version and the
+   version that will carry the fix (the next patch). You need concrete
+   version boundaries for the advisory's affected/patched ranges in
+   Step 3.
+
+3. **Score with CVSS.** Use the calculator built into the advisory form
+   (Step 3) or score independently. GitHub's advisory form supports
+   **CVSS v4.0 and CVSS v3.1** base scores; pick one and record the
+   full vector string, not just the numeric score. The chosen version
+   and vector carry through to the global advisory, Dependabot alerts,
+   and the API.
+
+4. **Classify with CWE.** Pick the most specific applicable
+   **Common Weakness Enumeration** id (CWE is the community weakness
+   taxonomy stewarded by MITRE for CISA; e.g., the repo has previously
+   worked CWE-674 uncontrolled recursion and CWE-248 uncaught
+   exception). The advisory form has a dedicated CWE field.
+
+5. **Decide the fix + disclosure plan** and confirm the target
+   disclosure date with the reporter in the private thread. If you will
+   need a window extension, request it now, not at day 89.
+
+---
+
+## Step 3 — Draft a private GHSA
+
+All UI navigation below is from the repository's **Security** tab →
+**Advisories** (left sidebar, under *Reporting*).
+
+1. From the repo's main page, open the **Security** tab → **Advisories**
+   → **New draft security advisory**. (If the report came in via PVR,
+   GitHub may have already created a draft from the report — edit that
+   one instead of opening a second.)
+
+2. Fill the draft form:
+   - **Title** — a precise one-line summary (no secrets, no exploit
+     payload).
+   - **CVE identifier** — choose **Request CVE ID later** unless the
+     reporter already holds a CVE for this issue (then paste it). You
+     will request the CVE in Step 5.
+   - **Description** — impact, affected configuration, and references.
+     Write it as the text you are willing to publish; keep proof-of-
+     concept detail minimal per the `SECURITY.md` safe-harbor
+     expectation ("only use exploits to the extent necessary").
+   - **Affected products** — set **Ecosystem** to **pip** (Evidentia's
+     packages are PyPI-published; pip/PyPI is a GitHub-Advisory-Database
+     -recognized ecosystem). Add **one entry per affected package**, with
+     the **Affected versions** range and the **Patched versions** value;
+     record the **Vulnerable functions** if known. The published
+     distribution surface is enumerated in `SECURITY.md` and the repo
+     `packages/` tree (the `evidentia-*` PyPI packages plus the bundled UI) —
+     name only the ones that actually carry the vulnerable code (most bugs live in one or
+     two packages, not all of them).
+   - **Severity** — use **Assess severity using CVSS** and paste/derive
+     the vector from Step 2.
+   - **Common weakness enumerator** — add the CWE id from Step 2.
+   - **Credits** — add the reporter (default to crediting them; honor an
+     opt-out per `SECURITY.md`). The reporter's handle here becomes the
+     public credit on publish.
+
+3. **Save the draft.** It is **private** — visible only to maintainers
+   and anyone you add. Drafting (and, later, requesting a CVE) does
+   **not** make the advisory public.
+
+> A package whose **Ecosystem** is left blank or unrecognized will not
+> become a database-reviewed advisory and will not generate Dependabot
+> alerts downstream. Set the pip ecosystem and exact ranges deliberately
+> — that is what turns a published GHSA into an automatic alert for
+> Evidentia's users.
+
+---
+
+## Step 4 — Coordinate the fix in a temporary private fork
+
+1. On the draft advisory page, scroll to **Collaborate on a patch** and
+   click **Start a temporary private fork**. GitHub creates a private
+   fork named `evidentia-ghsa-xxxx-xxxx-xxxx`.
+
+2. Develop the fix on a branch in that private fork (clone it, or edit
+   on GitHub). Keep the work **private** — do not push the fix to a
+   public branch, and do not reference the vulnerability in any public
+   commit message, issue, or PR until publish.
+
+3. From the advisory page, under **Collaborate on a patch**, open the
+   PR against the advisory (**Compare & pull request** → **Create Pull
+   Request** or **Create Draft Pull Request**). Review and merge it
+   **at the advisory level** — the merge does not expose the fix
+   publicly while the advisory is still a draft.
+
+4. Bring the patched code into the real release branch as part of the
+   tagged release in Step 6. **Publishing the advisory later deletes the
+   temporary private fork**, so the fix must reach the release flow
+   before then.
+
+> Evidentia's normal change flow is **PR → merge queue → `main`** with a
+> ruleset that forbids direct pushes. The private-fork path is the
+> sanctioned exception for an embargoed fix: it lets you prepare the
+> patch without a public PR. Reconcile it into the protected `main`
+> through the standard release tagging once the advisory is ready to go
+> public.
+
+---
+
+## Step 5 — Request the CVE (GitHub as CNA)
+
+1. On the draft advisory, click **Request CVE** (this button appears in
+   place of **Publish advisory** when you chose *Request CVE ID later*).
+
+2. GitHub reviews the request — **usually within 72 hours**. **Requesting
+   a CVE does not make the advisory public**: the reserved CVE id is
+   attached to the still-private draft, and the CVE record is only
+   published when you publish the advisory.
+
+3. Do **not** request a CVE for an issue that belongs to another CNA's
+   product (e.g., a dependency). GitHub will not assign a CVE for a
+   component another CNA covers.
+
+> You can request the CVE in parallel with the fix work in Step 4 — the
+> 72-hour review overlaps the patch development, so the reserved id is
+> usually in hand by the time the fix is ready to ship.
+
+---
+
+## Step 6 — Ship the fix (tag-driven release)
+
+The fix ships through Evidentia's normal **tag-driven** release, not the
+advisory UI. Per `SECURITY.md` → *Disclosure timeline*: the GHSA is
+published **after** the fix lands on PyPI.
+
+1. Land the patched code on `main` via the standard PR/merge-queue flow.
+2. Cut the patch release following
+   [`docs/release-checklist.md`](../release-checklist.md): bump all
+   package versions, update the CHANGELOG (see Step 8), run the gates,
+   then `git tag -s vX.Y.Z && git push origin vX.Y.Z` to fire
+   `release.yml` (PyPI publish + GHCR image + SBOM + attestations).
+3. Update the **Supported versions** table in `SECURITY.md` so the new
+   patch is the single supported release (older patches deprecate per
+   the pre-1.0 single-supported-patch policy).
+
+> Tagging a release and any `git push` remain Tier-4 actions requiring
+> explicit approval per the global publishing-authority protocol.
+> Publishing the GHSA (Step 7) is likewise a public-surface action —
+> surface it and get approval before clicking **Publish advisory**.
+
+---
+
+## Step 7 — Publish the GHSA + CVE
+
+1. Confirm the fix is **live on PyPI** (and the container on GHCR) for
+   the patched version — disclosure follows the fix, not the other way
+   around.
+
+2. On the advisory page, scroll to the bottom and click **Publish
+   advisory**.
+
+3. On publish:
+   - The advisory becomes **public**.
+   - GitHub reviews the published advisory, **adds it to the GitHub
+     Advisory Database**, and **may send Dependabot alerts** to affected
+     downstream repositories (this is why the pip ecosystem + exact
+     ranges in Step 3 matter).
+   - If GitHub assigned a CVE, **GitHub publishes the CVE record to the
+     MITRE database** (from there it propagates to NVD and the public
+     CVE List).
+   - The **temporary private fork is deleted**.
+
+> If you publish **without a patched version** set, GitHub will still
+> alert users about the issue but they'll have no fixed version to move
+> to — only publish after the fix is shipped and the patched-version
+> field is populated.
+
+---
+
+## Step 8 — Post-publish notification
+
+1. **CHANGELOG `Security` section.** The CHANGELOG follows *Keep a
+   Changelog* (which defines a `Security` change-type for
+   vulnerabilities). Add a **`### Security`** entry under the patched
+   version describing the fix, and reference the **GHSA id** and the
+   **CVE id**. Keep the entry factual and non-exploitable.
+
+2. **Release notes.** Ensure the GitHub Release body for the patched tag
+   names the advisory and CVE, consistent with the CHANGELOG (the
+   release-notes audit in `docs/release-checklist.md` Step 9.5 covers
+   this). Per `SECURITY.md` → *Acknowledgments*, coordinated reports are
+   **credited in the release notes and in the GHSA**.
+
+3. **Credit the reporter.** The **Credits** you set on the advisory
+   (Step 3) render publicly on the GHSA. `SECURITY.md` states
+   recognition is **in-release-only** for now (a
+   `SECURITY-HALL-OF-FAME.md`-style page is planned post-v1.0) — so the
+   credit lives on the GHSA + in the release notes, honoring any
+   reporter opt-out.
+
+4. **`security.txt`.** The repo's
+   [`.well-known/security.txt`](../../.well-known/security.txt) already
+   sets `Acknowledgments:` to the repository **advisories list**
+   (`.../security/advisories`), so a newly published GHSA appears there
+   automatically — no edit to `security.txt` is required per advisory.
+   (Only revisit `security.txt` if its `Expires:` date is near or the
+   contact/policy URLs change.)
+
+5. **Close the loop with the reporter** in the private thread: link the
+   published GHSA, the CVE, and the released version; thank them.
+
+---
+
+## Quick checklist (print-under-pressure)
+
+- [ ] Report received on a **private** channel; acknowledged within
+      **3 business days**; report date + 90-day target recorded.
+- [ ] Reproduced; **in scope** per `SECURITY.md`; affected + fix
+      versions identified.
+- [ ] **CVSS** vector (v4.0 or v3.1) recorded; **CWE** id chosen.
+- [ ] Draft GHSA created; **pip** ecosystem + per-package affected/
+      patched ranges set; **Request CVE ID later** selected; reporter
+      added to **Credits**.
+- [ ] **Temporary private fork** started; fix PR reviewed + merged at
+      the advisory level; nothing leaked to a public surface.
+- [ ] **Request CVE** clicked; reserved id attached (still private).
+- [ ] Fix shipped to **PyPI** via the tag-driven release;
+      `SECURITY.md` supported-versions table updated.
+- [ ] **Publish advisory** clicked **after** the fix is live; GHSA
+      public, CVE → MITRE, advisory in DB, private fork deleted.
+- [ ] CHANGELOG **`### Security`** entry (GHSA + CVE); release notes +
+      GHSA **credit the reporter**; reporter notified.
+
+---
+
+## Sources
+
+Primary sources consulted for the GitHub-as-CNA flow and the
+standards references (verify against the live pages, as GitHub's UI
+labels evolve):
+
+- GitHub Docs — *About repository security advisories* (GitHub is a CNA;
+  CVE assignment for public repos; requesting a CVE keeps the advisory
+  private until publish; publish adds to the Advisory Database and
+  publishes the CVE to the MITRE database).
+- GitHub Docs — *Creating a repository security advisory* (draft form
+  fields: Title, CVE identifier, Description, Affected products /
+  Ecosystem, Severity / *Assess severity using CVSS*, *Common weakness
+  enumerator*, Credits).
+- GitHub Docs — *Collaborating in a temporary private fork to resolve a
+  repository security vulnerability* (**Start a temporary private
+  fork**, **Compare & pull request**).
+- GitHub Docs — *Publishing a repository security advisory* (**Publish
+  advisory** / **Request CVE**; publishing deletes the temporary private
+  fork).
+- GitHub Docs — *About the GitHub Advisory Database* (reviewed
+  advisories → Dependabot alerts; **pip** / PyPI is a supported
+  ecosystem).
+- GitHub Changelog — *GitHub security advisories support CVSS 4.0*
+  (the advisory form supports CVSS v4.0 and v3.1).
+- CWE — *About CWE* (MITRE/CISA-stewarded community weakness taxonomy).
+- CVE Record Format is at **major version 5** (CVEProject/cve-schema);
+  GitHub-as-CNA emits records in this format. This is background — the
+  maintainer does not hand-author CVE JSON; GitHub generates the record.

--- a/docs/runbooks/release-rollback.md
+++ b/docs/runbooks/release-rollback.md
@@ -1,0 +1,448 @@
+# Release rollback / yank / recovery runbook
+
+> Consolidated decision procedure for recovering from a bad Evidentia
+> release. This runbook is the single home for guidance that was
+> previously scattered across [`release-checklist.md`](../release-checklist.md)
+> (Step 8 re-trigger notes, Step 10 yank note), the per-release
+> `security-review-*.md` "standard ladder" / "rollback path" text, and
+> the `release.yml` workflow comments.
+>
+> **Read the one-line invariant first.** Evidentia releases are
+> tag-driven and immutable by design: **a published `v*` tag is never
+> moved or deleted** (the server now refuses to, see §1), and a bad
+> release is recovered by **yanking on PyPI + shipping a new patch** —
+> never by deleting an artifact or rewriting history. A version pinned
+> with `==X.Y.Z` keeps installing after a yank, so the yank protects new
+> consumers without breaking pinned deployments.
+
+---
+
+## 0. Scope and the model this runbook protects
+
+Evidentia ships from a single tag push: `git tag -s vX.Y.Z && git push
+origin vX.Y.Z` fires [`release.yml`](../../.github/workflows/release.yml),
+which builds and validates **every** artifact — the 8 `evidentia-*`
+wheels + sdists, the CycloneDX SBOM, and the container image (built
+**from the locally-built wheels**, not from the package index) — and
+smoke-tests the image **before** the irreversible PyPI publish. Only
+after `build` succeeds does `publish-pypi` upload to PyPI, then
+`publish-container` pushes + cosign-signs the byte-identical image to
+GHCR and creates the GitHub Release last.
+
+That ordering (adopted in v0.10.14 after the v0.10.12 packages-only
+release) means **most failures are caught before anything is published**
+— a base-image regression, a failing smoke test, or a red gate fails
+`build` and `publish-pypi` never runs. This runbook covers the harder
+case: a release that *did* publish and then turned out to be bad.
+
+What "bad" means here:
+
+- A functional defect users hit (broken import, wrong output, crash).
+- A security issue in Evidentia's own code (see §6 for the GHSA path).
+- A supply-chain / dependency problem in the resolved tree.
+- A broken or incomplete artifact set (e.g. wheels published but the
+  container failed — the literal v0.10.12 → v0.10.13 case).
+
+What this runbook is **not**: it is not the place to "undo" a release by
+deleting it. PyPI deletion and tag deletion are off the table by policy
+**and** by server enforcement (§1). Recovery is always *forward*.
+
+---
+
+## 1. The invariant is now server-enforced (not just a convention)
+
+"Never move or delete a published tag" used to be a discipline you had
+to remember. As of **2026-06-26** it is enforced by GitHub on the
+canonical repo, so an accidental `git push --force` or `gh release
+delete` against a `v*` tag is refused at the server:
+
+1. **A tag ruleset blocks tag deletion, force-updates, and unsigned
+   tags.** The repository ruleset **"Protect release tags (v\*)"**
+   (`enforcement: active`, `target: tag`) applies to `refs/tags/v*` and
+   carries three rules: `deletion`, `non_fast_forward`, and
+   `required_signatures`. A `v*` tag therefore cannot be deleted, cannot
+   be moved to a new commit (no non-fast-forward update), and must be
+   signed.
+   *Verify:* `gh api repos/Polycentric-Labs/evidentia/rulesets/18175057
+   --jq '{name, enforcement, rules: [.rules[].type]}'` →
+   `non_fast_forward` / `deletion` / `required_signatures`.
+
+2. **GitHub Immutable Releases is enabled.** Published GitHub Releases
+   (and their attached assets — SBOM, SLSA provenance bundle) cannot be
+   altered or re-pointed after creation.
+   *Verify:* `gh api
+   repos/Polycentric-Labs/evidentia/immutable-releases` →
+   `{"enabled":true,...}`.
+
+**Consequence for this runbook:** the v0.10.3-era "move-tag re-fire"
+recovery (delete the remote tag, re-create it on a fixed commit,
+re-push) is now **impossible** on `v*` tags — and that is the intended
+state. The only correct recovery for a published-but-bad release is to
+**ship a new patch tag**. The decision tree below never asks you to
+delete or move a tag.
+
+> The `release.yml` concurrency comment still references the historical
+> "move-tag re-fire" pattern as the reason `cancel-in-progress: false`.
+> The `cancel-in-progress: false` setting is still correct (a re-pushed
+> *new patch* tag should queue behind an in-flight run, not cancel it);
+> the move-tag framing in that comment predates the tag ruleset.
+
+---
+
+## 2. Why "yank", not "delete" — PEP 592, verified
+
+The recovery ladder leans on PyPI **yank**, which is a deliberately
+weaker action than deletion. From **PEP 592 ("Adding Yank Support to the
+Simple API")**:
+
+- **Yank is not delete.** "Yanking a file allows authors to effectively
+  delete a file, without breaking things for people who have pinned to
+  exactly a specific version." The file stays hosted.
+- **A pinned `==X.Y.Z` install still resolves a yanked release.** Per the
+  installer specification, "Yanked files are always ignored, unless they
+  are the only file that matches a version specifier that 'pins' to an
+  exact version using either `==` (without any modifiers that make it a
+  range, such as `.*`)." So `pip install evidentia==X.Y.Z` and a
+  hash-pinned lockfile entry keep working after the yank.
+- **Non-pinned installs skip it.** "An installer MUST ignore yanked
+  releases, if the selection constraints can be satisfied with a
+  non-yanked version." A bare `pip install evidentia` or a range
+  specifier resolves to the next good version automatically.
+- **That is exactly the motivation.** PEP 592 frames yank as the way out
+  of the delete catch-22: deleting "will break users who have followed
+  best practices and pinned to a specific version," whereas yank stops
+  *new* inadvertent installs without breaking pinned consumers.
+
+**Provenance survives a yank.** Because the artifact bytes are
+preserved, every signature and attestation bound to them stays valid: a
+yanked wheel's PEP 740 / Sigstore attestation still verifies, its entry
+in the Rekor transparency log is unchanged, and its SLSA build
+provenance still resolves. Yank changes a release's *availability
+status*, not its bytes — so it never invalidates the supply-chain chain
+this project spends so much effort producing.
+
+> **One-line dry-run reminder.** Before yanking, sanity-check that you
+> are not about to break a pinned consumer: a yank leaves
+> `pip install evidentia==<bad-version>` working *on purpose*. If your
+> goal is to make that exact pin fail, yank is the wrong tool — there
+> is no policy-compatible tool for that (deletion is barred), and the
+> answer is to ship a fixed patch and advise upgrading.
+
+---
+
+## 3. Decision tree
+
+```
+A bad release vX.Y.Z is live (published to PyPI / GHCR / Releases).
+│
+├─ Q1. Is it a SECURITY issue in Evidentia's own code?
+│      ├─ YES → run the security track:
+│      │         · open/After-the-fact draft a GHSA (§6)
+│      │         · yank the affected PyPI artifacts (§4)
+│      │         · ship a fixed patch vX.Y.Z+1 (§4)
+│      │         · publish the GHSA after the fix is on PyPI (§6)
+│      └─ NO  → continue.
+│
+├─ Q2. What is broken, and how bad?
+│      ├─ Functional defect users hit at runtime
+│      │     → STANDARD LADDER (§4): yank + ship a new patch.
+│      ├─ Bad/incompatible dependency in the resolved tree
+│      │     → STANDARD LADDER (§4): yank + ship a new patch with the pin fixed.
+│      ├─ Container only (wheels are fine) — the v0.10.12→v0.10.13 case
+│      │     → CONTAINER ROLLBACK (§5): do NOT yank the good wheels;
+│      │       fix the Dockerfile/base and ship a new patch; GHCR steps in §5.
+│      └─ Cosmetic only (CHANGELOG typo, wrong release-note text)
+│            → no yank. Correct the source in a normal PR; if the published
+│              Release body is wrong, note that GitHub Immutable Releases
+│              (§1) bars editing it — carry the correction in the next
+│              release's notes + CHANGELOG instead.
+│
+├─ Q3. NEVER, regardless of branch above:
+│      ├─ move or delete the vX.Y.Z tag        (barred by §1; impossible)
+│      ├─ delete the PyPI files                (policy: yank, never delete)
+│      └─ auto-yank on a smoke-test failure    (see the note below)
+│
+└─ Q4. Capture evidence (§7) and communicate (§8) on every real rollback.
+```
+
+### The standard ladder, in one place
+
+For a published-but-bad release, the canonical recovery — the "standard
+ladder" the `security-review-*.md` docs reference — is:
+
+1. **Tell users to pin to the last good version:**
+   `pip install evidentia==X.Y.Z-1` (the prior patch). This is the
+   immediate user-facing mitigation and needs no maintainer action.
+2. **Yank the bad version's artifacts on PyPI** (§4). Yank ≠ delete;
+   cosign + Rekor signatures stay valid; pinned installs of the bad
+   version still resolve (§2).
+3. **For a container-only fault, delete/repoint the bad GHCR tag** (§5).
+4. **Ship a new patch `vX.Y.Z+1`** that fixes the defect, through the
+   normal PR → merge-queue → `git tag -s` flow.
+5. **Correct the CHANGELOG** (and open a GHSA if security, §6).
+
+This is forward-only by construction: every step either changes
+availability metadata (yank, GHCR tag) or adds a new release. Nothing is
+rewritten.
+
+### Why there is no auto-yank-on-smoke
+
+`release.yml` smoke-tests the container in the `build` job **before**
+`publish-pypi` runs. A failing smoke test therefore fails `build`, and
+the irreversible PyPI publish never happens — there is nothing to yank.
+By the time a release reaches PyPI it has already passed the smoke test.
+A yank is consequently always a **deliberate, human** decision made
+*after* publish in response to a real defect, never an automated
+reaction wired into the pipeline. Do not add an auto-yank step; it would
+fire only on conditions that cannot occur (a published-but-smoke-failed
+release) and would risk yanking a good release on a flaky check.
+
+---
+
+## 4. PyPI yank + ship-a-patch (the standard ladder, detailed)
+
+**When:** a functional or dependency defect has reached PyPI and you want
+to stop new non-pinned installs from resolving the bad version.
+
+### 4.1 Yank the affected artifacts
+
+Yank is performed in the **PyPI web UI** per project, per version — there
+is no first-party `pip`/`twine` yank command, and no API token is needed
+(yank is an account-owner action, not a publish action, so it does not
+go through the OIDC Trusted Publisher path):
+
+1. For **each** affected package, go to
+   `https://pypi.org/manage/project/<package>/releases/` (the 8 packages:
+   `evidentia`, `evidentia-core`, `evidentia-ai`, `evidentia-collectors`,
+   `evidentia-integrations`, `evidentia-api`, `evidentia-mcp`, and
+   `evidentia-eval`).
+2. Select release **X.Y.Z** → **Options** → **Yank** → supply a short
+   public reason (it shows in the API and to anyone who installs the
+   pinned version). Keep it factual, e.g. *"Yanked: container base
+   regression; use X.Y.Z+1"* or *"Yanked: <CVE/GHSA-id>; fixed in
+   X.Y.Z+1."*
+3. Yank **the whole version set** that shipped together, so a range
+   resolver doesn't pick a half-yanked release. If the defect is in one
+   package only, yank at minimum that package; prefer yanking the matched
+   version across all 8 so the inter-package pins stay coherent.
+
+> **Reversible.** Yank is reversible (un-yank in the same UI) if you
+> later determine the release was fine. Deletion is not — which is the
+> other reason the ladder never deletes.
+
+### 4.2 Verify the yank took effect
+
+```bash
+# The release's "yanked" flag is visible in the JSON API.
+curl -s https://pypi.org/pypi/evidentia/X.Y.Z/json | python -c \
+  "import sys,json; d=json.load(sys.stdin); \
+   print('yanked:', any(f.get('yanked') for f in d['urls']))"
+
+# Pinned install STILL works (expected — this is the PEP 592 contract):
+python -m venv /tmp/yank-check && /tmp/yank-check/bin/pip install \
+  "evidentia==X.Y.Z"          # resolves the yanked version: OK
+
+# Non-pinned install SKIPS the yanked version (resolves to the good one):
+python -m venv /tmp/range-check && /tmp/range-check/bin/pip install \
+  "evidentia"                  # must NOT resolve X.Y.Z
+```
+
+### 4.3 Ship the fixed patch
+
+Fix the defect on a branch and release `vX.Y.Z+1` through the normal
+flow (see [`release-checklist.md`](../release-checklist.md) Step 8):
+
+```bash
+git checkout -b fix/vX.Y.Z+1
+# ... fix + bump (scripts/bump_version.py --to X.Y.Z+1) + CHANGELOG ...
+git push origin fix/vX.Y.Z+1
+gh pr create --base main --head fix/vX.Y.Z+1 --title "..." --body "..."
+gh pr merge <PR#> --squash --auto        # merge queue re-tests + squash-merges
+# after it lands on main, tag (Tier-4 — get explicit approval first):
+git tag -s vX.Y.Z+1 -m "Release vX.Y.Z+1 — <one-line summary>"
+git push origin vX.Y.Z+1                  # fires release.yml
+gh run watch
+```
+
+The v0.10.12 → **v0.10.13** cycle is the worked example of this ladder's
+container variant (§5): wheels were fine, the container failed, and the
+fix shipped as a forward patch — no yank of the good wheels, no tag
+rewrite.
+
+---
+
+## 5. Container (GHCR) rollback
+
+**When:** the wheels are good but the container image is broken or must
+be withdrawn (e.g. a base-image regression, as in v0.10.12 where the
+`python:3.14-slim` base broke the `litellm` resolve and the container
+build failed *after* the PyPI publish).
+
+Key facts about the GHCR surface:
+
+- The image is published to `ghcr.io/polycentric-labs/evidentia` under
+  two tags pushed at the same digest: `:vX.Y.Z` and `:latest`.
+- It is **cosign-signed (keyless OIDC)** and carries a **SLSA build
+  provenance** attestation on the digest.
+
+### 5.1 Repoint `:latest` to the last good image (fastest mitigation)
+
+If a freshly-pushed `:latest` is bad, the quickest user-facing fix is to
+make `:latest` resolve to the previous good digest again. The durable
+fix is to ship a new patch (which re-pushes `:latest` at the new good
+digest); until then, consumers pulling `:vX.Y.Z-1` explicitly are
+unaffected.
+
+### 5.2 Delete the bad GHCR tag (when withdrawal is required)
+
+Unlike git tags and PyPI files, a GHCR image version *can* be deleted —
+GHCR is a registry, not the immutable release surface. Deleting the bad
+image version withdraws it cleanly. These calls hit the GitHub "package
+versions for a package owned by an organization" REST API, so the `gh`
+token needs `read:packages` (to list) and `delete:packages` (to delete)
+scope:
+
+```bash
+# List container versions (id + tags) to find the bad one:
+gh api "orgs/Polycentric-Labs/packages/container/evidentia/versions" \
+  --jq '.[] | {id, tags: .metadata.container.tags}'
+
+# Delete the specific bad version by id (Tier-4 — get approval first):
+gh api -X DELETE \
+  "orgs/Polycentric-Labs/packages/container/evidentia/versions/<VERSION_ID>"
+```
+
+> Deleting a GHCR image version is a public-surface mutation (Tier-4):
+> surface the exact `gh api -X DELETE …` command and get explicit
+> approval before running it, per the publishing-authority protocol.
+> Prefer repointing `:latest` + shipping a forward patch over deletion
+> unless the bad image must be actively withdrawn (e.g. it ships a
+> vulnerable layer).
+
+### 5.3 Ship the fixed-container patch
+
+Fix the Dockerfile / base / pin and ship `vX.Y.Z+1` exactly as in §4.3.
+Because `release.yml` now builds the container **from the local wheels
+and smoke-tests it before publish** (the v0.10.14 atomic-release
+change), a re-broken container fails `build` and blocks the PyPI publish
+of the patch — so you cannot accidentally re-create a wheels-only
+release while fixing one.
+
+---
+
+## 6. Security track — GHSA + coordinated disclosure
+
+If the bad release is a **security** issue in Evidentia's own code, run
+the standard ladder (§4) **and** the disclosure flow from
+[`SECURITY.md`](../../SECURITY.md):
+
+1. **Draft a GitHub Security Advisory** at
+   `https://github.com/Polycentric-Labs/evidentia/security/advisories/new`
+   (private draft). Request a CVE through the GHSA flow if warranted.
+2. **Fix + ship the patch** (§4.3). Per `SECURITY.md`, the supported
+   version is always the latest patch — there are no pre-1.0 backports,
+   so the fix ships as `vX.Y.Z+1` and older patches are deprecated.
+3. **Yank the vulnerable artifacts** (§4.1) with a reason referencing the
+   GHSA/CVE id once assigned.
+4. **Publish the GHSA** *after* the fix is live on PyPI (the `SECURITY.md`
+   pattern: "After fix lands and is published to PyPI, the GitHub
+   Security Advisory is published"). Credit the reporter unless they
+   opted out.
+5. **Disclosure window:** 90 days from report to public disclosure by
+   default, shorter when an upstream fix only needs a pin bump (the
+   v0.7.2 same-day pattern), longer by mutual agreement.
+
+A verification failure on a *published* artifact (cosign / PEP 740 /
+`gh attestation verify` fails where it previously passed) is itself a
+security incident, not a routine rollback — treat it as Q1=YES and
+investigate before yanking, since a yank does not change artifact bytes
+and would not "fix" a provenance compromise.
+
+---
+
+## 7. Evidence capture
+
+Every real rollback is a change event and gets a paper trail (this is a
+GRC tool — the rollback itself should be auditable):
+
+- **The trigger.** The failing `release.yml` run id + the failed job/step
+  (`gh run view <run-id>`), or the user report / advisory that surfaced
+  the defect.
+- **The decision.** Which ladder branch (§3) and why — note it in the
+  release tracking issue and in the next release's
+  `security-review-*.md` / CHANGELOG.
+- **The yank.** Package(s) + version yanked, the public reason string,
+  and the timestamp. The `curl …/json` yanked-flag check from §4.2 is a
+  good before/after artifact.
+- **The GHCR action.** The deleted version id or the repointed
+  `:latest` digest, plus the `gh api` command run.
+- **The fix.** The patch PR + the `vX.Y.Z+1` tag/run that resolved it.
+- **Provenance note.** Record that the yanked artifacts' signatures /
+  Rekor entries remain valid (yank preserved the bytes) — so an auditor
+  reading the trail later understands the supply-chain chain was never
+  broken.
+
+For a security rollback, the GHSA *is* the canonical evidence record;
+link the tracking issue and the fixing PR from it.
+
+---
+
+## 8. User communications
+
+Match the channel to the severity:
+
+- **CHANGELOG (always).** The fixing patch's `[X.Y.Z+1]` block states
+  plainly what was wrong, that the prior version was yanked, and the
+  upgrade action. The v0.10.13 CHANGELOG entry is the model: it names
+  the regression, the root cause, and the fix without blame.
+- **GitHub Release notes (the new patch).** `release.yml` builds the body
+  from the CHANGELOG block, so a clear CHANGELOG entry produces clear
+  release notes automatically. (The *bad* release's notes can't be edited
+  — Immutable Releases, §1 — so the correction lives in the new release.)
+- **Yank reason string (PyPI).** Short, points at the fixed version;
+  visible to anyone installing the pinned bad version.
+- **GHSA (security only, §6).** The coordinated-disclosure surface;
+  publish after the fix is on PyPI.
+- **Pin-to-last-good guidance.** For an actively-harmful release, the
+  immediate user message is `pip install evidentia==X.Y.Z-1` (or
+  `docker pull …:vX.Y.Z-1`) while the patch is prepared — this needs no
+  maintainer action and is the fastest mitigation.
+
+---
+
+## 9. Quick reference
+
+| Situation | Action | Never |
+|---|---|---|
+| Bad release on PyPI | Yank affected versions (§4.1) + ship patch (§4.3) | Delete PyPI files; move/delete the tag |
+| Container broken, wheels fine | Repoint `:latest` / delete bad GHCR version (§5) + patch | Yank the good wheels |
+| Security defect in our code | GHSA draft → patch → yank → publish GHSA (§6) | Publish the GHSA before the fix is on PyPI |
+| Cosmetic Release-notes error | Correct in next release's notes + CHANGELOG | Try to edit the published Release (barred, §1) |
+| Smoke test fails at release | Nothing to roll back — `build` failed pre-publish | Add auto-yank on smoke (§3) |
+| Pinned consumer of bad version | They keep working by design (PEP 592, §2) | Expect yank to break their pin |
+
+**Invariants:** tags are immutable and signature-required (§1) ·
+Immutable Releases is on (§1) · yank ≠ delete and preserves provenance
+(§2) · recovery is always *forward* (a new patch), never a rewrite.
+
+---
+
+## References
+
+- [`release.yml`](../../.github/workflows/release.yml) — the atomic
+  tag-driven flow (build-and-validate-all-artifacts-before-publish;
+  container from local wheels; pre-publish smoke).
+- [`release-checklist.md`](../release-checklist.md) — Step 8 (tag/push +
+  re-trigger notes), Step 10 (yank note).
+- [`SECURITY.md`](../../SECURITY.md) — vulnerability reporting, supported
+  versions (single supported patch), 90-day disclosure window.
+- [`engineering-practices.md`](../engineering-practices.md) — the
+  safeguard-stack narrative the atomic-release change belongs to.
+- [PEP 592 — Adding Yank Support to the Simple API](https://peps.python.org/pep-0592/)
+  — the normative basis for yank ≠ delete and the pinned-install
+  contract.
+- [Google SRE Workbook, Chapter 16 — Canarying Releases](https://sre.google/workbook/canarying-releases/)
+  — release-engineering context (smaller self-contained artifacts make
+  rollback cheaper; deployments should be automated; staged rollout
+  detects defects fast). The Workbook has no dedicated rollback chapter;
+  the rollback procedure here is Evidentia-specific.

--- a/docs/slsa-source-track.md
+++ b/docs/slsa-source-track.md
@@ -1,0 +1,283 @@
+# SLSA Source Track posture
+
+This document is an **honest self-assessment** of Evidentia's source-control
+integrity against the [SLSA](https://slsa.dev) **Source Track**, and a claim of
+the level the project **genuinely meets today**. It maps each Source Track
+requirement to verifiable evidence in this repository's GitHub configuration,
+and states — precisely — the controls that are **not** met and the gap to the
+next level. Every project-specific claim below is verifiable with the commands
+in [How to verify](#how-to-verify); nothing is asserted that cannot be checked
+against the live repo.
+
+> **Bottom line.** Evidentia **enforces the SLSA Source Level 3 technical
+> controls** (Continuous Technical Controls): continuous, technically-enforced,
+> signed branch and tag protection with retained history and no bypass actors —
+> all independently verifiable via the rulesets API. One honest caveat: GitHub
+> does not emit standardized SLSA Source *attestation artifacts* (VSAs), so this
+> is a **controls-enforced** claim, not a formal-attestation claim (disclosed
+> throughout). It does **not** meet **Source Level 4** (Two-Party Review),
+> because the project has a single maintainer and GitHub cannot let an author
+> approve their own pull request — so two-trusted-person review is structurally
+> unattainable until a second trusted maintainer joins. The L4 gap is a
+> deliberate, honestly-disclosed ceiling, not an oversight.
+
+## What the SLSA Source Track is
+
+SLSA (Supply-chain Levels for Software Artifacts) has **two tracks**: the
+**Build Track** (integrity of how artifacts are built) and the **Source
+Track** (integrity of the source / version-control process — authoring,
+reviewing, and managing source code *before* a tagged commit reaches a
+builder). The two are independent: a project earns a level on each track
+separately.
+
+**Spec version this assessment targets.** The current SLSA specification is
+**v1.2**, **Approved**. SLSA **v1.2** (announced November 2025) promoted the
+Source Track from *experimental* to *approved* and reorganized the source
+levels around history and continuous enforcement. The Build Track had been
+stabilized earlier in **SLSA v1.1** (approved **April 2025**), which was
+largely a clarity refresh. This document assesses Evidentia against the **v1.2
+Source Track**; it does not restate Evidentia's Build Track posture (PEP 740
+attestations, cosign keyless container signatures, SLSA build provenance),
+which is covered in `SECURITY.md` and [`docs/verification.md`](verification.md).
+
+> Note on Source Track terminology: SLSA generates **Verification Summary
+> Attestations (VSAs)** and **Source Provenance Attestations** through a Source
+> Control System (SCS). GitHub does not (yet) emit standardized SLSA Source VSAs
+> for arbitrary repositories. This assessment therefore maps each Source Track
+> requirement to the **technical control GitHub enforces** (rulesets, signature
+> verification, history protection) as the evidence, and flags the
+> attestation-emission requirements that depend on SCS tooling Evidentia does
+> not control. See [What we cannot self-attest](#what-we-cannot-self-attest).
+
+## The Source Track levels (SLSA v1.2)
+
+| Level | Name | Focus |
+|-------|------|-------|
+| **Source L1** | Version Controlled | Source is in a VCS with immutable, uniquely-identifiable revisions and change-display tooling. |
+| **Source L2** | History & Provenance | Branch history is continuous, immutable, and retained; tags cannot be moved or deleted; changes to named references are recorded; provenance is produced contemporaneously. |
+| **Source L3** | Continuous Technical Controls | The organization enforces customized technical controls on specific named references, continuously, with the controls recorded in contemporaneous attestations; continuity is tracked from a start revision and re-established after any lapse. |
+| **Source L4** | Two-Party Review | Changes to protected branches must be agreed to by **two or more trusted persons** (uploader + reviewer, or two reviewers), via an informed review covering security-relevant properties. |
+
+(Source: SLSA v1.2 Source requirements,
+<https://slsa.dev/spec/v1.2/source-requirements>.)
+
+## Evidentia's source controls (ground truth)
+
+All facts below were read from the live GitHub configuration of
+`Polycentric-Labs/evidentia`. Three rulesets govern the source:
+
+1. **Org default-branch baseline** (ruleset `16831409`,
+   `polycentric-labs-default-branch-baseline`, Organization-level, **active**)
+   — applies to the default branch of **all** repos in the org. Rules:
+   `deletion`, `non_fast_forward`, `required_signatures`. `bypass_actors: []`.
+
+2. **`main` PR flow** (ruleset `18097115`,
+   *"main — PR flow (required checks + merge queue)"*, Repository-level,
+   **active**) — targets the default branch. Rules: `pull_request`
+   (allowed merge methods: `squash`), `required_status_checks`
+   (**19** required checks), `merge_queue` (SQUASH), `required_linear_history`,
+   `required_signatures`, `non_fast_forward`. `bypass_actors: []`,
+   `current_user_can_bypass: never`.
+
+3. **Release-tag protection** (ruleset `18175057`,
+   *"Protect release tags (v\*)"*, Repository-level, **active**) — targets
+   `refs/tags/v*`. Rules: `deletion`, `non_fast_forward`,
+   `required_signatures`. `bypass_actors: []`, `current_user_can_bypass:
+   never`.
+
+Supporting facts:
+
+- **Signed commits.** `commit.gpgsign=true` with `gpg.format=ssh` locally, and
+  `required_signatures` is enforced server-side on both the default branch
+  (two rulesets) and release tags. The current `main` HEAD commit verifies on
+  GitHub (`verification.verified = true`, `reason = valid`) — merge-queue squash
+  commits are GitHub-signed.
+- **No force-push / no deletion.** `non_fast_forward` + `deletion` rules on
+  both the default branch and `v*` tags; `required_linear_history` on `main`.
+- **No bypass.** Every ruleset has an **empty** `bypass_actors` list; the
+  repo rulesets additionally report `current_user_can_bypass: never`. A direct
+  `git push origin main` fails — changes must go through a PR + the merge queue.
+- **Release model.** Tag-driven: `git tag -s vX.Y.Z && git push origin vX.Y.Z`
+  fires `release.yml`. Tags are signed and protected from move/delete by
+  ruleset `18175057`.
+- **Project shape.** 8 `evidentia-*` Python packages published to PyPI
+  (`evidentia`, `-ai`, `-api`, `-collectors`, `-core`, `-eval`, `-integrations`,
+  `-mcp`), plus `evidentia-ui` (a TypeScript/Vite/React UI served by the API,
+  not a PyPI wheel). Apache-2.0. Single maintainer (Allen Byrd / Polycentric
+  Labs).
+
+## Requirement-by-requirement assessment
+
+### Source L1 — Version Controlled · **MET**
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| Source in a VCS with a stable locator | Public Git repo `github.com/Polycentric-Labs/evidentia` | ✅ |
+| Revisions immutable + uniquely identifiable | Git content-addressed commit SHAs | ✅ |
+| Tooling to display changes between revisions | GitHub diff / `git diff` / PR review UI | ✅ |
+| Identity management to authenticate actors | GitHub accounts; signed commits attribute revisions | ✅ |
+
+**L1 is fully met.**
+
+### Source L2 — History & Provenance · **MET**
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| History is continuous, immutable, retained | `non_fast_forward` + `deletion` protection on `main` (org baseline + repo ruleset) and `required_linear_history` | ✅ |
+| Tags cannot be moved or deleted | Tag ruleset `18175057`: `deletion` + `non_fast_forward` on `refs/tags/v*` | ✅ |
+| Changes to named references recorded (who/when) | GitHub records every push/merge to `main` and every tag in the ref/activity log; merge-queue squash commits are attributed | ✅ |
+| Access control on history enforced | Rulesets active org-wide and repo-level; empty bypass | ✅ |
+| Branch updates preserve ancestry | `required_linear_history` + `non_fast_forward` | ✅ |
+| Source Provenance Attestation produced contemporaneously | GitHub's signed merge commits + ref activity log serve as the contemporaneous record; **standardized SLSA Source VSA emission is not available** — see caveat | ⚠️ partial (see below) |
+
+**L2 is met in substance.** The history-integrity, tag-immutability, and
+recorded-reference-change requirements are technically enforced and verifiable.
+The only soft spot is the *form* of the attestation: SLSA L2 envisions a Source
+Provenance Attestation emitted by the SCS. GitHub does not emit standardized
+SLSA Source VSAs for this repo; the equivalent evidence is GitHub's
+cryptographically-signed commit record and immutable ref-activity log. We claim
+L2 on the strength of the enforced controls and contemporaneous record, and
+flag the formal-VSA gap honestly in
+[What we cannot self-attest](#what-we-cannot-self-attest).
+
+### Source L3 — Continuous Technical Controls · **MET**
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| Org enforces customized technical controls on specific named refs | Repo ruleset `18097115` on `main`: PR-required, 19 required status checks, merge queue, signed commits, linear history; tag ruleset `18175057` on `v*` | ✅ |
+| Controls enforced **continuously** (no lapse) | Rulesets are `enforcement: active`; org baseline active since 2026-05-25; bypass lists empty — there is no actor who can silently disable enforcement for a single change | ✅ |
+| Controls documented (their meaning) | This document + [`docs/scorecard-posture.md`](scorecard-posture.md) + `SECURITY.md` define the enforced controls and their intent | ✅ |
+| Continuity tracked from a start revision | Org baseline ruleset `created_at` 2026-05-25; repo PR-flow ruleset `created_at` 2026-06-24; tag ruleset `created_at` 2026-06-26 — each establishes a continuity start point | ✅ |
+
+**L3 is met.** Evidentia enforces a customized, documented set of technical
+controls on its protected `main` and `v*` references, continuously and without
+bypass. The required-status-checks gate (19 contexts including CodeQL SAST,
+cross-platform pytest, ruff, mypy, OSV/SBOM scan, gitleaks secret-scan, OpenAPI
++ CLI↔GUI drift gates, and workflow-permission audit) is itself part of the
+enforced control surface.
+
+> Honest caveat on L3's attestation clause: SLSA L3 also expects the enforced
+> controls to be **recorded in contemporaneously-produced attestations** with
+> `ORG_SOURCE_`-prefixed properties emitted by the SCS. GitHub's ruleset model
+> does not emit those standardized source attestations today. We rely on the
+> enforced-control evidence (queryable live via the rulesets API) plus this
+> documented control inventory. This is the same SCS-tooling limitation noted at
+> L2 and is disclosed, not glossed.
+
+### Source L4 — Two-Party Review · **NOT MET** (this is the ceiling)
+
+| Requirement | Reality | Status |
+|-------------|---------|--------|
+| Changes to protected branches agreed to by **two or more trusted persons** | **Single maintainer.** The `main` ruleset requires a PR (`pull_request` rule), but `required_approving_review_count` is **0** — because GitHub does not permit an author to approve their own PR, a non-zero requirement on a solo project would deadlock every merge. There is no second trusted person to review. | ❌ |
+| Uploader and reviewer are different trusted persons (or two reviewers) | Not satisfiable with one maintainer | ❌ |
+| Informed review covering security-relevant properties | Partially substituted by automated gates (19 required checks incl. CodeQL SAST) + a mandatory `/pre-release-review` before every tag, but these are **automated controls, not a second human reviewer** | ⚠️ substitute only |
+
+**L4 is not met, and we do not claim it.** The honest gap is **two-person
+review**. Evidentia is a single-maintainer project; GitHub structurally blocks
+self-approval, so the "two trusted persons" requirement cannot be satisfied no
+matter how the ruleset is configured. The PR-flow ruleset enforces the *process*
+(every change is a PR through the merge queue, with 19 required checks and an
+empty bypass list), but the *human* two-party-review control at the heart of L4
+is absent. We surface this rather than papering over it with automated-gate
+substitutes.
+
+## Honest summary of the claim
+
+| Level | Name | Status |
+|-------|------|--------|
+| Source L1 | Version Controlled | **MET** |
+| Source L2 | History & Provenance | **MET** (formal SCS-emitted VSA not available; enforced-control + signed-history evidence substitutes — disclosed) |
+| Source L3 | Continuous Technical Controls | **MET** (formal SCS source attestation not available; live rulesets + this inventory substitute — disclosed) |
+| **Source L4** | **Two-Party Review** | **NOT MET — solo maintainer; self-approval is impossible on GitHub** |
+
+**Claimed: the SLSA Source Level 3 _technical controls_ are enforced and
+independently verifiable**, with the L2/L3 attestation-*format* caveats
+disclosed above (the enforced controls themselves are real and queryable; only
+the standardized SCS-emitted attestation artifacts are unavailable from GitHub
+today). This is deliberately a controls-enforced claim, **not** a formal SLSA
+Source VSA claim.
+
+## Gap to the next level (L3 → L4)
+
+The single blocker is **two trusted-person review**. To reach Source L4:
+
+1. **Add a second trusted maintainer** to `Polycentric-Labs`. This is the
+   structural prerequisite — without a second human, L4 is unreachable.
+2. **Set `required_approving_review_count` to ≥ 1** on the `main` ruleset
+   (`18097115`) once a second reviewer exists, so each PR is approved by a
+   trusted person who is not the author. Optionally enable
+   `require_last_push_approval` and a CODEOWNERS file (none exists today) to
+   bind review to the relevant code areas.
+3. **Keep the informed-review bar**: reviews should cover security-relevant
+   properties of the change (the spec's "informed review"), with re-review when
+   the final revision changes during review.
+4. **Trusted-robot exceptions** (e.g. Dependabot) remain permissible under L4
+   and need not be human-reviewed, consistent with the spec.
+
+Until a second trusted maintainer exists, **Source Level 3 is the honest
+ceiling**, and Evidentia claims exactly that — no more.
+
+## What we cannot self-attest
+
+To keep this assessment honest, these items are **not** claimed as fully
+satisfied and are flagged for a reviewer:
+
+- **Standardized SLSA Source VSAs / Source Provenance Attestations.** GitHub
+  does not emit machine-readable SLSA Source-track attestations (with
+  `ORG_SOURCE_` properties) for this repo. The L2/L3 evidence here is the
+  **enforced technical control** (queryable via the rulesets API) plus
+  signed-commit and ref-activity records — strong evidence of the control, but
+  not the spec's envisioned attestation *artifact*. A formal SLSA Source VSA
+  would require SCS tooling Evidentia does not control.
+- **Two-person review (L4).** Not met (solo maintainer) — stated plainly above.
+
+## How to verify
+
+All of the following are read-only and reproducible by anyone with `gh` (no
+special permissions needed for public ruleset metadata):
+
+```bash
+# 1. Org default-branch baseline (signed commits + no force-push/delete, org-wide)
+gh api orgs/Polycentric-Labs/rulesets/16831409
+
+# 2. main PR-flow ruleset: PR required, 19 status checks, merge queue,
+#    signed commits, linear history, EMPTY bypass_actors, can_bypass=never
+gh api repos/Polycentric-Labs/evidentia/rulesets/18097115
+
+#    Count the required status checks (expect 19):
+gh api repos/Polycentric-Labs/evidentia/rulesets/18097115 \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | .parameters.required_status_checks | length'
+
+# 3. Release-tag protection on refs/tags/v*: deletion + non_fast_forward +
+#    required_signatures, EMPTY bypass_actors
+gh api repos/Polycentric-Labs/evidentia/rulesets/18175057
+
+# 4. Confirm main HEAD commit is signature-verified by GitHub
+gh api repos/Polycentric-Labs/evidentia/commits/main \
+  --jq '.commit.verification | {verified, reason}'
+
+# 5. Local signing config
+git config --get commit.gpgsign   # -> true
+git config --get gpg.format       # -> ssh
+```
+
+Expected results (as of this writing): ruleset 16831409 has rules
+`deletion` + `non_fast_forward` + `required_signatures` with empty
+`bypass_actors`; ruleset 18097115 reports 19 required status checks, an empty
+`bypass_actors`, and `current_user_can_bypass: "never"`; ruleset 18175057
+protects `refs/tags/v*` with `deletion` + `non_fast_forward` +
+`required_signatures`; and `main`'s HEAD verifies (`verified: true`,
+`reason: "valid"`).
+
+## References
+
+- SLSA v1.2 specification — <https://slsa.dev/spec/v1.2/>
+- SLSA v1.2 Source requirements (Source Track levels) —
+  <https://slsa.dev/spec/v1.2/source-requirements>
+- Announcing SLSA v1.2 (Source Track promoted to Approved, November 2025) —
+  <https://slsa.dev/blog/2025/11/announce-slsa-v1.2>
+- SLSA v1.1 is now Approved (Build Track, April 2025) —
+  <https://slsa.dev/blog/2025/04/slsa-v1.1>
+- Evidentia OpenSSF Scorecard posture — [`docs/scorecard-posture.md`](scorecard-posture.md)
+- Evidentia verification guide — [`docs/verification.md`](verification.md)


### PR DESCRIPTION
Batch 1 of the 2026-06-26 elite-practice gap scan: four **public posture documents**, each grounded in the real repo + primary sources via a multi-agent authoring pass with a per-claim ledger audit, then hand-reviewed for accuracy and over-claim.

## Documents
- **`docs/SECURE-BY-DESIGN-PLEDGE.md`** — voluntary alignment with the CISA Secure by Design Pledge's seven goals. An *alignment statement, not a signatory claim*. Org 2FA verified via `gh api`; **zero CVEs-issued-to-date stated honestly**, not hidden. Verified goal-by-goal against the official pledge PDF (all seven goal titles + scope + "within one year" framing match).
- **`docs/slsa-source-track.md`** — honest SLSA v1.2 Source Track self-assessment. The L3 *technical controls* are enforced and independently verifiable (all three rulesets + signed-commit verification confirmed via `gh api`); the **L4 two-party-review gap is disclosed** (single maintainer). Framed as controls-enforced, **not** a formal Source-VSA claim (GitHub emits no standardized Source attestation).
- **`docs/runbooks/ghsa-cve-issuance.md`** — runbook for publishing a GitHub Security Advisory + issuing a CVE via GitHub-as-CNA; every GitHub-flow step grounded in GitHub's official docs.
- **`docs/runbooks/release-rollback.md`** — consolidated rollback / yank / recovery decision tree. PEP 592 yank semantics verified verbatim; the "never move a published tag" rule is now SERVER-enforced (the new tag ruleset + Immutable Releases).

Linked from `SECURITY.md` (new "Security posture documents" section); recorded in `CHANGELOG` `[Unreleased]`. Docs-only; `check_docs_health --strict`: 0 FAIL.
