### PR TITLE
Security(codeql): Model resolve_catalog_path + framework-id path sanitizers

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,9 +2,18 @@
 #
 # Loads the security-extended query suite (matching what default
 # setup runs) PLUS our custom python-sanitizers pack which declares
-# `evidentia_core.security.paths.validate_within` as a sanitizer
-# for the `py/path-injection` query. The custom pack closes the
-# 3 false-positive HIGH alerts (#71/#72/#73) at the analysis layer.
+# path-injection sanitizers at the analysis layer:
+#   - `evidentia_core.security.paths.validate_within`
+#     (ValidateWithinSanitizer) — closes the false-positive HIGH
+#     alerts #71/#72/#73.
+#   - `evidentia_core.catalogs.user_dir.resolve_catalog_path`
+#     (ResolveCatalogPathSanitizer) — closes alert #164 (the catalog
+#     loader read_text), whose path is the containment-checked /
+#     trusted-manifest value this helper returns.
+#   - `evidentia_api.routers.catalog._validate_framework_id`
+#     (FrameworkIdSanitizer) — the catalog-router id validator.
+# Encoding these in committed config (not per-instance dismissals) is
+# the "systemic false positives go in config" rule.
 #
 # To verify the sanitizer is firing, look at the CodeQL job logs
 # after a push: the `Analyze` step should show the python-sanitizers

--- a/.github/codeql/python-sanitizers/FrameworkIdSanitizer.qll
+++ b/.github/codeql/python-sanitizers/FrameworkIdSanitizer.qll
@@ -1,0 +1,52 @@
+/**
+ * Custom sanitizer for `evidentia_api.routers.catalog._validate_framework_id`.
+ *
+ * `_validate_framework_id(framework_id)` rejects any id that is not a kebab-case
+ * token matching `^[a-z0-9][a-z0-9._-]{0,127}$` and contains no `..`, then
+ * RETURNS the validated id. Callers reassign
+ * (`framework_id = _validate_framework_id(framework_id)`), so the validated
+ * value — not the raw request value — flows into the
+ * `user_dir / f"{framework_id}.json"` write path. A returned-value validator is
+ * a sanitizing transform CodeQL can model, mirroring
+ * `validate_within` / `ValidateWithinSanitizer`.
+ *
+ * Modeling note (honest): `_validate_framework_id` is module-private and is
+ * called intra-module (within `catalog.py`), so for those callsites CodeQL's
+ * *intra-procedural* analysis is what recognizes the barrier — it reads the
+ * regex + `..` rejection directly on the value the function returns. This API-
+ * graph entry additionally models any *cross-module* use (e.g. a test importing
+ * the helper) and documents the contract in committed config (the
+ * "encode systemic false positives in config, never one-off clicks" rule).
+ * The companion `ResolveCatalogPathSanitizer` covers the read-back / loader
+ * path (alert #164), where the value comes from the user manifest.
+ *
+ * v0.10.x engineering follow-up.
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.PathInjectionCustomizations
+import semmle.python.ApiGraphs
+
+/**
+ * The data-flow node for a call to
+ * `evidentia_api.routers.catalog._validate_framework_id(...)`.
+ */
+private DataFlow::Node validateFrameworkIdCall() {
+  result =
+    API::moduleImport("evidentia_api")
+        .getMember("routers")
+        .getMember("catalog")
+        .getMember("_validate_framework_id")
+        .getACall()
+}
+
+/**
+ * Sanitizer for `py/path-injection`: the value returned by
+ * `_validate_framework_id` is a shape-validated framework id that cannot
+ * contain path separators or `..`.
+ */
+class FrameworkIdSanitizer extends PathInjection::Sanitizer {
+  FrameworkIdSanitizer() { this = validateFrameworkIdCall() }
+}

--- a/.github/codeql/python-sanitizers/ResolveCatalogPathSanitizer.qll
+++ b/.github/codeql/python-sanitizers/ResolveCatalogPathSanitizer.qll
@@ -1,0 +1,52 @@
+/**
+ * Custom sanitizer for `evidentia_core.catalogs.user_dir.resolve_catalog_path`.
+ *
+ * `resolve_catalog_path(framework_id, ...)` maps a framework id to an on-disk
+ * catalog path and returns `(path, entry, source)`. For the user-dir branch it
+ * resolves the candidate and asserts `resolved.is_relative_to(user_dir)` (a
+ * CWE-22 containment guard) before returning the RESOLVED path; the bundled
+ * branch returns a path derived from the trusted package manifest. The
+ * framework id is only ever used as a dict KEY for the manifest lookup, never
+ * concatenated raw into the returned path. The returned path is therefore
+ * already containment-checked / trusted, so any flow OUT of this call is safe
+ * for `py/path-injection`.
+ *
+ * This is the query-level fix for alert #164 (`py/path-injection` at
+ * `evidentia_core/catalogs/loader.py` `_load_catalog_data` → `read_text`): the
+ * loader's path comes from `resolve_catalog_path` via
+ * `load_catalog` / `load_any_catalog`, so modeling this call's return as a
+ * barrier clears that finding at the analysis layer rather than by per-instance
+ * dismissal. It composes with the runtime change that now RETURNS the
+ * `is_relative_to`-checked `resolved` path (so CodeQL's built-in guard
+ * recognition also sees the barrier).
+ *
+ * Mirrors `ValidateWithinSanitizer.qll`. v0.10.x engineering follow-up.
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.security.dataflow.PathInjectionCustomizations
+import semmle.python.ApiGraphs
+
+/**
+ * The data-flow node for a call to
+ * `evidentia_core.catalogs.user_dir.resolve_catalog_path(...)`. Resolved across
+ * modules via the API graph (the loader + the API/CLI routers all import it).
+ */
+private DataFlow::Node resolveCatalogPathCall() {
+  result =
+    API::moduleImport("evidentia_core")
+        .getMember("catalogs")
+        .getMember("user_dir")
+        .getMember("resolve_catalog_path")
+        .getACall()
+}
+
+/**
+ * Sanitizer for `py/path-injection`: the value returned by
+ * `resolve_catalog_path` is a containment-checked / trusted-manifest path.
+ */
+class ResolveCatalogPathSanitizer extends PathInjection::Sanitizer {
+  ResolveCatalogPathSanitizer() { this = resolveCatalogPathCall() }
+}

--- a/.github/codeql/python-sanitizers/qlpack.yml
+++ b/.github/codeql/python-sanitizers/qlpack.yml
@@ -13,7 +13,7 @@
 # - https://github.com/github/codeql/blob/main/python/ql/lib/semmle/python/security/dataflow/PathInjectionCustomizations.qll
 
 name: polycentric-labs/evidentia-python-sanitizers
-version: 0.0.2
+version: 0.0.3
 library: true
 
 dependencies:

--- a/packages/evidentia-api/src/evidentia_api/routers/catalog.py
+++ b/packages/evidentia-api/src/evidentia_api/routers/catalog.py
@@ -76,12 +76,20 @@ _log = get_logger("evidentia.api.catalog")
 _FRAMEWORK_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 
 
-def _validate_framework_id(framework_id: str) -> None:
-    """Reject framework IDs whose shape could enable path traversal.
+def _validate_framework_id(framework_id: str) -> str:
+    """Validate a framework ID's shape and RETURN the validated value.
 
     Raises ``HTTPException(400)`` on an invalid shape. Bundled +
     user-imported IDs are all kebab-case (e.g. ``nist-csf-2.0``), so a
     well-formed ID always matches; only crafted inputs fail here.
+
+    Returns the (unchanged) ``framework_id`` so callers reassign it
+    (``framework_id = _validate_framework_id(framework_id)``): a validator
+    that *returns* its sanitized value is a sanitizing transform CodeQL can
+    model (see ``FrameworkIdSanitizer`` in the custom QL pack), mirroring
+    ``evidentia_core.security.paths.validate_within``. Functionally this is a
+    pass-through on success; the value-returning shape is purely so the
+    ``py/path-injection`` query sees the validation barrier.
     """
     if ".." in framework_id or not _FRAMEWORK_ID_RE.match(framework_id):
         raise HTTPException(
@@ -92,6 +100,7 @@ def _validate_framework_id(framework_id: str) -> None:
                 f"{_FRAMEWORK_ID_RE.pattern} (no path separators)."
             ),
         )
+    return framework_id
 
 
 # ── crosswalk (read) ───────────────────────────────────────────────
@@ -133,7 +142,7 @@ async def where_framework(
     Mirrors ``evidentia catalog where``. The user catalog dir is the one
     the ``EVIDENTIA_CATALOG_DIR`` env var (or platform default) points at.
     """
-    _validate_framework_id(framework_id)
+    framework_id = _validate_framework_id(framework_id)
     bundled = load_manifest()
     user = load_user_manifest()
     try:
@@ -171,7 +180,7 @@ async def license_info(framework_id: str) -> dict[str, object]:
     Mirrors ``evidentia catalog license-info``: user-imported entries
     take precedence over bundled, then 404 if neither knows the ID.
     """
-    _validate_framework_id(framework_id)
+    framework_id = _validate_framework_id(framework_id)
     bundled = load_manifest()
     user = load_user_manifest()
     entry = user.get(framework_id) or bundled.get(framework_id)
@@ -255,7 +264,7 @@ async def import_catalog(payload: CatalogImportPayload) -> dict[str, object]:
     via the ``user_dir`` helpers. Never touches a path outside the user
     catalog dir.
     """
-    _validate_framework_id(payload.framework_id)
+    framework_id = _validate_framework_id(payload.framework_id)
 
     tier = payload.tier.upper()
     if tier not in ("A", "B", "C", "D"):
@@ -291,21 +300,23 @@ async def import_catalog(payload: CatalogImportPayload) -> dict[str, object]:
 
     # Path/body framework_id is authoritative; rewrite the content so the
     # persisted catalog + manifest agree on the ID it lands under.
-    data["framework_id"] = payload.framework_id
+    data["framework_id"] = framework_id
     if payload.name:
         data["framework_name"] = payload.name
-    resolved_name = data.get("framework_name") or payload.framework_id
+    resolved_name = data.get("framework_name") or framework_id
     version = str(data.get("version", "unknown"))
     placeholder = bool(data.get("placeholder", False))
 
     user_dir = ensure_user_dir()
-    # framework_id is validated by _validate_framework_id above (no '..', no path
-    # separators), so this lands inside the user catalog dir by construction —
-    # the validator is the containment guarantee. (A second resolve()-based check
-    # here is redundant and CodeQL would itself flag it as a path operation on
-    # caller input; the resolve_catalog_path guard covers the read-back path,
-    # where the user-manifest value is NOT regex-validated.)
-    out_path = user_dir / f"{payload.framework_id}.json"
+    # ``framework_id`` is the VALIDATED value returned by _validate_framework_id
+    # above (no '..', no path separators), so this lands inside the user catalog
+    # dir by construction — the validator is the containment guarantee, and using
+    # its return value (not the raw payload field) is what lets CodeQL's
+    # py/path-injection see the barrier. (A second resolve()-based check here is
+    # redundant and CodeQL would itself flag it as a path operation on caller
+    # input; the resolve_catalog_path guard covers the read-back path, where the
+    # user-manifest value is NOT regex-validated.)
+    out_path = user_dir / f"{framework_id}.json"
     if out_path.exists() and not payload.force:
         raise HTTPException(
             status_code=400,
@@ -378,7 +389,7 @@ async def remove_catalog(framework_id: str) -> None:
     "no user-imported framework; bundled catalogs cannot be removed"
     behavior.
     """
-    _validate_framework_id(framework_id)
+    framework_id = _validate_framework_id(framework_id)
     user = load_user_manifest()
     entry = user.get(framework_id)
     if entry is None:

--- a/packages/evidentia-core/src/evidentia_core/catalogs/user_dir.py
+++ b/packages/evidentia-core/src/evidentia_core/catalogs/user_dir.py
@@ -123,7 +123,16 @@ def resolve_catalog_path(
         # writes a validated ``{framework_id}.json`` (no separators, no ``..``),
         # but a hand-edited manifest could carry an escaping path — assert
         # containment so a traversal can never reach the file loader.
-        if not path.resolve().is_relative_to(user_dir.resolve()):
+        #
+        # Resolve ONCE and RETURN the resolved, containment-checked path (not the
+        # raw join). Returning the value the ``is_relative_to`` guard actually
+        # checked is what lets CodeQL's built-in ``py/path-injection`` barrier
+        # recognize the guard — previously the check ran on ``path.resolve()``
+        # but the *unchecked* ``path`` was returned, so the loader's
+        # ``read_text`` was flagged (alert #164). ``ResolveCatalogPathSanitizer``
+        # (the custom QL pack) models this return as a second, explicit barrier.
+        resolved = path.resolve()
+        if not resolved.is_relative_to(user_dir.resolve()):
             raise ValueError(
                 f"User catalog path for {framework_id!r} escapes the user "
                 "catalog directory; refusing to load."
@@ -138,9 +147,9 @@ def resolve_catalog_path(
             if bundled_manifest.get(framework_id)
             else "Framework %r resolved from user dir (%r)",
             framework_id,
-            path,
+            resolved,
         )
-        return path, user_entry, "user"
+        return resolved, user_entry, "user"
 
     # Fall back to bundled
     bundled_entry = bundled_manifest.get(framework_id)
@@ -157,4 +166,8 @@ def resolve_catalog_path(
         from evidentia_core.catalogs.loader import DATA_DIR
 
         bundled_data_dir = DATA_DIR
-    return bundled_data_dir / bundled_entry.path, bundled_entry, "bundled"
+    # Resolve the bundled path too so resolve_catalog_path uniformly returns a
+    # resolved absolute path. Bundled entries come from the trusted package
+    # manifest (not user input), but returning a single sanitized shape keeps
+    # the choke-point's output consistent for both branches + the QL sanitizer.
+    return (bundled_data_dir / bundled_entry.path).resolve(), bundled_entry, "bundled"

--- a/tests/unit/test_catalogs/test_user_dir.py
+++ b/tests/unit/test_catalogs/test_user_dir.py
@@ -109,7 +109,10 @@ def test_user_entry_shadows_bundled(tmp_path) -> None:
         user_dir_override=tmp_path,
     )
     assert source == "user"
-    assert path == fake_json
+    # resolve_catalog_path returns the RESOLVED, containment-checked path
+    # (the value its is_relative_to guard checked) so CodeQL's path-injection
+    # barrier recognizes the guard; compare against the resolved fixture path.
+    assert path == fake_json.resolve()
 
 
 def test_resolve_falls_through_to_bundled(tmp_path) -> None:


### PR DESCRIPTION
Extend the custom CodeQL pack so `py/path-injection` recognizes the catalog router's path-validation choke points — clearing alert **#164** (the catalog loader `read_text` at `loader.py:68`) at the query level instead of by per-instance dismissal ("systemic false positives go in committed config").

- **`resolve_catalog_path`** now returns the `is_relative_to`-checked **resolved** path (was: the unchecked join), so CodeQL's built-in guard recognition sees the barrier; **`ResolveCatalogPathSanitizer.qll`** models its return as an explicit sanitizer. The loader path flows from here via `load_catalog`/`load_any_catalog`, so this is the operative fix for #164.
- **`_validate_framework_id`** now RETURNS its validated value and the 4 router callsites reassign it, so the sanitized id (not the raw request value) flows into the `user_dir/'{id}.json'` write path; **`FrameworkIdSanitizer.qll`** models it.

Two independent mechanisms (built-in barrier + custom `.qll`) maximize first-CI-run clearance. **Validation:** 606 catalog/API tests + mypy (157 files) + ruff clean. The `.qll` firing is CI-CodeQL-gated; the **#164 dismissal converts to *fixed*** once a CI CodeQL run confirms `loader.py:68` is no longer flagged. Engineering follow-up.