### PR TITLE
Test(ci): THROWAWAY — verify code-scanning merge protection (DO NOT MERGE)

### DIFF
--- a/tests/_throwaway_codeql_verify.py
+++ b/tests/_throwaway_codeql_verify.py
@@ -1,25 +1,29 @@
 """THROWAWAY — verifies code-scanning merge protection. DO NOT MERGE.
 
-This module deliberately contains a single ``py/path-injection`` finding so we
-can confirm the ``code_scanning`` ruleset rule (security_alerts_threshold =
-high_or_higher) BLOCKS a pull request that introduces a new HIGH code-scanning
-alert. The branch is closed + deleted as soon as the blocking check is observed;
-this file never reaches ``main``. It is intentionally ruff-/mypy-/pytest-clean
-so that the ONLY failing required check is the code-scanning result.
+Introduces ONE remote-source ``py/path-injection`` (HIGH) so we can confirm the
+``code_scanning`` ruleset rule BLOCKS a PR that introduces a new HIGH alert.
+
+The first attempt used ``sys.argv`` (a LOCAL source, which CodeQL's default
+*remote* threat model does not flag, so no alert was produced). This uses a
+FastAPI query parameter — a REMOTE source — which the stock query does flag.
+
+Intentionally ruff-/mypy-/pytest-clean so the ONLY failing required check is the
+code-scanning result. Closed + deleted as soon as the blocking check is observed;
+this file never reaches ``main``.
 """
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
+from fastapi import APIRouter
 
-def _throwaway_read(user_arg: str) -> str:
-    # Deliberate + unsanitized: CLI input flows straight into read_text with no
-    # containment guard, which CodeQL reports as py/path-injection (HIGH). This
-    # is the dummy finding that proves merge protection blocks the PR.
-    return Path(user_arg).read_text(encoding="utf-8")
+_throwaway_router = APIRouter()
 
 
-if __name__ == "__main__":  # pragma: no cover
-    sys.stdout.write(_throwaway_read(sys.argv[1]))
+@_throwaway_router.get("/_throwaway_codeql_verify")
+def _throwaway_endpoint(name: str) -> str:
+    # Remote source (the FastAPI query param ``name``) flows straight into a file
+    # read with no containment guard -> CodeQL py/path-injection (HIGH). This is
+    # the dummy finding that should trip the code_scanning merge-protection rule.
+    return Path(name).read_text(encoding="utf-8")

--- a/tests/_throwaway_codeql_verify.py
+++ b/tests/_throwaway_codeql_verify.py
@@ -1,0 +1,25 @@
+"""THROWAWAY — verifies code-scanning merge protection. DO NOT MERGE.
+
+This module deliberately contains a single ``py/path-injection`` finding so we
+can confirm the ``code_scanning`` ruleset rule (security_alerts_threshold =
+high_or_higher) BLOCKS a pull request that introduces a new HIGH code-scanning
+alert. The branch is closed + deleted as soon as the blocking check is observed;
+this file never reaches ``main``. It is intentionally ruff-/mypy-/pytest-clean
+so that the ONLY failing required check is the code-scanning result.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _throwaway_read(user_arg: str) -> str:
+    # Deliberate + unsanitized: CLI input flows straight into read_text with no
+    # containment guard, which CodeQL reports as py/path-injection (HIGH). This
+    # is the dummy finding that proves merge protection blocks the PR.
+    return Path(user_arg).read_text(encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.stdout.write(_throwaway_read(sys.argv[1]))


### PR DESCRIPTION
**Throwaway verification — will be closed without merging.** Confirms the new `code_scanning` ruleset rule blocks a PR that introduces a new HIGH py/path-injection alert. Once the Code-scanning-results check is observed blocking the merge, this PR is closed + the branch deleted.