### PR TITLE
Ci(security): Add zizmor Actions static-analysis gate (online, SHA-pinned)

### DIFF
--- a/.github/workflows/action-smoke-test.yml
+++ b/.github/workflows/action-smoke-test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/catalog-refresh.yml
+++ b/.github/workflows/catalog-refresh.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8  # v3.35.3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8  # v3.35.3
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -67,6 +67,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@14c9a0cbe6373488c2a41f7e75c8dd142bb2aba8  # v3.35.3
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -72,6 +72,7 @@ jobs:
           # Full history so the relevance step can diff the event's
           # base..head range (the base commit is not in a shallow clone).
           fetch-depth: 0
+          persist-credentials: false
 
       # v0.10.14: relevance gate. Diffs the event-appropriate base..head
       # range and sets `relevant=true` iff a container-build input changed
@@ -92,7 +93,7 @@ jobs:
               head="${{ github.event.pull_request.head.sha }}" ;;
             merge_group)
               base="${{ github.event.merge_group.base_sha }}"
-              head="${{ github.event.merge_group.head_sha }}" ;;
+              head="${GITHUB_EVENT_MERGE_GROUP_HEAD_SHA}" ;;
             push)
               base="${{ github.event.before }}"
               head="${{ github.sha }}" ;;
@@ -122,6 +123,8 @@ jobs:
             echo "relevant=false" >> "$GITHUB_OUTPUT"
             echo "No container-relevant path changed — skipping build, reporting SUCCESS."
           fi
+        env:
+          GITHUB_EVENT_MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
 
       - name: Set up Docker Buildx
         if: steps.relevant.outputs.relevant == 'true'

--- a/.github/workflows/evidentia.yml
+++ b/.github/workflows/evidentia.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:

--- a/.github/workflows/mutmut.yml
+++ b/.github/workflows/mutmut.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,11 +58,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          enable-cache: true
+          enable-cache: false
           python-version: "3.12"
 
       - name: Install docs toolchain

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -44,13 +44,16 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="${GITHUB_EVENT_INPUTS_VERSION}"
           else
-            REF="${{ github.event.release.tag_name }}"   # e.g. v0.10.13
+            REF="${GITHUB_EVENT_RELEASE_TAG_NAME}"   # e.g. v0.10.13
             VERSION="${REF#v}"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Smoke-testing evidentia==${VERSION}"
+        env:
+          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -116,11 +119,14 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="v${{ github.event.inputs.version }}"
+            TAG="v${GITHUB_EVENT_INPUTS_VERSION}"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="${GITHUB_EVENT_RELEASE_TAG_NAME}"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "latest"
-          enable-cache: true
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -127,12 +129,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "latest"
-          enable-cache: true
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -144,8 +148,9 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: packages/evidentia-ui/package-lock.json
+          # No npm cache in the release build (zizmor cache-poisoning hardening):
+          # a poisoned cache could taint the released wheel's bundled SPA. The
+          # release runs rarely, so the cache speedup isn't worth the risk.
 
       - name: Sync workspace
         run: uv sync --all-packages
@@ -153,7 +158,7 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          REF="${{ github.ref_name }}"
+          REF="${GITHUB_REF_NAME}"
           echo "tag=${REF}" >> "$GITHUB_OUTPUT"
           echo "semver=${REF#v}" >> "$GITHUB_OUTPUT"
 
@@ -309,8 +314,10 @@ jobs:
         run: |
           out=$(docker run --rm evidentia:rc version)
           echo "$out"
-          echo "$out" | grep -q "${{ steps.version.outputs.semver }}" \
-            || { echo "::error::image version does not match ${{ steps.version.outputs.semver }}"; exit 1; }
+          echo "$out" | grep -q "${STEPS_VERSION_OUTPUTS_SEMVER}" \
+            || { echo "::error::image version does not match ${STEPS_VERSION_OUTPUTS_SEMVER}"; exit 1; }
+        env:
+          STEPS_VERSION_OUTPUTS_SEMVER: ${{ steps.version.outputs.semver }}
 
       - name: Smoke test — `evidentia catalog list`
         run: docker run --rm evidentia:rc catalog list | head -10
@@ -402,7 +409,9 @@ jobs:
       # Hand the provenance bundle to publish-container (which creates the
       # Release) under a stable, recognizable filename.
       - name: Stage + upload SLSA provenance bundle
-        run: cp "${{ steps.provenance.outputs.bundle-path }}" evidentia.intoto.jsonl
+        run: cp "${STEPS_PROVENANCE_OUTPUTS_BUNDLE_PATH}" evidentia.intoto.jsonl
+        env:
+          STEPS_PROVENANCE_OUTPUTS_BUNDLE_PATH: ${{ steps.provenance.outputs.bundle-path }}
 
       - name: Upload release-provenance
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -446,11 +455,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version
         run: |
-          REF="${{ github.ref_name }}"
+          REF="${GITHUB_REF_NAME}"
           echo "tag=${REF}" >> "$GITHUB_OUTPUT"
           echo "semver=${REF#v}" >> "$GITHUB_OUTPUT"
 
@@ -493,7 +504,7 @@ jobs:
         id: push
         run: |
           REPO=ghcr.io/polycentric-labs/evidentia
-          TAG="${{ steps.version.outputs.tag }}"
+          TAG="${STEPS_VERSION_OUTPUTS_TAG}"
           docker tag evidentia:rc "${REPO}:${TAG}"
           docker tag evidentia:rc "${REPO}:latest"
           docker push "${REPO}:${TAG}"
@@ -501,6 +512,8 @@ jobs:
           DIGEST=$(docker buildx imagetools inspect "${REPO}:${TAG}" --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "Pushed ${REPO}:${TAG} + :latest @ ${DIGEST}"
+        env:
+          STEPS_VERSION_OUTPUTS_TAG: ${{ steps.version.outputs.tag }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
@@ -510,9 +523,10 @@ jobs:
       - name: Sign image with cosign (keyless OIDC)
         env:
           COSIGN_YES: "true"
+          STEPS_PUSH_OUTPUTS_DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           cosign sign --yes \
-            ghcr.io/polycentric-labs/evidentia@${{ steps.push.outputs.digest }}
+            ghcr.io/polycentric-labs/evidentia@${STEPS_PUSH_OUTPUTS_DIGEST}
 
       - name: Generate SLSA build provenance attestation for image
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
@@ -527,7 +541,7 @@ jobs:
       # (no append_body, no double-stanza-on-rerun).
       - name: Assemble Release body
         run: |
-          version="${{ steps.version.outputs.semver }}"
+          version="${STEPS_VERSION_OUTPUTS_SEMVER}"
           python scripts/extract_changelog_block.py "$version" > release-body.md
           body_size=$(wc -c < release-body.md)
           echo "CHANGELOG block: $body_size bytes"
@@ -568,9 +582,13 @@ jobs:
           # kept the backticks + cert-identity regex literal, and the YAML
           # literal block already stripped the base indent so the stanza is
           # flush-left.
-          sed -i "s|__TAG__|${{ steps.version.outputs.tag }}|g; s|__DIGEST__|${{ steps.push.outputs.digest }}|g" release-body.md
+          sed -i "s|__TAG__|${STEPS_VERSION_OUTPUTS_TAG}|g; s|__DIGEST__|${STEPS_PUSH_OUTPUTS_DIGEST}|g" release-body.md
           echo "---- assembled release-body.md ----"
           cat release-body.md
+        env:
+          STEPS_VERSION_OUTPUTS_SEMVER: ${{ steps.version.outputs.semver }}
+          STEPS_VERSION_OUTPUTS_TAG: ${{ steps.version.outputs.tag }}
+          STEPS_PUSH_OUTPUTS_DIGEST: ${{ steps.push.outputs.digest }}
 
       - name: Create the GitHub Release (wheels + container, full body)
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,8 +307,12 @@ jobs:
             INSTALL_SOURCE=local
           provenance: false
           sbom: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No type=gha build cache in the release pipeline: the shared Actions
+          # cache can be written by a PR-triggered run on a branch, so reading
+          # layers from it in an artifact-producing build is a cache-poisoning
+          # vector. Matches the disabled uv/npm caches above — a release builds
+          # from scratch. (Releases are tag-driven + infrequent; the lost layer
+          # cache costs a few minutes, not correctness.)
 
       - name: Smoke test — `evidentia version`
         run: |

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           # Full history so `gitleaks git` scans every commit, not just the tip.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install gitleaks (pinned binary, SHA256-verified)
         run: |

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -69,6 +69,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -76,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -144,6 +148,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -168,6 +174,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -189,6 +197,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -232,6 +242,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -274,6 +286,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -329,6 +343,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -51,6 +51,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -70,7 +72,7 @@ jobs:
 
       - name: Verify CHANGELOG block presence + size
         run: |
-          version="${{ steps.workspace-version.outputs.version }}"
+          version="${STEPS_WORKSPACE_VERSION_OUTPUTS_VERSION}"
           if ! python scripts/extract_changelog_block.py "$version" \
               > extracted-body.md 2>/tmp/extract-err.txt; then
             echo "::error::extract_changelog_block.py failed for [$version]"
@@ -106,3 +108,5 @@ jobs:
             exit 1
           fi
           echo "::notice::CHANGELOG block for [$version] looks healthy ($body_size bytes)."
+        env:
+          STEPS_WORKSPACE_VERSION_OUTPUTS_VERSION: ${{ steps.workspace-version.outputs.version }}

--- a/.github/workflows/verify-osps-conformance.yml
+++ b/.github/workflows/verify-osps-conformance.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0

--- a/.github/workflows/verify-workflow-perms.yml
+++ b/.github/workflows/verify-workflow-perms.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,50 @@
+# Static analysis of the GitHub Actions workflows themselves (zizmor, by Trail
+# of Bits). Mechanically enforces the invariants the workflows were maintaining
+# by hand: full-SHA action pins, least-privilege permissions, no template
+# injection, no cache poisoning, no credential persistence (artipacked). Runs on
+# every PR + the merge queue so a regressing workflow edit is caught BEFORE it
+# lands. Findings are listed in the job log; the run goes RED on any finding not
+# justified in .github/zizmor.yml.
+
+name: zizmor
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel only on PR iteration; push:[main] + merge_group run to a green
+  # conclusion (matches the other required-check workflows — green-checks MUST).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  zizmor:
+    name: zizmor (Actions static analysis)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          version: "latest"
+
+      # Pinned zizmor release; --persona regular = minimal false positives;
+      # --offline runs the deterministic local audits (template-injection,
+      # cache-poisoning, artipacked, permissions, pinning) with no token needed
+      # and auto-discovers .github/zizmor.yml (the two justified ignores). A
+      # non-zero exit on any unjustified finding fails the job. (Online audits
+      # — impostor-commit / ref-confusion — can be added later with a token.)
+      - name: Audit workflows with zizmor (pinned 1.26.1, offline)
+        run: uvx zizmor@1.26.1 --persona regular --offline .github/workflows/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,7 +1,8 @@
 # Static analysis of the GitHub Actions workflows themselves (zizmor, by Trail
 # of Bits). Mechanically enforces the invariants the workflows were maintaining
-# by hand: full-SHA action pins, least-privilege permissions, no template
-# injection, no cache poisoning, no credential persistence (artipacked). Runs on
+# by hand: full-SHA action pins (resolving to the right commit, not a moved tag
+# or stale version comment), least-privilege permissions, no template injection,
+# no cache poisoning, no credential persistence (artipacked). Runs on
 # every PR + the merge queue so a regressing workflow edit is caught BEFORE it
 # lands. Findings are listed in the job log; the run goes RED on any finding not
 # justified in .github/zizmor.yml.
@@ -35,16 +36,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      # Official SHA-pinned zizmor runner. Runs the ONLINE audits by default
+      # (impostor-commit, ref-confusion, ref-version-mismatch) using the job's
+      # read-only github.token — these catch SHA-pin tampering and stale/forged
+      # version comments that the offline-only audits cannot see. zizmor itself
+      # is version-pinned (1.26.1); --persona regular keeps false positives low;
+      # config carries the two justified ignores. advanced-security:false prints
+      # findings to the log and fails the job on any unjustified finding (no
+      # SARIF upload, so the contents:read permission above stays sufficient).
+      - name: Audit workflows with zizmor (online, SHA-pinned action)
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa  # v0.5.7
         with:
-          version: "latest"
-
-      # Pinned zizmor release; --persona regular = minimal false positives;
-      # --offline runs the deterministic local audits (template-injection,
-      # cache-poisoning, artipacked, permissions, pinning) with no token needed
-      # and auto-discovers .github/zizmor.yml (the two justified ignores). A
-      # non-zero exit on any unjustified finding fails the job. (Online audits
-      # — impostor-commit / ref-confusion — can be added later with a token.)
-      - name: Audit workflows with zizmor (pinned 1.26.1, offline)
-        run: uvx zizmor@1.26.1 --persona regular --offline .github/workflows/
+          inputs: .github/workflows/
+          version: "1.26.1"
+          persona: regular
+          config: .github/zizmor.yml
+          advanced-security: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,4 +19,7 @@ rules:
       # the SBOM + SLSA provenance bundle. Reimplementing via `gh release create`
       # in a script step would duplicate that logic for no security gain — the
       # action is already pinned by full commit SHA. Informational only.
-      - release.yml:594
+      # (Line tracks the action-gh-release `uses:`; the zizmor gate itself
+      # flags this ignore if a release.yml edit shifts the line, so it stays
+      # in sync — re-point it to the new line when that happens.)
+      - release.yml:598

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,22 @@
+# zizmor (Trail-of-Bits GitHub Actions static analysis) configuration.
+# https://docs.zizmor.sh/configuration/
+#
+# Every workflow finding must pass EXCEPT the two justified exceptions below.
+# Both are documented; neither hides an actual vulnerability.
+rules:
+  cache-poisoning:
+    ignore:
+      # release.yml "Set up Node": the npm cache is explicitly DISABLED (the
+      # step has no `cache:` key — see its inline comment), so there is no
+      # cache-poisoning vector. zizmor's Low-confidence heuristic flags the
+      # action's mere presence in a release-publishing workflow; the actual
+      # cache is off (as are the setup-uv caches, set enable-cache: false).
+      - release.yml:148
+  superfluous-actions:
+    ignore:
+      # release.yml "Create the GitHub Release": softprops/action-gh-release is
+      # intentionally used (SHA-pinned) to assemble the release body and attach
+      # the SBOM + SLSA provenance bundle. Reimplementing via `gh release create`
+      # in a script step would duplicate that logic for no security gain — the
+      # action is already pinned by full commit SHA. Informational only.
+      - release.yml:594


### PR DESCRIPTION
## What

Adds **zizmor** (Trail of Bits GitHub Actions static analysis) as a CI gate and remediates every finding it reports across the existing workflows. The gate runs on every PR + the merge queue, so a regressing workflow edit is caught before it lands.

## How

- New `.github/workflows/zizmor.yml`: runs the SHA-pinned `zizmorcore/zizmor-action@v0.5.7` **online** (using the job's read-only `github.token`) so the impostor-commit / ref-confusion / ref-version-mismatch audits run, not just the offline set. zizmor itself is version-pinned at 1.26.1; `advanced-security: false` keeps the job at `contents: read`.
- New `.github/zizmor.yml`: two justified, documented ignores (a setup-node cache that is explicitly disabled; an intentionally-used SHA-pinned `action-gh-release`).
- Remediations across the workflows: every `${{ … }}` moved out of `run:` blocks into `env:` (template-injection); `persist-credentials: false` on all checkouts (artipacked); the release pipeline's uv/npm **and** docker `type=gha` build caches disabled (cache-poisoning in an artifact-producing build).
- `codeql.yml`: the codeql-action is pinned to the **commit** for v3.35.3, not the annotated-tag object (the online ref-version-mismatch audit caught the tag-object pin).

## Verification

`zizmor --persona regular` online over `.github/workflows/`: **no findings** (2 justified ignores, 51 SHA-pin suppressions). `actionlint` clean; `audit_workflow_permissions.py --strict` PASS.
