### PR TITLE
Docs(practices): Release-incident lessons 8-9 + ghost-tag recovery runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`docs/engineering-practices.md`** gains lessons 8 (a release pipeline's
+  publish jobs failed on their first live run — twice; the first-live-run audit)
+  and 9 (assurance jobs green while verifying nothing — assert coverage, not
+  exit codes; a gate is not real until observed firing), plus a supply-chain
+  bullet: release pipelines regenerate resolution artifacts from scratch and run
+  cache-free. **`docs/runbooks/release-rollback.md`** gains the
+  nothing-published "ghost tag" recovery case (verify-nothing-shipped → never
+  weaken the tag ruleset → re-release as the next patch → record the ghost
+  honestly). Distilled from the v0.10.14/v0.10.15 unpublished-tag incident.
+
 ## [0.10.16] - 2026-07-02
 
 **Theme**: *Engineering hardening + distroless container base — never ship a failed test again.* Bundles the accumulated supply-chain work into one release: cryptography-native DSSE/in-toto air-gap signing, the atomic (validate-before-publish) release pipeline, and the migration of the published container onto a distroless **Docker Hardened Images** base (nonroot uid 65532; no shell, `curl`, or `gpg`). No package API changes. (The 0.10.14 and 0.10.15 tags were created but never published — in both cases the atomic release's validate-before-publish design stopped anything from shipping. 0.10.14's build caught a non-reproducible container-requirements-hash issue; 0.10.15 fixed that, built and validated everything, then failed pre-upload on a missing `uv` install in the restructured publish job's `twine check` — the publish jobs' first-ever live execution, since they cannot run in PR CI. 0.10.16 is the same release content plus both pipeline fixes.)

--- a/docs/engineering-practices.md
+++ b/docs/engineering-practices.md
@@ -90,6 +90,15 @@ Evidentia's releases are designed to be independently verifiable end to end:
   `dhi.io/python:3.13` (Docker Hardened Images) runtime carries only that venv as
   nonroot uid 65532 — no shell, package manager, `curl`, or `gpg` binary. Both base
   images are digest-pinned.
+- **Release pipelines regenerate, never reuse.** The container's hash-pinned
+  closure is regenerated from scratch inside the release run, against the exact
+  wheels the run just built — an existing resolution output is never trusted
+  (`pip-compile` silently reuses a prior output file's pins and hashes; see
+  lesson 8), and the committed copy of that file is a lagging preview for
+  inspection, never an input to a release. The publish path also runs
+  **cache-free**: a PR-writable Actions cache read inside an artifact-producing
+  job is a cache-poisoning vector, so the release builds every layer and
+  toolchain from source-of-truth references.
 - **Vulnerability scanning** runs `osv-scanner` against the resolved dependency
   closure — including the container's independently-resolved closure — on every
   pull request, surfacing transitive and disputed advisories the standard alert
@@ -344,6 +353,48 @@ lockfile, synced with identical flags *including the optional extras*
 `nox`/`tox` session or a one-command bootstrap) that both the pre-push hook and
 the CI job invoke, with a `uv lock --check` gate keeping the lockfile itself
 honest, so "passes locally" and "passes in CI" cannot mean two different things.
+
+**8. A release pipeline's publish jobs failed on their first live run — twice.**
+The atomic-release restructure moved publishing into jobs that *cannot execute in
+pull-request CI* — so the first release tag after the change was also their first
+execution, on an irreversible trigger. Two consecutive tags failed inside that
+never-exercised surface: first a hash mismatch (the release's dependency
+resolution *reused* a committed preview file's pins and hashes — `pip-compile`
+silently reuses an existing output file — and that preview carried
+locally-built wheel hashes at the same version, which cannot match the CI-built
+wheels because wheel builds are not byte-reproducible across platforms), then an
+exit-127 (a verification step invoked a tool the job never installs). Both times
+the validate-before-publish gate stopped the run with **nothing published** — the
+two burned tags remain as signed, immutable, unpublished "ghost" tags, which is
+the accepted cost of an append-only tag ruleset, not a defect. *Root cause:* code
+that only runs on an irreversible trigger was reviewed by diff but never executed
+or simulated. *Prevention:* a **first-live-run audit** whenever the release
+workflow changes — walk every post-build step in execution order and verify each
+shell command's tool is installed *in that job* (or runner-preinstalled), each
+pinned action's inputs and outputs against the action's schema *at the pinned
+commit*, artifact names and paths across the job graph, that environment
+deployment policies admit tag refs, and that the publish path runs cache-free
+and regenerates every resolution artifact from scratch rather than trusting a
+committed preview.
+
+**9. Assurance jobs were green while verifying nothing.** Two post-publish
+assurance workflows installed package *extras that do not exist* — `pip` emits a
+warning for an unknown extra and exits 0 — so for weeks the scheduled
+published-closure rescan scanned an incomplete dependency closure, missing the
+API server package entirely. The same latent bug sat in the post-publish smoke
+workflow's "verify every published package resolves" step — but that step turned
+out *never to have run at all*: the smoke workflow triggers on the Release
+event, and a Release created by the release workflow's default `GITHUB_TOKEN`
+never fires other workflows (GitHub's anti-recursion rule) — a structurally dead
+trigger that looked wired, with zero runs in the workflow's lifetime. *Root
+cause:* gates were trusted for their exit codes and their wiring, not for
+observed behavior. *Prevention:* **assert coverage, not exit codes** — an
+assurance step carries a post-condition that proves its claim (import checks,
+`pip show` per expected package, names validated against the package manifest);
+and **a gate is not real until it has been observed firing** — a workflow whose
+trigger has never produced a run is a dead gate (the never-fired generalization
+of lesson 2's silently-died gate), detectable mechanically from the workflow-runs
+API.
 
 ---
 

--- a/docs/runbooks/release-rollback.md
+++ b/docs/runbooks/release-rollback.md
@@ -197,6 +197,39 @@ reaction wired into the pipeline. Do not add an auto-yank step; it would
 fire only on conditions that cannot occur (a published-but-smoke-failed
 release) and would risk yanking a good release on a flaky check.
 
+### The nothing-published case: ghost tags (the atomic gate fired)
+
+The best failure this runbook covers is the one with **zero public
+blast radius**: the tag was pushed, `release.yml` fired, and the run
+failed *before* the irreversible publish — the validate-before-publish
+design working as intended (observed live: v0.10.14 failed in build
+validation, v0.10.15 failed pre-upload; neither put a byte on PyPI or
+GHCR).
+
+What remains is a **ghost tag**: a signed, immutable tag whose version
+slot is consumed but which published nothing. Recovery:
+
+1. **Verify nothing actually published** before anything else:
+   `pip index versions evidentia` / the PyPI JSON API (the version must
+   be absent), `docker manifest inspect ghcr.io/...:v<X.Y.Z>` (must
+   404), and `gh release view v<X.Y.Z>` (must not exist).
+2. **Do not try to delete or move the tag.** The `Protect release tags
+   (v*)` ruleset (deletion + non-fast-forward blocked, empty bypass
+   list) makes the tag permanent *by design* — the append-only tag
+   history is the provenance property being protected, and a burned
+   patch number is its accepted, cheap cost. Do not weaken the ruleset
+   to "clean up."
+3. **Root-cause on a branch, then re-release as the next patch
+   number** — normal PR flow, then a fresh tag. If the release workflow
+   itself changed, run the first-live-run audit (engineering-practices
+   lesson 8) before the new tag: publish jobs are unreachable in PR CI,
+   so re-tagging is their next first execution.
+4. **Record the ghost honestly**: the shipped release's CHANGELOG block
+   names the ghost tag(s) and why the gate stopped them (see the
+   0.10.16 entry) — a burned number with a one-line explanation reads
+   as the safety system working; an unexplained gap reads as history
+   editing.
+
 ---
 
 ## 4. PyPI yank + ship-a-patch (the standard ladder, detailed)

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`docs/engineering-practices.md`** gains lessons 8 (a release pipeline's
+  publish jobs failed on their first live run — twice; the first-live-run audit)
+  and 9 (assurance jobs green while verifying nothing — assert coverage, not
+  exit codes; a gate is not real until observed firing), plus a supply-chain
+  bullet: release pipelines regenerate resolution artifacts from scratch and run
+  cache-free. **`docs/runbooks/release-rollback.md`** gains the
+  nothing-published "ghost tag" recovery case (verify-nothing-shipped → never
+  weaken the tag ruleset → re-release as the next patch → record the ghost
+  honestly). Distilled from the v0.10.14/v0.10.15 unpublished-tag incident.
+
 ## [0.10.16] - 2026-07-02
 
 **Theme**: *Engineering hardening + distroless container base — never ship a failed test again.* Bundles the accumulated supply-chain work into one release: cryptography-native DSSE/in-toto air-gap signing, the atomic (validate-before-publish) release pipeline, and the migration of the published container onto a distroless **Docker Hardened Images** base (nonroot uid 65532; no shell, `curl`, or `gpg`). No package API changes. (The 0.10.14 and 0.10.15 tags were created but never published — in both cases the atomic release's validate-before-publish design stopped anything from shipping. 0.10.14's build caught a non-reproducible container-requirements-hash issue; 0.10.15 fixed that, built and validated everything, then failed pre-upload on a missing `uv` install in the restructured publish job's `twine check` — the publish jobs' first-ever live execution, since they cannot run in PR CI. 0.10.16 is the same release content plus both pipeline fixes.)


### PR DESCRIPTION
Distills the v0.10.14/v0.10.15 unpublished-tag incident into the public doctrine (both tags were stopped by the atomic validate-before-publish gate with nothing published — the safety system's live proof):

- **engineering-practices lesson 8** — publish jobs are structurally unreachable in PR CI; a release-workflow change makes the next tag their first live execution → the **first-live-run audit** (per-job tool availability, action schemas verified at the pinned SHA, artifact handoffs, environment tag policies, cache-free + regenerate-from-scratch).
- **engineering-practices lesson 9** — assurance jobs green while verifying nothing (nonexistent pip extras silently skipped by the rescan; a `release:` trigger that can never fire from a GITHUB_TOKEN-created Release — zero runs ever) → **assert coverage, not exit codes**; **a gate is not real until observed firing**.
- **Supply-chain integrity** — new bullet: release pipelines regenerate resolution artifacts from scratch and run cache-free.
- **release-rollback runbook** — the nothing-published **ghost tag** recovery case (verify nothing shipped → never weaken the tag ruleset → re-release as next patch → record the ghost honestly).

Docs-only; no code or workflow changes. Reviewed by a 2-lens adversarial accuracy pass (1 misattribution + 1 antecedent fix folded in). docs-health --strict 0 FAIL; mirrors synced.