### PR TITLE
Chore(docs): Correct SECURITY.md distribution surface to 8 packages; refresh stale release.yml comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,13 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # cancel-in-progress: false so a move-tag re-fire (the documented v0.10.3 /
-  # v0.10.8 recovery pattern) queues BEHIND an in-flight run rather than
-  # cancelling a job mid-publish.
+  # cancel-in-progress: false so any re-fired release run (e.g. re-running a
+  # failed publish) queues BEHIND an in-flight run rather than cancelling a job
+  # mid-publish. Note: moving or deleting a published v* tag is now blocked
+  # server-side by the "Protect release tags (v*)" ruleset + GitHub Immutable
+  # Releases, so the historical v0.10.3 / v0.10.8 move-tag re-fire recovery no
+  # longer applies — recovery is yank + a forward patch
+  # (see docs/runbooks/release-rollback.md).
   cancel-in-progress: false
 
 # ---------------------------------------------------------------------------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,7 +113,7 @@ In scope:
 - Build + release infrastructure (`.github/workflows/*.yml`).
 - Distribution surface (PyPI packages `evidentia`, `evidentia-core`,
   `evidentia-collectors`, `evidentia-ai`, `evidentia-api`,
-  `evidentia-integrations`).
+  `evidentia-integrations`, `evidentia-mcp`, `evidentia-eval`).
 - The composite GitHub Action
   (`.github/actions/gap-analysis/action.yml`).
 - The bundled framework catalogs and crosswalk mappings


### PR DESCRIPTION
Two accuracy tidy-ups surfaced by the Batch-1 doc audit:

1. **SECURITY.md `Distribution surface`** listed 6 PyPI packages but all 8 are published (verified live on PyPI: `evidentia-mcp` and `evidentia-eval` are both at 0.10.13). Added the two missing packages.
2. **`release.yml` concurrency comment** cited the v0.10.3/v0.10.8 move-tag re-fire recovery, now blocked server-side by the tag ruleset + Immutable Releases. Updated to point at the rollback runbook; `cancel-in-progress: false` is unchanged and still correct.