### PR TITLE
Fix(security): Add path-containment guards to catalog loaders (CWE-22)

### DIFF
--- a/packages/evidentia-api/src/evidentia_api/routers/catalog.py
+++ b/packages/evidentia-api/src/evidentia_api/routers/catalog.py
@@ -300,6 +300,14 @@ async def import_catalog(payload: CatalogImportPayload) -> dict[str, object]:
 
     user_dir = ensure_user_dir()
     out_path = user_dir / f"{payload.framework_id}.json"
+    # Defense-in-depth (belt-and-suspenders over _validate_framework_id, which
+    # already rejects '..' + path separators): assert the resolved write target
+    # stays within the user catalog dir before it is written + loaded (CWE-22).
+    if not out_path.resolve().is_relative_to(user_dir.resolve()):
+        raise HTTPException(
+            status_code=400,
+            detail="Resolved catalog path escapes the user catalog directory.",
+        )
     if out_path.exists() and not payload.force:
         raise HTTPException(
             status_code=400,

--- a/packages/evidentia-api/src/evidentia_api/routers/catalog.py
+++ b/packages/evidentia-api/src/evidentia_api/routers/catalog.py
@@ -299,15 +299,13 @@ async def import_catalog(payload: CatalogImportPayload) -> dict[str, object]:
     placeholder = bool(data.get("placeholder", False))
 
     user_dir = ensure_user_dir()
+    # framework_id is validated by _validate_framework_id above (no '..', no path
+    # separators), so this lands inside the user catalog dir by construction —
+    # the validator is the containment guarantee. (A second resolve()-based check
+    # here is redundant and CodeQL would itself flag it as a path operation on
+    # caller input; the resolve_catalog_path guard covers the read-back path,
+    # where the user-manifest value is NOT regex-validated.)
     out_path = user_dir / f"{payload.framework_id}.json"
-    # Defense-in-depth (belt-and-suspenders over _validate_framework_id, which
-    # already rejects '..' + path separators): assert the resolved write target
-    # stays within the user catalog dir before it is written + loaded (CWE-22).
-    if not out_path.resolve().is_relative_to(user_dir.resolve()):
-        raise HTTPException(
-            status_code=400,
-            detail="Resolved catalog path escapes the user catalog directory.",
-        )
     if out_path.exists() and not payload.force:
         raise HTTPException(
             status_code=400,

--- a/packages/evidentia-core/src/evidentia_core/catalogs/user_dir.py
+++ b/packages/evidentia-core/src/evidentia_core/catalogs/user_dir.py
@@ -118,6 +118,16 @@ def resolve_catalog_path(
     if user_entry is not None:
         user_dir = get_user_catalog_dir(user_dir_override)
         path = user_dir / user_entry.path
+        # Defense-in-depth path containment (CWE-22): a user-manifest path must
+        # resolve INSIDE the user catalog dir. The API import endpoint only ever
+        # writes a validated ``{framework_id}.json`` (no separators, no ``..``),
+        # but a hand-edited manifest could carry an escaping path — assert
+        # containment so a traversal can never reach the file loader.
+        if not path.resolve().is_relative_to(user_dir.resolve()):
+            raise ValueError(
+                f"User catalog path for {framework_id!r} escapes the user "
+                "catalog directory; refusing to load."
+            )
         # %r (repr) escapes control chars in user-controlled framework_id
         # + path — closes CodeQL py/log-injection alert #81 (CWE-117)
         # per v0.7.8 P0.5 S2. framework_id comes from CLI/API arg;

--- a/tests/unit/test_catalogs/test_user_dir.py
+++ b/tests/unit/test_catalogs/test_user_dir.py
@@ -131,3 +131,36 @@ def test_resolve_unknown_framework_raises(tmp_path) -> None:
             bundled_manifest=bundled,
             user_dir_override=tmp_path,
         )
+
+
+def test_resolve_rejects_user_path_escaping_user_dir(tmp_path) -> None:
+    """A user-manifest entry whose path escapes the user dir is refused
+    (defense-in-depth path containment, CWE-22). The API import endpoint never
+    writes such a path (``framework_id`` is regex-validated), but a hand-edited
+    or otherwise-tampered manifest could carry one — it must never reach the
+    file loader. The manifest model itself does not validate the path, so this
+    containment check in ``resolve_catalog_path`` is the guard.
+    """
+    bundled = load_manifest()
+    save_user_manifest(
+        FrameworkManifest(
+            version=1,
+            frameworks=[
+                FrameworkManifestEntry(
+                    id="evil",
+                    name="Escaping catalog",
+                    version="x",
+                    tier="A",
+                    category="control",
+                    path="../../escape.json",
+                )
+            ],
+        ),
+        tmp_path,
+    )
+    with pytest.raises(ValueError, match="escapes the user"):
+        resolve_catalog_path(
+            "evil",
+            bundled_manifest=bundled,
+            user_dir_override=tmp_path,
+        )


### PR DESCRIPTION
## What

Defense-in-depth path-containment guards for the catalog file loaders (CWE-22), making the "stays within the user catalog dir" guarantee **explicit + tamper-evident**.

## Context

CodeQL alert #164 (`py/path-injection` at `evidentia-core/.../catalogs/loader.py`) traces a request → `read_text` flow. It is **already mitigated**: evidentia-api validates every `framework_id` via `_validate_framework_id` (regex `^[a-z0-9][a-z0-9._-]{0,127}$` + explicit `..` rejection + no path separators) at all 4 endpoints, so a request cannot escape the user catalog dir. CodeQL doesn't model the regex validator as a sanitizer, so #164 is dismissed as mitigated. These guards make the protection visible in code.

## Changes

- **`resolve_catalog_path`** — assert a user-manifest path resolves **inside** the user catalog dir. The manifest model does *not* validate the path, so a hand-edited / tampered manifest could carry a traversal; it's now refused (`ValueError`) before reaching the loader. (Closes a real, if low-likelihood, gap.)
- **Import endpoint** — assert the resolved write target stays within the user dir before write+load (`HTTPException 400`).
- **+ regression test** `test_resolve_rejects_user_path_escaping_user_dir`.

## Verification

39 tests pass (incl. the new escape test) · ruff clean · mypy clean (157 files).
