### PR TITLE
Fix(supply-chain): Floor joserfc >=1.6.7 to clear CVE-2026-48990 (day-N)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,21 @@ version = "0.10.13"
 requires-python = ">=3.12"
 description = "Workspace root for the Evidentia GRC tool monorepo"
 
+[tool.uv]
+# Security version-floor for a TRANSITIVE dependency — the transitive analog of the
+# direct-dep CVE floors in packages/*/pyproject.toml (e.g. litellm>=1.83.7, the
+# evidentia-api >=0.0.26 floor). joserfc reaches the workspace ONLY via moto[all]
+# (the AWS-mock test library, dev group); it is not imported in any src/ and is in no
+# shipped wheel or the container image. constraint-dependencies are resolution/lock
+# ONLY — they do NOT propagate into published wheel/sdist metadata, and a constraint
+# never *adds* a package (it is inert if moto ever stops pulling joserfc). This floors
+# joserfc out of GHSA-wphv-vfrh-23q5 / CVE-2026-48990 (affects >=1.3.4,<1.6.7; Medium
+# 5.3, b64=false RFC7797 JWS payload-size bypass; published 2026-06-26). Fail-closed: a
+# future re-lock that would select joserfc<1.6.7 errors out instead of silently
+# regressing. REMOVAL TRIGGER: moto raises its own joserfc floor to >=1.6.7 (it
+# currently caps only >=0.9.0), or the advisory is withdrawn. Re-validate by 2026-12-26.
+constraint-dependencies = ["joserfc>=1.6.7"]
+
 [tool.uv.workspace]
 members = [
     "packages/evidentia-core",

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
     "evidentia-mcp",
     "evidentia-workspace",
 ]
+constraints = [{ name = "joserfc", specifier = ">=1.6.7" }]
 
 [[package]]
 name = "aenum"
@@ -2154,14 +2155,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.4"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Day-N CVE response

GHSA-wphv-vfrh-23q5 / **CVE-2026-48990** (Medium 5.3 — b64=false RFC7797 JWS payload-size bypass in joserfc deserialization) was published **2026-06-26 20:59 UTC**, after main's last green run, turning the `osv-scanner (SBOM)` gate red **repo-wide** (every open PR + main's next run).

## Scope

joserfc reaches the workspace **only** as a dev/test-only transitive dependency via `moto[all]` (the AWS-mock test library). It is **not imported in any `src/`** and is in **no shipped wheel or the container image** — no production reachability, no shipped-artifact change (so no release/tag).

## Fix

- `uv lock --upgrade-package joserfc` → **1.7.1** (outside all three known joserfc advisory ranges).
- `[tool.uv] constraint-dependencies = ["joserfc>=1.6.7"]` — a documented security floor, the transitive analog of the direct-dep CVE floors already in `packages/*/pyproject.toml` (e.g. `litellm>=1.83.7`, the `evidentia-api >=0.0.26` floor). uv constraints are **resolution-only** (they do not propagate into published wheel/sdist metadata) and **fail-closed** against a future re-lock that would reselect a vulnerable joserfc.

## Verification

- `osv-scanner` SSOT gate: **PASS** (joserfc cleared; the 2 prior allowlist entries unchanged).
- `uv audit`: down to the 2 accepted/allowlisted advisories (torch no-fix-exists, cryptography upgrade-blocked).
- moto/AWS test suite (43 tests): **green** against joserfc 1.7.1.
- Change scope: only `pyproject.toml` + `uv.lock` (a single package moved in the lock).
