### PR TITLE
Docs(practices): Fold the dev-best-practices doctrine into engineering-practices.md

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2030,6 +2030,29 @@ detailed integration plan" §v0.11. Substantive minor (~6-8 weeks):
   post-operator-deep-dive (incorporate AWS OSCAL MCP / Vanta MCP /
   ComplianceCow MCP / Snyk AI Trust Platform shifts).
 
+### Engineering & security follow-ups — PLANNED (not feature-tied)
+
+Hardening items the continuous-assurance gates surfaced about themselves, tracked
+here so they aren't lost between feature cycles (see
+[`docs/engineering-practices.md`](engineering-practices.md)):
+
+- **Extend the CodeQL custom sanitizer model to recognize `_validate_framework_id`.**
+  The catalog router validates every `framework_id` (regex + `..`/separator
+  rejection) before deriving an on-disk path, but the sanitizer model doesn't yet
+  model that helper, so `py/path-injection` flagged the catalog loader (alert #164
+  — dismissed as mitigated 2026-06-27, with a runtime
+  `resolve()`/`is_relative_to(user_dir)` containment guard added as defense-in-
+  depth). Teaching the model the validator clears that finding class at the query
+  level — restoring the "report real findings, not known-safe ones" property.
+- **Enable code-scanning merge protection** so a *new* High/Critical code-scanning
+  alert blocks the PR. The CodeQL `Analyze` jobs are required, but they gate on the
+  analysis *running*, not on introduced findings; the "Code scanning results" gate
+  is the piece that blocks a newly-introduced alert.
+- **Dependabot patch auto-merge** (`dependabot/fetch-metadata` + `gh pr merge
+  --auto`, patch-only, after the full required-check suite is green; majors +
+  security PRs stay human-reviewed). Validate once on a harmless Dependabot PR and
+  confirm the workflow itself passes the now-required zizmor gate before enabling.
+
 ### Medical-device GRC feature line (v0.11 → v1.1+) — PLANNED (web-grounded research 2026-06-17)
 
 The medical-device-security direction the v0.10.10 FDA Section 524B catalogs opened, scanned + validated in a multi-angle web-grounded research pass. **Each feature gets a dedicated `polycentric-labcoat` research fleet at build-time** — the entries below are the high-level scan + positioning, not build specs. Effort and tier are planning-grade. The throughline: **don't rebuild commodity layers (STRIDE authoring, CBOM scanners) — ingest them; the uncontested slice is the open, signed, OSCAL/BOM-emitting evidence wrapper.**

--- a/docs/engineering-practices.md
+++ b/docs/engineering-practices.md
@@ -25,6 +25,10 @@ Three principles run through all of it:
 - **Verify, don't assert.** Documented commands and factual claims are executed
   against the live tool, not trusted because they were true once.
 
+This document is the **single home** for Evidentia's engineering + security
+practices: a new safeguard, finding-handling rule, or dependency policy extends
+the relevant section below rather than starting a parallel document.
+
 ---
 
 ## The development & release flow
@@ -86,6 +90,14 @@ Evidentia's releases are designed to be independently verifiable end to end:
   closure — including the container's independently-resolved closure — on every
   pull request, surfacing transitive and disputed advisories the standard alert
   feed suppresses.
+- **Dependency updates are automated with guardrails.** Dependabot proposes
+  weekly, grouped, cooldown-delayed version updates (a freshly-published release
+  is held a few days, so a yanked or hot-fixed bad release is superseded before it
+  is proposed); breaking-prone framework packages are isolated into their own
+  reviewable PR; per-ecosystem open-PR caps bound the queue; and security
+  advisories are never grouped — each rides its own PR. Majors and security
+  updates always get human review: CI verifies correctness, not the *intent* of a
+  possibly-poisoned dependency.
 
 These are also the signals OpenSSF Scorecard scores, which the project tracks
 publicly.
@@ -98,8 +110,20 @@ publicly.
   relevant pull request and on a scheduled batch, exercising the parsing and
   catalog-loading surfaces with coverage-guided inputs.
 - **Static analysis.** CodeQL runs in an advanced configuration with a custom
-  sanitizer model, so the path-traversal queries understand the project's own
-  validation helpers and report real findings rather than known-safe ones.
+  sanitizer model that teaches the path-traversal queries about the project's
+  validation helpers, so they report real findings rather than known-safe ones.
+  (The model is extended as new validators land — see the roadmap's engineering
+  follow-ups.) **zizmor** statically audits the workflows themselves — full-commit-
+  SHA action pins that resolve to the right commit, least-privilege permissions,
+  no template injection, no cache poisoning, no credential persistence — online,
+  on every PR and the merge queue, as a required check.
+- **Findings are handled, not accumulated.** Every security gate that *runs* is a
+  *required* check — no advisory-only scanners left to rot. A code-scanning
+  finding is either fixed in the PR or dismissed with a written, primary-source-
+  grounded reason; systemic false positives are encoded in committed config (a
+  CodeQL query filter or sanitizer-model entry), never one-off clicks. High alerts
+  carry a tight triage SLA toward a zero-open-High goal, and open code-scanning +
+  Dependabot alerts are reviewed before a change is called done.
 - **Secret scanning.** A pinned gitleaks binary scans the full history on every
   push and pull request, complementing a local pre-push secret scan.
 - **Defensive guards in the code itself.** Network-egress paths enforce a


### PR DESCRIPTION
## What

Fold the dev-best-practices doctrine (from the 2026-06-27 labcoat pass on auto-handling security findings) into the **existing** `docs/engineering-practices.md` rather than creating a parallel `docs/dev-best-practices.md`.

## Why not a new doc

`engineering-practices.md` already owns "Continuous security assurance" + "Supply-chain integrity"; a second doc would duplicate them and drift — the exact failure the doc's own "one definition, no drift" discipline warns against. So Evidentia's narrative extends the one canonical doc; the portable, cross-project rules live in the `polycentric-labsmith` skill seed.

## Changes

- **engineering-practices.md** — declares itself the single home for engineering/security practices; adds the **finding-handling discipline** (every gate that *runs* is *required*; the new zizmor required gate; fix-or-dismiss-with-reason; systemic false-positives → committed config; SLA + before-done alert review) and the **Dependabot guardrails** (grouped / cooldown / framework-isolation; security PRs never grouped; majors + security human-reviewed).
- **ROADMAP.md** — queues 3 engineering follow-ups the assurance gates surfaced: extend the CodeQL sanitizer model for `_validate_framework_id` (clears the #164 finding class at the query level), enable code-scanning merge protection, and Dependabot patch auto-merge.

## Verification

`check_docs_health.py --strict`: **0 FAIL**.
