### PR TITLE
Fix(release): Install uv in the publish-pypi job + bump to 0.10.16

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -81,6 +81,11 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    # Deploy only from main: the github-pages environment's branch policy
+    # allows main only, so a tag-triggered deploy is REJECTED and reds the
+    # run (observed on v0.10.14/v0.10.15). Tags still run the strict docs
+    # BUILD above as a gate; the deploy is main's job.
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # JUSTIFIED: a GitHub Pages deployment requires pages:write (publish the

--- a/.github/workflows/post-publish-rescan.yml
+++ b/.github/workflows/post-publish-rescan.yml
@@ -91,10 +91,13 @@ jobs:
           set -euo pipefail
           VERSION="${VERSION_INPUT}"
           python -m venv /tmp/rescan
+          # [gui,mcp] + the meta base deps = all 8 published packages (the
+          # prior `[ai,api,collectors]` extras never existed — pip silently
+          # skipped them, so the rescanned closure omitted evidentia-api).
           if [ -n "$VERSION" ]; then
-            SPEC="evidentia[ai,api,collectors,mcp]==${VERSION}"
+            SPEC="evidentia[gui,mcp]==${VERSION}"
           else
-            SPEC="evidentia[ai,api,collectors,mcp]"
+            SPEC="evidentia[gui,mcp]"
           fi
           echo "Installing ${SPEC} from PyPI ..."
           /tmp/rescan/bin/pip install --quiet "${SPEC}"

--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -99,8 +99,13 @@ jobs:
           set -euo pipefail
           python -m venv /tmp/smoke-extras
           # Intentionally UNPINNED (see the base-install step): install the live
-          # published extras exactly as a consumer would.
-          /tmp/smoke-extras/bin/pip install "evidentia[ai,api,collectors,mcp]==${VERSION}"
+          # published extras exactly as a consumer would. The meta-package's
+          # BASE deps already pull evidentia-core/-ai/-eval/-collectors/
+          # -integrations; [gui] adds evidentia-api and [mcp] adds
+          # evidentia-mcp — together = all 8 published packages. (The prior
+          # `[ai,api,collectors]` extras never existed; pip warned + silently
+          # skipped them, so evidentia-api was never actually verified.)
+          /tmp/smoke-extras/bin/pip install "evidentia[gui,mcp]==${VERSION}"
           OUT="$(/tmp/smoke-extras/bin/evidentia version)"
           echo "$OUT"
           echo "$OUT" | grep -q "${VERSION}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,11 +405,15 @@ jobs:
       # below, and its absence is exactly what killed the first live run of the
       # restructured publish path (v0.10.15: exit 127 `uvx: command not found`;
       # the publish jobs never run in PR CI, so tag time is their first
-      # execution). Same pinned action the build job uses.
+      # execution). Same pinned action the build job uses. Cache DISABLED:
+      # a PR-writable Actions cache read inside an artifact-publishing job is a
+      # cache-poisoning vector (zizmor cache-poisoning; same rationale as the
+      # disabled docker type=gha cache above — a release builds from scratch).
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: "latest"
+          enable-cache: false
 
       - name: Check distributions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,16 @@ jobs:
           name: release-dist
           path: .
 
+      # uv is NOT preinstalled on the runner — this job runs `uvx twine check`
+      # below, and its absence is exactly what killed the first live run of the
+      # restructured publish path (v0.10.15: exit 127 `uvx: command not found`;
+      # the publish jobs never run in PR CI, so tag time is their first
+      # execution). Same pinned action the build job uses.
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          version: "latest"
+
       - name: Check distributions
         run: |
           ls -la dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,10 @@ jobs:
           # failure). Removing it forces the hashes below to be generated from
           # these exact local wheels.
           rm -f docker/requirements.txt
-          echo "evidentia[gui]==${VERSION}" > docker/requirements.in
+          # Keep the committed .in's deliberate urllib3 security floor (the
+          # regen would otherwise silently drop it; the osv-scan below is the
+          # backstop, the floor is the defense-in-depth minimum).
+          printf 'evidentia[gui]==%s\nurllib3>=2.7.0\n' "${VERSION}" > docker/requirements.in
           attempts=0
           max_attempts=3
           until docker run --rm -v "$PWD:/work" -w /work python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.15] - 2026-07-01
+## [0.10.16] - 2026-07-02
 
-**Theme**: *Engineering hardening + distroless container base — never ship a failed test again.* Bundles the accumulated supply-chain work into one release: cryptography-native DSSE/in-toto air-gap signing, the atomic (validate-before-publish) release pipeline, and the migration of the published container onto a distroless **Docker Hardened Images** base (nonroot uid 65532; no shell, `curl`, or `gpg`). No package API changes. (The 0.10.14 tag was created but never published: the atomic release's build-before-publish gate correctly caught a non-reproducible container-requirements-hash issue *before* any artifact shipped — 0.10.15 is the same content plus the release-pipeline fix.)
+**Theme**: *Engineering hardening + distroless container base — never ship a failed test again.* Bundles the accumulated supply-chain work into one release: cryptography-native DSSE/in-toto air-gap signing, the atomic (validate-before-publish) release pipeline, and the migration of the published container onto a distroless **Docker Hardened Images** base (nonroot uid 65532; no shell, `curl`, or `gpg`). No package API changes. (The 0.10.14 and 0.10.15 tags were created but never published — in both cases the atomic release's validate-before-publish design stopped anything from shipping. 0.10.14's build caught a non-reproducible container-requirements-hash issue; 0.10.15 fixed that, built and validated everything, then failed pre-upload on a missing `uv` install in the restructured publish job's `twine check` — the publish jobs' first-ever live execution, since they cannot run in PR CI. 0.10.16 is the same release content plus both pipeline fixes.)
 
 ### Added
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,5 +47,5 @@ keywords:
   - slsa
   - python
 license: Apache-2.0
-version: 0.10.15
-date-released: '2026-07-01'
+version: 0.10.16
+date-released: '2026-07-02'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For the full workspace (AI risk-statements, REST API, all collectors, MCP server
 pip install 'evidentia[ai,api,collectors,mcp]'
 ```
 
-Container: `docker pull ghcr.io/polycentric-labs/evidentia:v0.10.15` (cosign keyless OIDC + SLSA Provenance v1 verified).
+Container: `docker pull ghcr.io/polycentric-labs/evidentia:v0.10.16` (cosign keyless OIDC + SLSA Provenance v1 verified).
 
 See the [Getting Started wiki section](https://github.com/Polycentric-Labs/evidentia/wiki/Getting-Started) for air-gapped install, virtualenv setup, and full extras matrix.
 
@@ -120,7 +120,7 @@ See it first, no install — a self-hosted [asciinema](https://asciinema.org/) r
 
 ## Recent Releases
 
-**v0.10.15 (2026-07-01)** — *Engineering hardening + distroless container base — never ship a failed test again*. **Cryptography-native air-gap signing via DSSE/in-toto**, a binary-free, network-free signing path that works inside distroless and minimal-base containers.
+**v0.10.16 (2026-07-02)** — *Engineering hardening + distroless container base — never ship a failed test again*. **Cryptography-native air-gap signing via DSSE/in-toto**, a binary-free, network-free signing path that works inside distroless and minimal-base containers.
 
 **v0.10.13 (2026-06-23)** — *Patch — restore the container base to Python 3.13*. **Container base reverted to `python:3.13-slim`** after a Dependabot bump (#83) to `python:3.14-slim` broke `release.yml`'s container build.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ a vulnerability in Evidentia's own code.
 
 | Version | Status | Reason |
 |---------|--------|--------|
-| **`0.10.15`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](CHANGELOG.md) and the latest `docs/security-review-*.md` for what shipped and the CVE posture at this release. |
+| **`0.10.16`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](CHANGELOG.md) and the latest `docs/security-review-*.md` for what shipped and the CVE posture at this release. |
 | Earlier patches | ❌ Deprecated | Pre-v1.0 single-supported-patch policy; upgrade to the latest patch. |
 | Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](docs/archive/RENAMED.md). |
 
@@ -172,7 +172,7 @@ Verify a release wheel:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.15-py3-none-any.whl"
+  "pypi:evidentia-0.10.16-py3-none-any.whl"
 ```
 
 If verification fails, **stop and report immediately** via the

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -48,7 +48,7 @@
 # obtained from cosign verification, NOT `:latest`):
 #   docker build -f docker/Dockerfile.demo \
 #       --build-arg BASE=ghcr.io/polycentric-labs/evidentia@sha256:<digest> \
-#       -t evidentia-demo:v0.10.15 .
+#       -t evidentia-demo:v0.10.16 .
 #
 # Smoke test (before the signed digest exists — BASE is overridable so the
 # allowlist/refusal logic is testable against a bare Python base):
@@ -62,7 +62,7 @@
 #   docker run --rm --network none --read-only --tmpfs /tmp \
 #       --memory 512m --cpus 1 --pids-limit 256 \
 #       --security-opt no-new-privileges --cap-drop ALL \
-#       evidentia-demo:v0.10.15 doctor
+#       evidentia-demo:v0.10.16 doctor
 
 # Default to the signed release digest at deploy time. The placeholder
 # below is intentionally a non-resolvable pin so a production build that

--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -1,2 +1,2 @@
-evidentia[gui]==0.10.15
+evidentia[gui]==0.10.16
 urllib3>=2.7.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Evidentia roadmap
 
-**Last updated: v0.10.15 (planning, July 2026).**
+**Last updated: v0.10.16 (planning, July 2026).**
 
 > **Engineering practices** — how Evidentia is built, tested, and shipped (the
 > PR-flow + merge-queue gate, atomic releases, supply-chain integrity, and the
@@ -8,7 +8,7 @@
 
 This roadmap synthesizes community feedback with the architecture plan
 at the project root. Versions v0.3.0 through v0.7.16 + v0.8.0-v0.8.7
-+ v0.9.0-v0.9.9 + v0.10.0-v0.10.13 have shipped; v0.10.15 is the current
++ v0.9.0-v0.9.9 + v0.10.0-v0.10.13 have shipped; v0.10.16 is the current
 release (cryptography-native DSSE air-gap signing + the distroless DHI
 container base hardening, following v0.10.12's CLI↔GUI parity build-out + the
 OMB M-25-21 AI-governance migration), before the v0.11 federal-compliance theme. **v0.9.0 opened the
@@ -2091,7 +2091,7 @@ engineering-hardening batch addressed all three:
   signal ("a fix is now available → rebuild"), not noise — and it is *expected* to fire red on
   the current published image until a rebuild clears its 4 fixable advisories. Doctrine:
   `docs/engineering-practices.md` ("Continuous security assurance").
-- **Container base-image migration — SHIPPED (0.10.15).** The published image rides a
+- **Container base-image migration — SHIPPED (0.10.16).** The published image rides a
   multi-stage build: a `python:3.13-slim` builder resolves the hash-pinned closure into a
   venv, and a distroless **`dhi.io/python:3.13`** (Docker Hardened Images; free, Apache-2.0,
   anonymous pull) runtime carries only that venv as nonroot uid 65532 — no shell, `curl`,
@@ -2100,7 +2100,7 @@ engineering-hardening batch addressed all three:
   post-exploitation attack-surface reduction + keeping the fixable-rescan gate green, NOT a
   raw CVE-count cut (DHI carries ~40 unfixable advisories; "0 fixable" is a snapshot whose
   durable control is the scheduled rebuild + digest re-pin). NOT Alpine (musl breaks
-  manylinux wheels). (Verified 2026-06-28; shipped in 0.10.15, 2026-07-01.)
+  manylinux wheels). (Verified 2026-06-28; shipped in 0.10.16, 2026-07-01.)
 
 ### Medical-device GRC feature line (v0.11 → v1.1+) — PLANNED (web-grounded research 2026-06-17)
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -21,10 +21,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  pypi:evidentia_core-0.10.15-py3-none-any.whl
+  pypi:evidentia_core-0.10.16-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.15-py3-none-any.whl
+#   OK: evidentia_core-0.10.16-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -36,10 +36,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  pypi:evidentia_core-0.10.15-py3-none-any.whl
+  pypi:evidentia_core-0.10.16-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.15-py3-none-any.whl
+#   OK: evidentia_core-0.10.16-py3-none-any.whl
 ```
 
 Per-release sweep across all 8 packages:
@@ -51,7 +51,7 @@ for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
            evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
   pypi-attestations verify pypi \
     --repository https://github.com/Polycentric-Labs/evidentia \
-    "pypi:${pkg}-0.10.15-py3-none-any.whl"
+    "pypi:${pkg}-0.10.16-py3-none-any.whl"
 done
 ```
 
@@ -62,7 +62,7 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
                  'evidentia_core','evidentia_eval','evidentia_integrations','evidentia_mcp') {
   pypi-attestations verify pypi `
     --repository https://github.com/Polycentric-Labs/evidentia `
-    "pypi:${pkg}-0.10.15-py3-none-any.whl"
+    "pypi:${pkg}-0.10.16-py3-none-any.whl"
 }
 ```
 
@@ -75,8 +75,8 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -89,8 +89,8 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -102,7 +102,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 `
 
 ```bash
 # Download the SBOM
-gh release download v0.10.15 --pattern 'evidentia-sbom.cdx.json' \
+gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' \
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -115,7 +115,7 @@ osv-scanner scan --sbom evidentia-sbom.cdx.json
 
 ```powershell
 # Download the SBOM
-gh release download v0.10.15 --pattern 'evidentia-sbom.cdx.json' `
+gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' `
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -132,8 +132,8 @@ attestation inline. To extract it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.15 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" \
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --type slsaprovenance1
 ```
@@ -141,8 +141,8 @@ cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.15 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.15 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" `
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com `
   --type slsaprovenance1
 ```

--- a/docs/wiki/1-getting-started/installation.md
+++ b/docs/wiki/1-getting-started/installation.md
@@ -28,7 +28,7 @@ Verify the install:
 
 ```bash
 evidentia version
-# → Evidentia v0.10.15
+# → Evidentia v0.10.16
 # → Python 3.12.x
 ```
 
@@ -83,9 +83,9 @@ Every release publishes a cosign-signed multi-arch image to GitHub Container
 Registry:
 
 ```bash
-docker pull ghcr.io/polycentric-labs/evidentia:v0.10.15
-docker run --rm ghcr.io/polycentric-labs/evidentia:v0.10.15 version
-# → Evidentia v0.10.15
+docker pull ghcr.io/polycentric-labs/evidentia:v0.10.16
+docker run --rm ghcr.io/polycentric-labs/evidentia:v0.10.16 version
+# → Evidentia v0.10.16
 # → Python 3.13.x
 ```
 
@@ -93,7 +93,7 @@ To run a gap analysis against a local inventory, mount your working directory:
 
 ```bash
 docker run --rm -v "$PWD:/work" -w /work \
-  ghcr.io/polycentric-labs/evidentia:v0.10.15 \
+  ghcr.io/polycentric-labs/evidentia:v0.10.16 \
   gap analyze --inventory my-controls.yaml \
   --frameworks nist-800-53-rev5-moderate --output gap-report.json
 ```
@@ -102,7 +102,7 @@ On **Windows PowerShell**, use PowerShell's backtick line-continuation instead o
 
 ```powershell
 docker run --rm -v "${PWD}:/work" -w /work `
-  ghcr.io/polycentric-labs/evidentia:v0.10.15 `
+  ghcr.io/polycentric-labs/evidentia:v0.10.16 `
   gap analyze --inventory my-controls.yaml `
   --frameworks nist-800-53-rev5-moderate --output gap-report.json
 ```
@@ -112,7 +112,7 @@ The image is keyless-signed via Fulcio + Rekor. Verify it before you trust it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"
@@ -121,7 +121,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"

--- a/docs/wiki/1-getting-started/quickstart.md
+++ b/docs/wiki/1-getting-started/quickstart.md
@@ -17,7 +17,7 @@ Verify:
 
 ```bash
 evidentia version
-# → Evidentia v0.10.15 / Python 3.12.x
+# → Evidentia v0.10.16 / Python 3.12.x
 ```
 
 ## Step 2 — Pick a framework (10 seconds)
@@ -122,8 +122,8 @@ The wheel you installed has a PEP 740 attestation:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.15-py3-none-any.whl"
-# → OK: evidentia-0.10.15-py3-none-any.whl
+  "pypi:evidentia-0.10.16-py3-none-any.whl"
+# → OK: evidentia-0.10.16-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -132,8 +132,8 @@ pypi-attestations verify pypi \
 pip install pypi-attestations
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  "pypi:evidentia-0.10.15-py3-none-any.whl"
-# → OK: evidentia-0.10.15-py3-none-any.whl
+  "pypi:evidentia-0.10.16-py3-none-any.whl"
+# → OK: evidentia-0.10.16-py3-none-any.whl
 ```
 
 The container image is cosign-signed (if you used the Docker install path):
@@ -141,7 +141,7 @@ The container image is cosign-signed (if you used the Docker install path):
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"
@@ -150,7 +150,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"

--- a/docs/wiki/2-guides/air-gapped-install.md
+++ b/docs/wiki/2-guides/air-gapped-install.md
@@ -38,8 +38,8 @@ Pull the cosign-signed image on the connected host, save it to a tarball, and
 carry the tarball across the air gap:
 
 ```bash
-docker pull ghcr.io/polycentric-labs/evidentia:v0.10.15
-docker save ghcr.io/polycentric-labs/evidentia:v0.10.15 -o evidentia.tar
+docker pull ghcr.io/polycentric-labs/evidentia:v0.10.16
+docker save ghcr.io/polycentric-labs/evidentia:v0.10.16 -o evidentia.tar
 ```
 
 On the air-gapped host: `docker load -i evidentia.tar`.
@@ -56,7 +56,7 @@ index disabled so pip never reaches for the network:
 python -m venv .venv && source .venv/bin/activate
 pip install --no-index --find-links ./evidentia-wheelhouse evidentia
 evidentia version
-# → Evidentia v0.10.15 / Python 3.12.x
+# → Evidentia v0.10.16 / Python 3.12.x
 ```
 
 **PowerShell (Windows)**
@@ -65,7 +65,7 @@ evidentia version
 python -m venv .venv ; .\.venv\Scripts\Activate.ps1
 pip install --no-index --find-links ./evidentia-wheelhouse evidentia
 evidentia version
-# → Evidentia v0.10.15 / Python 3.12.x
+# → Evidentia v0.10.16 / Python 3.12.x
 ```
 
 ## Step 3 — Validate the air-gap posture

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.15] - 2026-07-01
+## [0.10.16] - 2026-07-02
 
-**Theme**: *Engineering hardening + distroless container base — never ship a failed test again.* Bundles the accumulated supply-chain work into one release: cryptography-native DSSE/in-toto air-gap signing, the atomic (validate-before-publish) release pipeline, and the migration of the published container onto a distroless **Docker Hardened Images** base (nonroot uid 65532; no shell, `curl`, or `gpg`). No package API changes. (The 0.10.14 tag was created but never published: the atomic release's build-before-publish gate correctly caught a non-reproducible container-requirements-hash issue *before* any artifact shipped — 0.10.15 is the same content plus the release-pipeline fix.)
+**Theme**: *Engineering hardening + distroless container base — never ship a failed test again.* Bundles the accumulated supply-chain work into one release: cryptography-native DSSE/in-toto air-gap signing, the atomic (validate-before-publish) release pipeline, and the migration of the published container onto a distroless **Docker Hardened Images** base (nonroot uid 65532; no shell, `curl`, or `gpg`). No package API changes. (The 0.10.14 and 0.10.15 tags were created but never published — in both cases the atomic release's validate-before-publish design stopped anything from shipping. 0.10.14's build caught a non-reproducible container-requirements-hash issue; 0.10.15 fixed that, built and validated everything, then failed pre-upload on a missing `uv` install in the restructured publish job's `twine check` — the publish jobs' first-ever live execution, since they cannot run in PR CI. 0.10.16 is the same release content plus both pipeline fixes.)
 
 ### Added
 

--- a/docs/wiki/6-project/roadmap.md
+++ b/docs/wiki/6-project/roadmap.md
@@ -3,7 +3,7 @@
 
 # Evidentia roadmap
 
-**Last updated: v0.10.15 (planning, July 2026).**
+**Last updated: v0.10.16 (planning, July 2026).**
 
 > **Engineering practices** — how Evidentia is built, tested, and shipped (the
 > PR-flow + merge-queue gate, atomic releases, supply-chain integrity, and the
@@ -11,7 +11,7 @@
 
 This roadmap synthesizes community feedback with the architecture plan
 at the project root. Versions v0.3.0 through v0.7.16 + v0.8.0-v0.8.7
-+ v0.9.0-v0.9.9 + v0.10.0-v0.10.13 have shipped; v0.10.15 is the current
++ v0.9.0-v0.9.9 + v0.10.0-v0.10.13 have shipped; v0.10.16 is the current
 release (cryptography-native DSSE air-gap signing + the distroless DHI
 container base hardening, following v0.10.12's CLI↔GUI parity build-out + the
 OMB M-25-21 AI-governance migration), before the v0.11 federal-compliance theme. **v0.9.0 opened the
@@ -2094,7 +2094,7 @@ engineering-hardening batch addressed all three:
   signal ("a fix is now available → rebuild"), not noise — and it is *expected* to fire red on
   the current published image until a rebuild clears its 4 fixable advisories. Doctrine:
   `docs/engineering-practices.md` ("Continuous security assurance").
-- **Container base-image migration — SHIPPED (0.10.15).** The published image rides a
+- **Container base-image migration — SHIPPED (0.10.16).** The published image rides a
   multi-stage build: a `python:3.13-slim` builder resolves the hash-pinned closure into a
   venv, and a distroless **`dhi.io/python:3.13`** (Docker Hardened Images; free, Apache-2.0,
   anonymous pull) runtime carries only that venv as nonroot uid 65532 — no shell, `curl`,
@@ -2103,7 +2103,7 @@ engineering-hardening batch addressed all three:
   post-exploitation attack-surface reduction + keeping the fixable-rescan gate green, NOT a
   raw CVE-count cut (DHI carries ~40 unfixable advisories; "0 fixable" is a snapshot whose
   durable control is the scheduled rebuild + digest re-pin). NOT Alpine (musl breaks
-  manylinux wheels). (Verified 2026-06-28; shipped in 0.10.15, 2026-07-01.)
+  manylinux wheels). (Verified 2026-06-28; shipped in 0.10.16, 2026-07-01.)
 
 ### Medical-device GRC feature line (v0.11 → v1.1+) — PLANNED (web-grounded research 2026-06-17)
 

--- a/docs/wiki/6-project/security.md
+++ b/docs/wiki/6-project/security.md
@@ -73,7 +73,7 @@ a vulnerability in Evidentia's own code.
 
 | Version | Status | Reason |
 |---------|--------|--------|
-| **`0.10.15`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](https://github.com/Polycentric-Labs/evidentia/blob/main/CHANGELOG.md) and the latest `docs/security-review-*.md` for what shipped and the CVE posture at this release. |
+| **`0.10.16`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](https://github.com/Polycentric-Labs/evidentia/blob/main/CHANGELOG.md) and the latest `docs/security-review-*.md` for what shipped and the CVE posture at this release. |
 | Earlier patches | ❌ Deprecated | Pre-v1.0 single-supported-patch policy; upgrade to the latest patch. |
 | Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/archive/RENAMED.md). |
 
@@ -175,7 +175,7 @@ Verify a release wheel:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.15-py3-none-any.whl"
+  "pypi:evidentia-0.10.16-py3-none-any.whl"
 ```
 
 If verification fails, **stop and report immediately** via the

--- a/docs/wiki/6-project/verification.md
+++ b/docs/wiki/6-project/verification.md
@@ -24,10 +24,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  pypi:evidentia_core-0.10.15-py3-none-any.whl
+  pypi:evidentia_core-0.10.16-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.15-py3-none-any.whl
+#   OK: evidentia_core-0.10.16-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -39,10 +39,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  pypi:evidentia_core-0.10.15-py3-none-any.whl
+  pypi:evidentia_core-0.10.16-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.15-py3-none-any.whl
+#   OK: evidentia_core-0.10.16-py3-none-any.whl
 ```
 
 Per-release sweep across all 8 packages:
@@ -54,7 +54,7 @@ for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
            evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
   pypi-attestations verify pypi \
     --repository https://github.com/Polycentric-Labs/evidentia \
-    "pypi:${pkg}-0.10.15-py3-none-any.whl"
+    "pypi:${pkg}-0.10.16-py3-none-any.whl"
 done
 ```
 
@@ -65,7 +65,7 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
                  'evidentia_core','evidentia_eval','evidentia_integrations','evidentia_mcp') {
   pypi-attestations verify pypi `
     --repository https://github.com/Polycentric-Labs/evidentia `
-    "pypi:${pkg}-0.10.15-py3-none-any.whl"
+    "pypi:${pkg}-0.10.16-py3-none-any.whl"
 }
 ```
 
@@ -78,8 +78,8 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -92,8 +92,8 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 \
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -105,7 +105,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.15 `
 
 ```bash
 # Download the SBOM
-gh release download v0.10.15 --pattern 'evidentia-sbom.cdx.json' \
+gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' \
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -118,7 +118,7 @@ osv-scanner scan --sbom evidentia-sbom.cdx.json
 
 ```powershell
 # Download the SBOM
-gh release download v0.10.15 --pattern 'evidentia-sbom.cdx.json' `
+gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' `
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -135,8 +135,8 @@ attestation inline. To extract it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.15 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" \
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --type slsaprovenance1
 ```
@@ -144,8 +144,8 @@ cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.15 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.15 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.15" `
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com `
   --type slsaprovenance1
 ```

--- a/marketplace/grc-engineering-suite/plugins/evidentia/.claude-plugin/plugin.json
+++ b/marketplace/grc-engineering-suite/plugins/evidentia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "evidentia",
   "description": "Evidentia GRC engine — OSCAL-first gap analysis, SARIF CI-gate output, OCSF ingestion. Open-source Apache-2.0 (Polycentric Labs). Wraps the evidentia-mcp server so AI clients drive the full product through one tool surface.",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "author": {
     "name": "Polycentric Labs",
     "url": "https://github.com/Polycentric-Labs"

--- a/packages/evidentia-ai/pyproject.toml
+++ b/packages/evidentia-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-ai"
-version = "0.10.15"
+version = "0.10.16"
 description = "LLM-powered risk statement generator and evidence validator for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -17,7 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
     # v0.10.5 P9: the DFAH eval harness was extracted to the
     # ``evidentia-eval`` workspace package so air-gap installs of
     # the production risk-statement runtime no longer pull the
@@ -25,7 +25,7 @@ dependencies = [
     # dependency here so the v0.10.5 deprecation shims (``from
     # evidentia_ai.eval import …``) continue to work through
     # v0.11.x; v0.12.0 removes both the shims and this pin.
-    "evidentia-eval>=0.10.15,<0.11.0",
+    "evidentia-eval>=0.10.16,<0.11.0",
     # v0.7.0 Step-3 review: pin LiteLLM above the compromised
     # 1.82.7 / 1.82.8 versions from the March 24, 2026 PyPI supply
     # chain incident (~40-min compromise window before quarantine).

--- a/packages/evidentia-api/pyproject.toml
+++ b/packages/evidentia-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-api"
-version = "0.10.15"
+version = "0.10.16"
 description = "FastAPI REST server + bundled React web UI for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -19,8 +19,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
-    "evidentia-ai>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-ai>=0.10.16,<0.11.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
     # v0.7.2 supply-chain follow-up: floor bumped from >=0.0.9 to

--- a/packages/evidentia-collectors/pyproject.toml
+++ b/packages/evidentia-collectors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-collectors"
-version = "0.10.15"
+version = "0.10.16"
 description = "Evidence collection agents for AWS, Databricks, GitHub, Okta, Snowflake, SQL databases, and vendor-risk APIs (Vanta, Drata, BitSight, SecurityScorecard)"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -17,7 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
     "httpx>=0.27",
 ]
 

--- a/packages/evidentia-core/pyproject.toml
+++ b/packages/evidentia-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-core"
-version = "0.10.15"
+version = "0.10.16"
 description = "Core data models, catalog loading, and gap analysis engine for Evidentia GRC tool"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]

--- a/packages/evidentia-eval/pyproject.toml
+++ b/packages/evidentia-eval/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-eval"
-version = "0.10.15"
+version = "0.10.16"
 description = "DFAH (Decision-Faithfulness Assessment Harness) determinism + faithfulness eval harness for Evidentia — dev-time AI-output quality gates"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -17,7 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/evidentia-integrations/pyproject.toml
+++ b/packages/evidentia-integrations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-integrations"
-version = "0.10.15"
+version = "0.10.16"
 description = "Output integrations for Jira and ServiceNow"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -17,7 +17,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
     "httpx>=0.27",
 ]
 

--- a/packages/evidentia-mcp/pyproject.toml
+++ b/packages/evidentia-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-mcp"
-version = "0.10.15"
+version = "0.10.16"
 description = "Model Context Protocol (MCP) server for Evidentia — exposes gap analysis, risk generation, explanation, and OSCAL emit to MCP-aware AI clients (Claude Desktop, Claude Code, ChatGPT, etc.)"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -17,9 +17,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
-    "evidentia-ai>=0.10.15,<0.11.0",
-    "evidentia-collectors>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-ai>=0.10.16,<0.11.0",
+    "evidentia-collectors>=0.10.16,<0.11.0",
     # MCP Python SDK. Includes FastMCP server scaffolding +
     # protocol types. Floor pinned to 1.27 (the version Evidentia
     # was tested against during v0.8.0 P0.3 development);

--- a/packages/evidentia-ui/openapi.json
+++ b/packages/evidentia-ui/openapi.json
@@ -5930,7 +5930,7 @@
   "info": {
     "description": "REST API for the Evidentia GRC tool. All endpoints mirror CLI capabilities. Binds to 127.0.0.1 by default for localhost web-UI use.",
     "title": "Evidentia API",
-    "version": "0.10.15"
+    "version": "0.10.16"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/packages/evidentia-ui/package.json
+++ b/packages/evidentia-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evidentia/ui",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Evidentia web UI — React + Vite + shadcn/ui frontend served by evidentia-api.",
   "private": true,
   "type": "module",

--- a/packages/evidentia/pyproject.toml
+++ b/packages/evidentia/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia"
-version = "0.10.15"
+version = "0.10.16"
 description = "Open-source GRC tool: gap analysis, risk statements, evidence collection, web UI, and compliance automation"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -17,16 +17,16 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.15,<0.11.0",
-    "evidentia-ai>=0.10.15,<0.11.0",
+    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-ai>=0.10.16,<0.11.0",
     # v0.10.5 P9: DFAH eval harness extracted from evidentia-ai.
     # ``evidentia eval`` CLI verbs live here, so the meta-package
     # depends on evidentia-eval directly (not via the evidentia-ai
     # transitive pin) so the verbs work even when the v0.12.0
     # shim removal eventually trims evidentia-ai's runtime dep.
-    "evidentia-eval>=0.10.15,<0.11.0",
-    "evidentia-collectors>=0.10.15,<0.11.0",
-    "evidentia-integrations>=0.10.15,<0.11.0",
+    "evidentia-eval>=0.10.16,<0.11.0",
+    "evidentia-collectors>=0.10.16,<0.11.0",
+    "evidentia-integrations>=0.10.16,<0.11.0",
     # click 8.2 removed CliRunner's mix_stderr (stderr is now always a separate
     # stream) and typer 0.26 vendors its own click. The test suite and the wiki
     # reference generator (scripts/wiki/sync_reference.py) were updated to match
@@ -42,7 +42,7 @@ dependencies = [
 # Web UI — installs the FastAPI server + bundled React SPA.
 # Usage: `pip install "evidentia[gui]"` or `uv tool install "evidentia[gui]"`,
 # then `evidentia serve` to open the local web UI.
-gui = ["evidentia-api>=0.10.15,<0.11.0"]
+gui = ["evidentia-api>=0.10.16,<0.11.0"]
 # v0.7.12 P0: cloud-backed WORM storage adapters. Each extra
 # pulls in the cloud SDK + maps to the matching evidentia-core
 # extra so the WORM impl module imports cleanly. Operators
@@ -56,7 +56,7 @@ worm-gcs = ["evidentia-core[worm-gcs]>=0.10.0,<0.11.0"]
 # Code, ChatGPT Desktop, custom clients) over stdio.
 # Usage: `pip install "evidentia[mcp]"`, then `evidentia mcp
 # serve`.
-mcp = ["evidentia-mcp>=0.10.15,<0.11.0"]
+mcp = ["evidentia-mcp>=0.10.16,<0.11.0"]
 
 [project.scripts]
 evidentia = "evidentia.cli.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-workspace"
-version = "0.10.15"
+version = "0.10.16"
 requires-python = ">=3.12"
 description = "Workspace root for the Evidentia GRC tool monorepo"
 

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ wheels = [
 
 [[package]]
 name = "evidentia"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia" }
 dependencies = [
     { name = "click" },
@@ -979,7 +979,7 @@ provides-extras = ["gui", "worm-s3", "worm-azure", "worm-gcs", "mcp"]
 
 [[package]]
 name = "evidentia-ai"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-ai" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1007,7 +1007,7 @@ provides-extras = ["eval-faithfulness"]
 
 [[package]]
 name = "evidentia-api"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-api" }
 dependencies = [
     { name = "evidentia-ai" },
@@ -1030,7 +1030,7 @@ requires-dist = [
 
 [[package]]
 name = "evidentia-collectors"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-collectors" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1120,7 +1120,7 @@ provides-extras = ["aws", "github", "okta", "sql-postgres", "sql-mysql", "sql-sq
 
 [[package]]
 name = "evidentia-core"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-core" }
 dependencies = [
     { name = "cryptography" },
@@ -1178,7 +1178,7 @@ provides-extras = ["sigstore", "xlsx", "worm-s3", "worm-azure", "worm-gcs", "ocs
 
 [[package]]
 name = "evidentia-eval"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-eval" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1200,7 +1200,7 @@ provides-extras = ["faithfulness-semantic"]
 
 [[package]]
 name = "evidentia-integrations"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-integrations" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1244,7 +1244,7 @@ provides-extras = ["jira", "servicenow", "tableau", "powerbi", "all"]
 
 [[package]]
 name = "evidentia-mcp"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "packages/evidentia-mcp" }
 dependencies = [
     { name = "evidentia-ai" },
@@ -1263,7 +1263,7 @@ requires-dist = [
 
 [[package]]
 name = "evidentia-workspace"
-version = "0.10.15"
+version = "0.10.16"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
Recovers the v0.10.15 release attempt as **0.10.16**. The 0.10.14 hash fix worked (Build + validate succeeded), but the restructured `publish-pypi` job then failed **pre-upload** with exit 127: its defense-in-depth `uvx twine check` runs on a runner where uv is never installed — the publish jobs' first-ever live execution, since they cannot run in PR CI. **Nothing reached PyPI or ghcr** (the upload step never ran; the container job was skipped). v0.10.15 joins v0.10.14 as an immutable, unpublished ghost tag.

## Fix
- `release.yml` (publish-pypi): add the pinned `astral-sh/setup-uv` step before `Check distributions`, matching the build job, with a comment explaining the first-live-run failure class.
- **Audited every remaining publish-path step for the same class**: publish-container's tools are all action-installed (buildx, cosign-installer) or runner-preinstalled (docker, gunzip, python); the `pypi` environment's deployment policy allowlists `v*` tags (verified via API); permissions + environment bindings correct.
- Version 0.10.15 → 0.10.16 (plain bump); CHANGELOG block renamed `[0.10.16]` with an honest two-ghost note; README/ROADMAP/wiki mirrors regenerated; `uv.lock` synced.

## Verification
Full local gate green: pytest 4680 passed (only the 4 pre-existing environmental collector failures), mypy 286 clean, ruff, frontend 138 vitest + build, version-consistency, docs-health 0 FAIL, `verify-changelog` `[0.10.16]` extractable, workflow-perms strict PASS.