### PR TITLE
Ci(deps): Patch-only Dependabot auto-merge + reconcile auto-merge doctrine

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,84 @@
+name: dependabot-auto-merge
+
+# Patch-only Dependabot auto-merge (v0.10.x engineering follow-up). The policy
+# was settled by a multi-model, primary-source research pass; the verdict +
+# rationale live in docs/engineering-practices.md ("Lessons that shaped the
+# system" #1). Scope is deliberately NARROW and FAIL-CLOSED: a PR auto-merges
+# ONLY when every allow-list condition holds; anything else falls through to
+# human review.
+#
+#   - author is dependabot[bot]
+#   - update-type is version-update:semver-patch (never minor, never major)
+#   - ecosystem is Python (uv/pip) or npm. NEVER docker (base-image caution from
+#     the v0.10.12 incident — a docker minor bump broke the release) and NEVER
+#     github-actions in v1 (action-SHA bumps are supply-chain-sensitive and stay
+#     human-reviewed even though zizmor gates them; promote later if desired).
+#   - the PR is a GROUPED version update (dependency-group != ''). Dependabot
+#     SECURITY updates are never grouped in this repo (every group in
+#     .github/dependabot.yml is applies-to: version-updates), so requiring a
+#     group membership EXCLUDES every security PR. A "security patch" can carry a
+#     poisoned dependency, so it always gets a human. (If security-update
+#     grouping is ever added to dependabot.yml, add an explicit fetch-metadata
+#     `alert-lookup: true` + `ghsa-id == ''` check here.)
+#   - NOT the breaking-prone python-frameworks group.
+#
+# Auto-merge does NOT bypass any gate. It calls GitHub native auto-merge, so the
+# PR merges only after the full required-check suite is green and the merge queue
+# re-tests the prospective merge; a 3-day release-age cooldown (dependabot.yml)
+# sits in front. Auto-merge != auto-publish: a merged patch lands on main but
+# ships only when a human cuts a signed release tag (pre-release-review gates it).
+#
+# Security model (verified against GitHub's official Dependabot auto-merge doc):
+# trigger on `pull_request` (NOT pull_request_target) and elevate the token via a
+# JOB-scoped permissions block — the documented pattern, which never executes
+# PR-controlled code. There is NO checkout; the job only reads PR metadata and
+# calls the GitHub API. fetch-metadata is full-SHA pinned; tokens pass via env,
+# never interpolated into a run: block (zizmor template-injection hardening).
+
+on:
+  pull_request:
+    branches: [main]
+
+# Least privilege at the top level; the single job elevates only what native
+# auto-merge requires.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge (Dependabot patch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Act ONLY on Dependabot's own PRs. Use the PR author (not github.actor,
+    # which can be a human re-runner) so the gate is not spoofable.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    permissions:
+      contents: write # enable native auto-merge on the PR
+      pull-requests: write # gh pr merge --auto
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for in-scope patch updates
+        # Fail-closed allow-list: patch-only, Python/npm only, GROUPED (=> not a
+        # security PR), not the frameworks group. Anything else => no auto-merge.
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+          && steps.meta.outputs.dependency-group != ''
+          && steps.meta.outputs.dependency-group != 'python-frameworks'
+          && (steps.meta.outputs.package-ecosystem == 'uv'
+          || steps.meta.outputs.package-ecosystem == 'pip'
+          || steps.meta.outputs.package-ecosystem == 'npm')
+        # `gh pr merge --auto` with NO strategy flag: the merge queue owns the
+        # squash strategy (passing --squash makes gh bail on a queue repo).
+        run: gh pr merge --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2030,28 +2030,34 @@ detailed integration plan" §v0.11. Substantive minor (~6-8 weeks):
   post-operator-deep-dive (incorporate AWS OSCAL MCP / Vanta MCP /
   ComplianceCow MCP / Snyk AI Trust Platform shifts).
 
-### Engineering & security follow-ups — PLANNED (not feature-tied)
+### Engineering & security follow-ups (not feature-tied)
 
 Hardening items the continuous-assurance gates surfaced about themselves, tracked
 here so they aren't lost between feature cycles (see
-[`docs/engineering-practices.md`](engineering-practices.md)):
+[`docs/engineering-practices.md`](engineering-practices.md)). The v0.10.x
+engineering-hardening batch addressed all three:
 
-- **Extend the CodeQL custom sanitizer model to recognize `_validate_framework_id`.**
-  The catalog router validates every `framework_id` (regex + `..`/separator
-  rejection) before deriving an on-disk path, but the sanitizer model doesn't yet
-  model that helper, so `py/path-injection` flagged the catalog loader (alert #164
-  — dismissed as mitigated 2026-06-27, with a runtime
-  `resolve()`/`is_relative_to(user_dir)` containment guard added as defense-in-
-  depth). Teaching the model the validator clears that finding class at the query
-  level — restoring the "report real findings, not known-safe ones" property.
-- **Enable code-scanning merge protection** so a *new* High/Critical code-scanning
-  alert blocks the PR. The CodeQL `Analyze` jobs are required, but they gate on the
-  analysis *running*, not on introduced findings; the "Code scanning results" gate
-  is the piece that blocks a newly-introduced alert.
-- **Dependabot patch auto-merge** (`dependabot/fetch-metadata` + `gh pr merge
-  --auto`, patch-only, after the full required-check suite is green; majors +
-  security PRs stay human-reviewed). Validate once on a harmless Dependabot PR and
-  confirm the workflow itself passes the now-required zizmor gate before enabling.
+- **CodeQL custom sanitizer model extended — DONE.** The custom QL pack now models
+  `evidentia_core.catalogs.user_dir.resolve_catalog_path` (the choke point whose
+  return feeds the catalog loader's `read_text`, alert #164) and the catalog
+  router's `_validate_framework_id` as `py/path-injection` sanitizers, and
+  `resolve_catalog_path` now returns the `is_relative_to`-checked *resolved* path
+  so CodeQL's built-in guard recognition also sees the barrier. This clears the
+  #164 class at the query level — restoring "report real findings, not known-safe
+  ones." (The #164 dismissal is converted to *fixed* once a CI CodeQL run confirms
+  the loader is no longer flagged.)
+- **Code-scanning merge protection — DONE.** A `code_scanning` rule on the `main`
+  ruleset (CodeQL, `high_or_higher` / `errors`) now blocks a PR that introduces a
+  new High/Critical alert. The CodeQL `Analyze` jobs gate on the analysis
+  *running*; this rule is the piece that gates on introduced *findings*.
+- **Dependabot patch auto-merge — DONE (narrow).** `dependabot-auto-merge.yml`
+  enables GitHub native auto-merge for **patch-only**, Python/npm, grouped (=> not
+  a security PR), non-frameworks updates, after the full required-check suite is
+  green; majors, minors, container/Actions, and security PRs stay human-reviewed.
+  The policy was settled by a multi-model, primary-source research pass (the
+  earlier broad patch+minor auto-merge was removed after a docker-minor base-image
+  break — see engineering-practices.md lesson #1). The workflow passes the required
+  zizmor gate; it is validated end-to-end on the next real Dependabot patch PR.
 
 ### Medical-device GRC feature line (v0.11 → v1.1+) — PLANNED (web-grounded research 2026-06-17)
 

--- a/docs/engineering-practices.md
+++ b/docs/engineering-practices.md
@@ -95,9 +95,11 @@ Evidentia's releases are designed to be independently verifiable end to end:
   is held a few days, so a yanked or hot-fixed bad release is superseded before it
   is proposed); breaking-prone framework packages are isolated into their own
   reviewable PR; per-ecosystem open-PR caps bound the queue; and security
-  advisories are never grouped — each rides its own PR. Majors and security
-  updates always get human review: CI verifies correctness, not the *intent* of a
-  possibly-poisoned dependency.
+  advisories are never grouped — each rides its own PR. Patch updates in the
+  lower-risk ecosystems (Python and npm) auto-merge once the full required-check
+  suite is green (narrow, fail-closed; see lesson #1); majors, minors, container
+  and Actions updates, and security updates always get human review, because CI
+  verifies correctness, not the *intent* of a possibly-poisoned dependency.
 
 These are also the signals OpenSSF Scorecard scores, which the project tracks
 publicly.
@@ -174,11 +176,20 @@ interpreter, so on the new base the resolver could only reach a
 vulnerability-bearing version of one dependency and the patched pin became
 uninstallable — and the container build failed. *Root cause:* a
 security-sensitive, deliberately-chosen pin was reverted by a change that
-merged on green CI without a human reading it. *Prevention:* patch/minor
-dependency auto-merge was removed so a maintainer reviews **every** dependency
-change; the base image is pinned by digest with a guard comment; and the
-container smoke test (see below) now catches an incompatible base bump at
-pull-request time.
+merged on green CI without a human reading it. *Prevention:* the **broad**
+auto-merge policy (patch **and minor**, every ecosystem) was removed; the base
+image is pinned by digest with a guard comment; and the container smoke test
+(see below) now catches an incompatible base bump at pull-request time.
+Auto-merge was later **reinstated in a deliberately narrow form** — patch-only,
+Python and npm ecosystems only, excluding majors, minors, the container
+(`docker`) and `github-actions` ecosystems, the breaking-prone frameworks
+group, and **all security updates** — firing only after the full required-check
+suite is green, behind the release-age cooldown and the merge queue, via a
+workflow that never executes pull-request code. The incident was a *minor*
+`docker` bump under the broad policy with a silently-dead gate (lesson #2); the
+narrow policy excludes that class twice over, and every major or security change
+still gets a human. The narrow policy was settled by a multi-model,
+primary-source research pass before it shipped.
 
 **2. The gate that should have caught it had silently died.** The container
 smoke test had been exiting early on a version-extraction step for several


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`: GitHub native auto-merge for **patch-only**, Python/npm, **grouped** (=> never a security PR), non-frameworks Dependabot updates — firing only after the full required-check suite is green (the merge queue re-tests the prospective merge; the 3-day release-age cooldown sits in front). Excludes majors, minors, docker + github-actions ecosystems, the `python-frameworks` group, and every security PR.

**Security model** (verified vs GitHub's official Dependabot auto-merge doc): `on: pull_request` (NOT `pull_request_target`) + a job-scoped permissions block + **no checkout** — the documented pattern that never runs PR code; `fetch-metadata` SHA-pinned; `gh pr merge --auto` with no strategy flag (queue owns squash). Passes the required **zizmor** gate (verified online). Auto-merge != auto-publish: a merged patch ships only when a human cuts a signed release tag.

**Doctrine reconciliation:** `engineering-practices.md` lesson #1 + the supply-chain bullet now describe the narrow reinstated policy honestly (the broad patch+minor policy was removed after a docker-minor base-image break; the narrow policy excludes that class twice over, every major/security change still gets a human). The policy was **settled by a multi-model, primary-source research pass**. ROADMAP engineering-follow-ups section updated.

Validation: zizmor online clean (all workflows); YAML valid; full suite green. Engineering follow-up.