### PR TITLE
Feat(ci): Workflow tool-availability + extras-validity checker (G8+G9)

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -276,6 +276,7 @@ jobs:
       - name: osv-scan regenerated container requirements
         if: steps.relevant.outputs.relevant == 'true'
         run: |
+          # tool-check: ok osv-scanner  (installed by the prior curl step "Install osv-scanner" in this job)
           osv-scanner scan source \
             --config osv-scanner.toml \
             --lockfile docker/requirements.txt

--- a/.github/workflows/post-publish-rescan.yml
+++ b/.github/workflows/post-publish-rescan.yml
@@ -204,6 +204,7 @@ jobs:
           set -euo pipefail
           echo "Scanning ${IMAGE} (OS + language advisories) -> rescan.json ..."
           rc=0
+          # tool-check: ok osv-scanner  (installed by the prior curl step "Install osv-scanner" in this job)
           osv-scanner scan image \
             --config=osv-scanner.toml \
             --format json \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,7 @@ jobs:
       # osv-scanner.toml allowlist as everywhere else.
       - name: osv-scan regenerated container requirements
         run: |
+          # tool-check: ok osv-scanner  (installed by the prior curl step "Install osv-scanner" in this job)
           osv-scanner scan source \
             --config osv-scanner.toml \
             --lockfile docker/requirements.txt

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -54,9 +54,12 @@ jobs:
           echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  /tmp/gitleaks.tar.gz" | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          # tool-check: ok gitleaks  (just installed to /usr/local/bin by the sudo mv above, this same step)
           gitleaks version
 
       - name: Run gitleaks (scan git history)
         # --redact: never echo a matched secret to the log.
         # Exit 1 on any un-allowlisted finding fails the job.
-        run: gitleaks git . --config .gitleaks.toml --redact --no-banner
+        run: |
+          # tool-check: ok gitleaks  (installed by the prior "Install gitleaks" step in this job)
+          gitleaks git . --config .gitleaks.toml --redact --no-banner

--- a/.github/workflows/verify-workflow-perms.yml
+++ b/.github/workflows/verify-workflow-perms.yml
@@ -60,3 +60,29 @@ jobs:
 
       - name: Audit workflow permissions (--strict)
         run: uv run --no-sync python scripts/audit_workflow_permissions.py --strict
+
+  # G8+G9 (engineering-practices lessons 8-9): every run: command must be
+  # provided by that job's own uses: steps or the runner image, and every
+  # workspace-package install-spec may only name declared extras. Same
+  # checker pattern as audit-permissions above.
+  check-workflow-tools:
+    name: Check workflow tools (strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Check workflow tools + extras (--strict)
+        run: uv run --no-sync python scripts/check_workflow_tools.py --strict

--- a/scripts/check_workflow_tools.py
+++ b/scripts/check_workflow_tools.py
@@ -43,9 +43,12 @@ Exit codes (mirrors the precedent):
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
+import sys
 import tomllib
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import yaml
@@ -350,3 +353,38 @@ def check_workflow_extras(
                             )
                         )
     return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 2 if any finding (incl. parse errors); default is advisory",
+    )
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    args = ap.parse_args(argv)
+
+    extras_by_pkg = collect_workspace_extras(workspace_manifests())
+    paths = sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml"))
+    findings: list[Finding] = []
+    for path in paths:
+        findings.extend(check_workflow_tools(path))
+        findings.extend(check_workflow_extras(path, extras_by_pkg))
+
+    if args.as_json:
+        print(json.dumps({"findings": [asdict(f) for f in findings]}, indent=2))
+    else:
+        for f in findings:
+            print(f"{f.kind:13} {f.workflow} :: {f.job} :: {f.step} :: {f.detail}")
+        print(
+            f"check_workflow_tools: {len(findings)} finding(s) across "
+            f"{len(paths)} workflow file(s)"
+        )
+    if findings and args.strict:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_workflow_tools.py
+++ b/scripts/check_workflow_tools.py
@@ -44,7 +44,10 @@ Exit codes (mirrors the precedent):
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
 
 REPO_ROOT = Path(__file__).parent.parent
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
@@ -213,3 +216,66 @@ def extract_commands(script: str) -> list[str]:
                 continue
             tokens.append(first)
     return tokens
+
+
+@dataclass
+class Finding:
+    workflow: str
+    job: str
+    step: str
+    kind: str  # "missing-tool" | "unknown-extra" | "parse-error"
+    detail: str
+
+
+def _load_workflow(path: Path) -> dict | Finding:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        return Finding(path.name, "-", "-", "parse-error", str(exc))
+    if not isinstance(data, dict):
+        return Finding(path.name, "-", "-", "parse-error", "top-level not a YAML mapping")
+    return data
+
+
+def check_workflow_tools(path: Path) -> list[Finding]:
+    """G8: per-job, every run-block command must be provided/allowed/waived."""
+    data = _load_workflow(path)
+    if isinstance(data, Finding):
+        return [data]
+    findings: list[Finding] = []
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        return findings
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict) or "steps" not in job:
+            # Reusable-workflow call jobs (job-level `uses:`) — out of scope v1.
+            continue
+        available = set(RUNNER_PREINSTALLED)
+        steps = job.get("steps") or []
+        for idx, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            uses = step.get("uses")
+            if isinstance(uses, str):
+                available |= ACTION_TOOLS.get(uses.split("@", 1)[0], set())
+                continue
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            waived = {m.group("cmd") for m in WAIVER_RE.finditer(run)}
+            step_name = str(step.get("name", f"step[{idx}]"))
+            for cmd in extract_commands(run):
+                if cmd in available or cmd in waived:
+                    continue
+                findings.append(
+                    Finding(
+                        path.name,
+                        str(job_id),
+                        step_name,
+                        "missing-tool",
+                        f"`{cmd}` is not provided by an earlier `uses:` step in "
+                        f"job `{job_id}`, not runner-preinstalled, and not "
+                        f"waived (`# tool-check: ok {cmd}`)",
+                    )
+                )
+    return findings

--- a/scripts/check_workflow_tools.py
+++ b/scripts/check_workflow_tools.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""G8 tool-availability + G9 extras-validity checker for GitHub workflows.
+
+Mechanizes engineering-practices lessons 8-9 (the v0.10.15 exit-127 ghost tag
+and the nonexistent-[ai,api,collectors] silent-skip incident):
+
+G8 — for every job in every TOP-LEVEL workflow, each command invoked in a
+``run:`` block must be (i) provided by an earlier ``uses:`` step in the SAME
+job (committed ACTION_TOOLS map), (ii) on the committed RUNNER_PREINSTALLED
+allowlist, (iii) a shell keyword/builtin, or (iv) waived by an inline
+``# tool-check: ok <cmd>`` comment inside that ``run:`` block. Waivers are for
+VERIFIED false-positives only (e.g. a tool installed by a prior ``run:`` step);
+a genuinely missing setup step is a workflow bug — fix it, never waive it.
+
+G9 — any install-spec ``<pkg>[<extras>]`` in a ``run:`` block whose ``<pkg>``
+is a WORKSPACE package must only name extras declared in that package's
+pyproject manifest (pip warns and exits 0 on a nonexistent extra — verified
+live 2026-07-02 — so nothing downstream catches it). Third-party specs like
+``psycopg[binary]`` are ignored: their extras are not in workspace manifests.
+
+SCOPE (v1, honest limits):
+- Top-level ``.github/workflows/*.yml`` only; composite actions and reusable
+  workflows are OUT of scope.
+- RUNNER_PREINSTALLED approximates ubuntu-latest; cross-OS matrix jobs share it.
+- Extraction is a QUOTE-AWARE first-token heuristic: quoted-string content is
+  masked (with cross-line state, so multi-line ``python -c "..."`` bodies are
+  opaque) before operator splitting; heredoc bodies and ``case``…``esac``
+  bodies are skipped; ``VAR=value`` prefixes are stripped; line-leading
+  ``$(...)`` unwraps one level; backslash continuations fold. Tools invoked
+  via variables/paths (``$X``, ``./x``, ``/usr/bin/x``) and commands inside
+  mid-line substitutions or case arms are skipped — a disclosed
+  false-NEGATIVE surface, accepted for v1. A literal ``<<`` inside a string
+  can false-trigger heredoc skipping (disclosed; none in this repo today).
+
+Dependency note: PyYAML (an existing dev dependency, same as the
+``audit_workflow_permissions.py`` precedent) + stdlib ``tomllib``. Zero NEW
+third-party dependencies.
+
+Exit codes (mirrors the precedent):
+    0 — clean, or advisory mode (no ``--strict``)
+    2 — findings (including parse errors) under ``--strict``
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+# Committed action -> provided-tools map. Keyed on the action name WITHOUT the
+# version ref. Owned like osv-scanner.toml's allowlist: PR-reviewed, commented.
+# Unknown actions contribute nothing (never a finding by themselves).
+ACTION_TOOLS: dict[str, set[str]] = {
+    "astral-sh/setup-uv": {"uv", "uvx"},
+    "actions/setup-python": {"python", "python3", "pip", "pip3"},
+    "actions/setup-node": {"node", "npm", "npx"},
+    "sigstore/cosign-installer": {"cosign"},
+    # docker/* setup actions provide no CLI beyond the preinstalled `docker`.
+}
+
+# ubuntu-latest preinstalled approximation — the honest 20% that catches the
+# 80%. Deliberately conservative; extend only with a comment naming the need.
+RUNNER_PREINSTALLED: set[str] = {
+    "awk", "basename", "bash", "cat", "chmod", "cp", "curl", "cut", "date",
+    "df", "dirname", "docker", "du", "env", "find", "gh", "git", "grep",
+    "gunzip", "gzip", "head", "jq", "ls", "mkdir", "mv", "node", "npm",
+    "npx", "pip", "pip3", "python", "python3", "rm", "sed", "sh",
+    "sha256sum", "sleep", "sort", "tail", "tar", "tee", "touch", "tr",
+    "uniq", "unzip", "wc", "wget", "which", "xargs", "zip",
+}
+
+# Wrapper tokens: strip and keep parsing the remainder of the statement.
+_WRAPPER_TOKENS: set[str] = {
+    "sudo", "command", "nohup", "exec", "time", "if", "until", "while",
+    "then", "else", "elif", "do", "!",
+}
+
+# Terminal keywords/builtins: the statement is satisfied — skip it.
+SHELL_BUILTINS: set[str] = {
+    ".", ":", "[", "[[", "break", "continue", "cd", "declare", "done",
+    "echo", "esac", "eval", "exit", "export", "false", "fi", "for",
+    "function", "hash", "in", "let", "local", "popd", "printf", "pushd",
+    "read", "readonly", "return", "select", "set", "shift", "source",
+    "test", "trap", "true", "type", "ulimit", "umask", "unset", "wait",
+}
+
+WAIVER_RE = re.compile(r"#\s*tool-check:\s*ok\s+(?P<cmd>[\w.+-]+)")
+_STMT_SPLIT_RE = re.compile(r"&&|\|\||\||;")
+_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?")
+_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=(?P<rest>.*)$", re.DOTALL)
+_REDIRECT_RE = re.compile(r"^\d*[<>]")
+_COMMENT_SPLIT_RE = re.compile(r"(?:^|\s)#")
+
+
+def _mask_line(line: str, state: str) -> tuple[str, str]:
+    """Mask quoted-string CONTENT on one line with spaces, threading quote
+    state ('' / \"'\" / '\"') across lines so multi-line strings (python -c
+    bodies) stay opaque. Quote characters themselves are preserved.
+    POSIX-ish: no escapes inside single quotes; backslash escapes inside
+    double quotes and in bare context."""
+    out: list[str] = []
+    escaped = False
+    for ch in line:
+        if state == "'":
+            if ch == "'":
+                state = ""
+                out.append(ch)
+            else:
+                out.append(" ")
+        elif state == '"':
+            if escaped:
+                escaped = False
+                out.append(" ")
+            elif ch == "\\":
+                escaped = True
+                out.append(" ")
+            elif ch == '"':
+                state = ""
+                out.append(ch)
+            else:
+                out.append(" ")
+        else:
+            if escaped:
+                escaped = False
+                out.append(ch)
+            elif ch == "\\":
+                escaped = True
+                out.append(ch)
+            elif ch == "'":
+                state = "'"
+                out.append(ch)
+            elif ch == '"':
+                state = '"'
+                out.append(ch)
+            else:
+                out.append(ch)
+    return "".join(out), state
+
+
+def extract_commands(script: str) -> list[str]:
+    """Quote-aware first-token command candidates from a run: block."""
+    tokens: list[str] = []
+    pending_heredocs: list[str] = []
+    continuation = False
+    in_case = False
+    quote_state = ""
+    for raw in script.splitlines():
+        if pending_heredocs:
+            if raw.strip() == pending_heredocs[0]:
+                pending_heredocs.pop(0)
+            continue
+        masked, quote_state = _mask_line(raw, quote_state)
+        if continuation:
+            continuation = masked.rstrip().endswith("\\")
+            continue
+        line = masked.strip()
+        if not line or line.startswith("#"):
+            continue
+        if in_case:
+            if re.search(r"\besac\b", line):
+                in_case = False
+            continue
+        # Heredoc openers are detected on the RAW line — a quoted terminator
+        # (<<'STANZA') is masked in `masked` and would be missed there.
+        for m in _HEREDOC_RE.finditer(raw):
+            pending_heredocs.append(m.group(1))
+        continuation = line.endswith("\\")
+        # Truncate any trailing comment (safe post-masking: a '#' inside a
+        # string has been masked away).
+        line = _COMMENT_SPLIT_RE.split(line, maxsplit=1)[0].strip()
+        if not line:
+            continue
+        for stmt in _STMT_SPLIT_RE.split(line):
+            stmt = stmt.strip()
+            m = _ASSIGN_RE.match(stmt)
+            if m:
+                rest = m.group("rest").strip()
+                if not rest or rest.startswith(("'", '"')) or rest.startswith("$(("):
+                    continue
+                if rest.startswith("$("):
+                    stmt = rest[2:].strip()
+                else:
+                    parts = rest.split(None, 1)
+                    if len(parts) < 2:
+                        continue
+                    stmt = parts[1].strip()
+            if stmt.startswith("$(("):
+                continue
+            if stmt.startswith("$("):
+                stmt = stmt[2:].strip()
+            while stmt:
+                first = stmt.split()[0].strip("\"'()").rstrip(";")
+                if first in _WRAPPER_TOKENS:
+                    parts = stmt.split(None, 1)
+                    stmt = parts[1].strip() if len(parts) > 1 else ""
+                    continue
+                break
+            if not stmt:
+                continue
+            first = stmt.split()[0].strip("\"'()").rstrip(";")
+            if not first or first.startswith(("$", "-", "&")):
+                continue
+            if _REDIRECT_RE.match(first):
+                continue
+            if "/" in first or "=" in first:
+                continue
+            if first == "case":
+                in_case = True
+                break
+            if first in SHELL_BUILTINS:
+                continue
+            tokens.append(first)
+    return tokens

--- a/scripts/check_workflow_tools.py
+++ b/scripts/check_workflow_tools.py
@@ -85,12 +85,16 @@ _WRAPPER_TOKENS: set[str] = {
 }
 
 # Terminal keywords/builtins: the statement is satisfied — skip it.
+# ``{`` / ``}`` are brace-group compound-command delimiters (``{ cmd; } >> f``),
+# not external commands — a first token of ``{`` or ``}`` is shell grouping, never
+# a tool invocation (real in base-freshness.yml / stale-branches.yml).
 SHELL_BUILTINS: set[str] = {
     ".", ":", "[", "[[", "break", "continue", "cd", "declare", "done",
     "echo", "esac", "eval", "exit", "export", "false", "fi", "for",
     "function", "hash", "in", "let", "local", "popd", "printf", "pushd",
     "read", "readonly", "return", "select", "set", "shift", "source",
     "test", "trap", "true", "type", "ulimit", "umask", "unset", "wait",
+    "{", "}",
 }
 
 WAIVER_RE = re.compile(r"#\s*tool-check:\s*ok\s+(?P<cmd>[\w.+-]+)")
@@ -106,16 +110,25 @@ def _mask_line(line: str, state: str) -> tuple[str, str]:
     state ('' / \"'\" / '\"') across lines so multi-line strings (python -c
     bodies) stay opaque. Quote characters themselves are preserved.
     POSIX-ish: no escapes inside single quotes; backslash escapes inside
-    double quotes and in bare context."""
+    double quotes and in bare context.
+
+    An unquoted ``#`` at a word boundary (line start or after whitespace)
+    begins a shell comment: the rest of the line is copied verbatim and does
+    NOT mutate quote state. Without this, an apostrophe in a prose comment
+    (``can't``, ``package's``) would spuriously open single-quote state that
+    leaks across lines and desyncs the masking of every command below it —
+    the root cause of the ``%s`` / ``s`` / ``evidentia`` fragment noise."""
     out: list[str] = []
     escaped = False
-    for ch in line:
+    prev_ws = True  # line start counts as a word boundary
+    for i, ch in enumerate(line):
         if state == "'":
             if ch == "'":
                 state = ""
                 out.append(ch)
             else:
                 out.append(" ")
+            prev_ws = False
         elif state == '"':
             if escaped:
                 escaped = False
@@ -128,21 +141,32 @@ def _mask_line(line: str, state: str) -> tuple[str, str]:
                 out.append(ch)
             else:
                 out.append(" ")
+            prev_ws = False
         else:
             if escaped:
                 escaped = False
                 out.append(ch)
+                prev_ws = False
             elif ch == "\\":
                 escaped = True
                 out.append(ch)
+                prev_ws = False
+            elif ch == "#" and prev_ws:
+                # Word-boundary '#' → comment; copy the tail verbatim and stop
+                # (a comment cannot open a cross-line string).
+                out.append(line[i:])
+                break
             elif ch == "'":
                 state = "'"
                 out.append(ch)
+                prev_ws = False
             elif ch == '"':
                 state = '"'
                 out.append(ch)
+                prev_ws = False
             else:
                 out.append(ch)
+                prev_ws = ch.isspace()
     return "".join(out), state
 
 

--- a/scripts/check_workflow_tools.py
+++ b/scripts/check_workflow_tools.py
@@ -44,6 +44,7 @@ Exit codes (mirrors the precedent):
 from __future__ import annotations
 
 import re
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -278,4 +279,74 @@ def check_workflow_tools(path: Path) -> list[Finding]:
                         f"waived (`# tool-check: ok {cmd}`)",
                     )
                 )
+    return findings
+
+
+_INSTALL_SPEC_RE = re.compile(
+    r"(?P<pkg>[A-Za-z0-9][A-Za-z0-9._-]*)\[(?P<extras>[A-Za-z0-9_,\s-]+)\]"
+)
+
+
+def _normalize(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def workspace_manifests() -> list[Path]:
+    """Root pyproject + every packages/*/pyproject.toml that exists."""
+    candidates = [REPO_ROOT / "pyproject.toml"]
+    candidates += sorted((REPO_ROOT / "packages").glob("*/pyproject.toml"))
+    return [p for p in candidates if p.is_file()]
+
+
+def collect_workspace_extras(manifests: list[Path]) -> dict[str, set[str]]:
+    extras_by_pkg: dict[str, set[str]] = {}
+    for manifest in manifests:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        project = data.get("project")
+        if not isinstance(project, dict) or "name" not in project:
+            continue
+        extras = project.get("optional-dependencies", {})
+        extras_by_pkg[_normalize(str(project["name"]))] = {
+            _normalize(e) for e in extras
+        }
+    return extras_by_pkg
+
+
+def check_workflow_extras(
+    path: Path, extras_by_pkg: dict[str, set[str]]
+) -> list[Finding]:
+    """G9: workspace-package install-specs may only name declared extras."""
+    data = _load_workflow(path)
+    if isinstance(data, Finding):
+        return []  # the parse error is already reported by the G8 pass
+    findings: list[Finding] = []
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        return findings
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for idx, step in enumerate(job.get("steps") or []):
+            if not isinstance(step, dict) or not isinstance(step.get("run"), str):
+                continue
+            step_name = str(step.get("name", f"step[{idx}]"))
+            for m in _INSTALL_SPEC_RE.finditer(step["run"]):
+                pkg = _normalize(m.group("pkg"))
+                if pkg not in extras_by_pkg:
+                    continue  # third-party spec (or shell noise) — out of scope
+                declared = extras_by_pkg[pkg]
+                for extra in m.group("extras").split(","):
+                    if _normalize(extra) not in declared:
+                        findings.append(
+                            Finding(
+                                path.name,
+                                str(job_id),
+                                step_name,
+                                "unknown-extra",
+                                f"`{extra.strip()}` is not a declared extra of "
+                                f"workspace package `{pkg}` (declared: "
+                                f"{sorted(declared)}); pip silently skips "
+                                f"unknown extras (exit 0)",
+                            )
+                        )
     return findings

--- a/tests/unit/test_check_workflow_tools.py
+++ b/tests/unit/test_check_workflow_tools.py
@@ -1,0 +1,150 @@
+"""Tests for ``scripts/check_workflow_tools.py`` (G8 tool-availability +
+G9 extras-validity; engineering-practices lessons 8-9).
+
+Mirrors the ``test_audit_workflow_permissions.py`` precedent: the script is
+loaded via ``importlib`` (scripts/ has no ``__init__.py``), and every test
+uses ``tmp_path`` fixtures — never the repo's real workflows — so the unit
+tests stay independent of workflow churn. The repo-tree run happens in CI
+via ``verify-workflow-perms.yml``, not here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_workflow_tools.py"
+
+
+@pytest.fixture(scope="module")
+def cwt() -> Any:
+    spec = importlib.util.spec_from_file_location("check_workflow_tools", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_workflow_tools"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# extract_commands — the quote-aware first-token heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_simple_commands_and_operators(cwt: Any) -> None:
+    script = "uv sync --all-packages\ndocker pull foo && cosign verify bar | jq .\n"
+    assert cwt.extract_commands(script) == ["uv", "docker", "cosign", "jq"]
+
+
+def test_comments_and_blank_lines_skipped(cwt: Any) -> None:
+    script = "# a comment\n\nuvx twine check dist/*\n"
+    assert cwt.extract_commands(script) == ["uvx"]
+
+
+def test_env_prefix_assignment_unwraps_command(cwt: Any) -> None:
+    assert cwt.extract_commands("FOO=bar uv run pytest\n") == ["uv"]
+
+
+def test_plain_quoted_assignment_is_not_a_command(cwt: Any) -> None:
+    assert cwt.extract_commands('VERSION="${REF#v}"\n') == []
+
+
+def test_command_substitution_assignment_unwraps(cwt: Any) -> None:
+    script = 'pinned=$(grep -oE "x" Dockerfile || true)\n'
+    assert cwt.extract_commands(script) == ["grep"]
+
+
+def test_arithmetic_assignment_skipped(cwt: Any) -> None:
+    script = "age_days=$(( ( $(date -u +%s) - 5 ) / 86400 ))\n"
+    assert cwt.extract_commands(script) == []
+
+
+def test_heredoc_body_skipped(cwt: Any) -> None:
+    # `echo` is a shell builtin -> filtered; the heredoc BODY must not leak
+    # a phantom `not-a-command` token.
+    script = "cat >> out.md <<'STANZA'\nnot-a-command --flag\nSTANZA\necho done\n"
+    assert cwt.extract_commands(script) == ["cat"]
+
+
+def test_backslash_continuation_folds(cwt: Any) -> None:
+    script = "curl -sSfL https://example.com \\\n  -o out.bin\nchmod +x out.bin\n"
+    assert cwt.extract_commands(script) == ["curl", "chmod"]
+
+
+def test_control_keywords_unwrapped_and_terminals_skipped(cwt: Any) -> None:
+    script = (
+        "if ! printf '%s' \"$REF\" | grep -Eq 'x'; then\n"
+        "  exit 1\n"
+        "fi\n"
+        "until docker run --rm img; do\n"
+        "  sleep 15\n"
+        "done\n"
+        "for i in $(seq 1 30); do\n"
+        "  true\n"
+        "done\n"
+    )
+    got = cwt.extract_commands(script)
+    # printf/exit/true are builtins -> filtered; grep/docker/sleep are real
+    # commands unwrapped from `if !` / `until` wrappers.
+    assert "grep" in got and "docker" in got and "sleep" in got
+    assert "printf" not in got
+    assert "for" not in got and "fi" not in got and "done" not in got and "i" not in got
+
+
+def test_sudo_and_wrappers_unwrapped(cwt: Any) -> None:
+    assert cwt.extract_commands("sudo docker prune\n") == ["docker"]
+
+
+def test_variable_and_path_invocations_skipped(cwt: Any) -> None:
+    script = '"$HOME/.local/bin/osv-scanner" scan\n/tmp/venv/bin/pip install x\n./local-script.sh\n'
+    assert cwt.extract_commands(script) == []
+
+
+def test_redirect_only_tokens_skipped(cwt: Any) -> None:
+    assert cwt.extract_commands("uv run x 2>/dev/null\n") == ["uv"]
+
+
+# --- quote-masking regressions (the classes that false-positived on the
+# --- real tree during plan verification: semicolons/pipes INSIDE strings,
+# --- multi-line python -c bodies, case arms, quoted jq/sed programs) -------
+
+
+def test_semicolon_inside_quotes_not_split(cwt: Any) -> None:
+    script = 'gh issue create --title "No liveness findings; nothing to do."\n'
+    assert cwt.extract_commands(script) == ["gh"]
+
+
+def test_multiline_python_c_body_is_opaque(cwt: Any) -> None:
+    script = (
+        'python -c "\n'
+        "import zipfile, glob, sys\n"
+        "wheels = [p for p in glob.glob('dist/*.whl')]\n"
+        "assert wheels, f'none: {wheels}'\n"
+        '"\n'
+        "uv sync\n"
+    )
+    assert cwt.extract_commands(script) == ["python", "uv"]
+
+
+def test_case_arms_skipped_until_esac(cwt: Any) -> None:
+    script = (
+        'case "$GITHUB_EVENT_NAME" in\n'
+        "  pull_request|merge_group) echo pr ;;\n"
+        "  *) echo other ;;\n"
+        "esac\n"
+        "docker ps\n"
+    )
+    assert cwt.extract_commands(script) == ["docker"]
+
+
+def test_single_quoted_program_bodies_opaque(cwt: Any) -> None:
+    script = (
+        "gh api x -q '.[0].number; select(.title)'\n"
+        'sed -i "s|__TAG__|v1|g; s|__D__|abc|g" file.md\n'
+    )
+    assert cwt.extract_commands(script) == ["gh", "sed"]

--- a/tests/unit/test_check_workflow_tools.py
+++ b/tests/unit/test_check_workflow_tools.py
@@ -292,3 +292,56 @@ def test_unknown_extras_flagged_known_and_thirdparty_pass(cwt: Any, tmp_path: Pa
 
 def test_normalization_underscore_dash_case(cwt: Any) -> None:
     assert cwt._normalize("Evidentia_Core") == "evidentia-core"
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes (monkeypatch WORKFLOWS_DIR + workspace manifests like the
+# audit_workflow_permissions precedent)
+# ---------------------------------------------------------------------------
+
+
+def _patch_tree(cwt: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    monkeypatch.setattr(cwt, "WORKFLOWS_DIR", wf_dir)
+    manifest = _write(tmp_path, "pyproject.toml", PYPROJECT_META)
+    monkeypatch.setattr(cwt, "workspace_manifests", lambda: [manifest])
+
+
+def test_strict_exit_2_on_finding(
+    cwt: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_tree(cwt, monkeypatch, tmp_path)
+    _write(tmp_path / "workflows", "missing.yml", WF_MISSING)
+    assert cwt.main(["--strict"]) == 2
+
+
+def test_strict_exit_0_when_clean(
+    cwt: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_tree(cwt, monkeypatch, tmp_path)
+    _write(tmp_path / "workflows", "ok.yml", WF_OK)
+    assert cwt.main(["--strict"]) == 0
+
+
+def test_advisory_exit_0_despite_finding(
+    cwt: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _patch_tree(cwt, monkeypatch, tmp_path)
+    _write(tmp_path / "workflows", "missing.yml", WF_MISSING)
+    assert cwt.main([]) == 0
+
+
+def test_json_output_shape(
+    cwt: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json as _json
+
+    _patch_tree(cwt, monkeypatch, tmp_path)
+    _write(tmp_path / "workflows", "missing.yml", WF_MISSING)
+    cwt.main(["--json"])
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload["findings"][0]["kind"] == "missing-tool"

--- a/tests/unit/test_check_workflow_tools.py
+++ b/tests/unit/test_check_workflow_tools.py
@@ -148,3 +148,99 @@ def test_single_quoted_program_bodies_opaque(cwt: Any) -> None:
         'sed -i "s|__TAG__|v1|g; s|__D__|abc|g" file.md\n'
     )
     assert cwt.extract_commands(script) == ["gh", "sed"]
+
+
+# ---------------------------------------------------------------------------
+# check_workflow_tools — G8 job walk
+# ---------------------------------------------------------------------------
+
+WF_OK = """\
+name: ok
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@abc123
+      - name: Install uv
+        uses: astral-sh/setup-uv@def456
+      - name: Check
+        run: uvx twine check dist/*
+"""
+
+WF_MISSING = """\
+name: missing
+on: [push]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@abc123
+      - name: Check distributions
+        run: uvx twine check dist/*
+"""
+
+WF_WAIVED = """\
+name: waived
+on: [push]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install scanner then use it
+        run: |
+          curl -sSfL https://example.com -o "$HOME/.local/bin/osv-scanner"
+          # tool-check: ok osv-scanner
+          osv-scanner scan source --lockfile x.txt
+"""
+
+WF_CROSS_JOB = """\
+name: crossjob
+on: [push]
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: astral-sh/setup-uv@def456
+  use:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Uses uv without installing it in THIS job
+        run: uv sync
+"""
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_tools_provided_by_uses_pass(cwt: Any, tmp_path: Path) -> None:
+    assert cwt.check_workflow_tools(_write(tmp_path, "ok.yml", WF_OK)) == []
+
+
+def test_missing_setup_step_is_finding(cwt: Any, tmp_path: Path) -> None:
+    findings = cwt.check_workflow_tools(_write(tmp_path, "missing.yml", WF_MISSING))
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.kind == "missing-tool" and f.job == "publish" and "uvx" in f.detail
+
+
+def test_waiver_comment_suppresses(cwt: Any, tmp_path: Path) -> None:
+    assert cwt.check_workflow_tools(_write(tmp_path, "waived.yml", WF_WAIVED)) == []
+
+
+def test_tools_do_not_leak_across_jobs(cwt: Any, tmp_path: Path) -> None:
+    findings = cwt.check_workflow_tools(_write(tmp_path, "crossjob.yml", WF_CROSS_JOB))
+    assert len(findings) == 1 and findings[0].job == "use"
+
+
+def test_malformed_yaml_is_parse_error(cwt: Any, tmp_path: Path) -> None:
+    findings = cwt.check_workflow_tools(_write(tmp_path, "bad.yml", "jobs: ["))
+    assert len(findings) == 1 and findings[0].kind == "parse-error"
+
+
+def test_reusable_workflow_job_skipped(cwt: Any, tmp_path: Path) -> None:
+    wf = "name: r\non: [push]\njobs:\n  call:\n    uses: org/repo/.github/workflows/x.yml@main\n"
+    assert cwt.check_workflow_tools(_write(tmp_path, "r.yml", wf)) == []

--- a/tests/unit/test_check_workflow_tools.py
+++ b/tests/unit/test_check_workflow_tools.py
@@ -244,3 +244,51 @@ def test_malformed_yaml_is_parse_error(cwt: Any, tmp_path: Path) -> None:
 def test_reusable_workflow_job_skipped(cwt: Any, tmp_path: Path) -> None:
     wf = "name: r\non: [push]\njobs:\n  call:\n    uses: org/repo/.github/workflows/x.yml@main\n"
     assert cwt.check_workflow_tools(_write(tmp_path, "r.yml", wf)) == []
+
+
+# ---------------------------------------------------------------------------
+# G9 — extras validity
+# ---------------------------------------------------------------------------
+
+PYPROJECT_META = """\
+[project]
+name = "evidentia"
+version = "0.10.16"
+[project.optional-dependencies]
+gui = ["evidentia-api>=0.10.16"]
+mcp = ["evidentia-mcp>=0.10.16"]
+"""
+
+WF_EXTRAS = """\
+name: extras
+on: [push]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: good
+        run: pip install "evidentia[gui,mcp]==0.10.16"
+      - name: bogus
+        run: pip install "evidentia[ai,api]==0.10.16"
+      - name: third-party ignored
+        run: pip install "psycopg[binary]>=3.1"
+"""
+
+
+def test_collect_workspace_extras(cwt: Any, tmp_path: Path) -> None:
+    manifest = _write(tmp_path, "pyproject.toml", PYPROJECT_META)
+    extras = cwt.collect_workspace_extras([manifest])
+    assert extras == {"evidentia": {"gui", "mcp"}}
+
+
+def test_unknown_extras_flagged_known_and_thirdparty_pass(cwt: Any, tmp_path: Path) -> None:
+    manifest = _write(tmp_path, "pyproject.toml", PYPROJECT_META)
+    extras = cwt.collect_workspace_extras([manifest])
+    findings = cwt.check_workflow_extras(_write(tmp_path, "e.yml", WF_EXTRAS), extras)
+    kinds = {(f.kind, f.detail.split("`")[1]) for f in findings}
+    assert ("unknown-extra", "ai") in kinds and ("unknown-extra", "api") in kinds
+    assert len(findings) == 2  # gui/mcp pass; psycopg[binary] ignored
+
+
+def test_normalization_underscore_dash_case(cwt: Any) -> None:
+    assert cwt._normalize("Evidentia_Core") == "evidentia-core"

--- a/tests/unit/test_check_workflow_tools.py
+++ b/tests/unit/test_check_workflow_tools.py
@@ -150,6 +150,62 @@ def test_single_quoted_program_bodies_opaque(cwt: Any) -> None:
     assert cwt.extract_commands(script) == ["gh", "sed"]
 
 
+# --- apostrophe-in-comment must NOT desync quote state (the real-tree
+# --- `s` / `%s` / `evidentia` fragment noise: a prose comment like
+# --- `can't` / `package's` opened single-quote state that leaked across
+# --- lines and inverted the masking of every command below it) ------------
+
+
+def test_apostrophe_in_comment_does_not_desync_masking(cwt: Any) -> None:
+    # The comment's lone apostrophe must not open a cross-line string; the
+    # `printf '%s'` below must stay opaque (printf is a builtin -> filtered)
+    # rather than leaking a bare `%s` token because quote state was inverted.
+    script = (
+        "# the range can't be resolved (empty, all-zero \"no\n"
+        "# parent\" sentinel), so build unconditionally.\n"
+        "printf '%s' \"$base\" | grep -qE '^0+$'\n"
+        "docker build .\n"
+    )
+    assert cwt.extract_commands(script) == ["grep", "docker"]
+
+
+def test_apostrophe_in_comment_keeps_later_single_quotes_paired(cwt: Any) -> None:
+    # A later `'evidentia version'` string must remain a paired, opaque unit
+    # (not expose a bare `evidentia`) after an apostrophe-bearing comment.
+    script = (
+        "# install the extras exactly as a consumer would; the meta-package's\n"
+        "# base deps already pull the closure.\n"
+        "pip install \"evidentia[gui,mcp]==1.0\"\n"
+        "grep -q x || { echo \"'evidentia version' mismatch\"; exit 1; }\n"
+    )
+    got = cwt.extract_commands(script)
+    assert "evidentia" not in got
+    assert got == ["pip", "grep"]
+
+
+def test_brace_group_delimiters_are_not_commands(cwt: Any) -> None:
+    # `{ ...; } >> file` is a compound-command group: the `{` opener and `}`
+    # closer are shell grouping, never tool invocations (real in
+    # base-freshness.yml / stale-branches.yml).
+    script = (
+        "{\n"
+        '  echo "## report"\n'
+        '  echo ""\n'
+        '} >> "$GITHUB_STEP_SUMMARY"\n'
+        "gh api repos/x/branches\n"
+    )
+    got = cwt.extract_commands(script)
+    assert "{" not in got and "}" not in got
+    assert got == ["gh"]
+
+
+def test_inline_brace_group_on_one_line(cwt: Any) -> None:
+    # The single-line form: `{ echo a; echo b; } >> f` — the leading `{`
+    # and the `; }` closer must both be skipped.
+    script = '{ echo "stale=true"; echo "reasons=x"; } >> "$GITHUB_OUTPUT"\n'
+    assert cwt.extract_commands(script) == []
+
+
 # ---------------------------------------------------------------------------
 # check_workflow_tools — G8 job walk
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `scripts/check_workflow_tools.py` — a strict, unit-tested CI checker that mechanizes engineering-practices **lessons 8 and 9**:

- **G8 — per-job tool availability** (the v0.10.15 exit-127 class): every command invoked in a `run:` block must be provided by an earlier `uses:` step in the *same job* (committed action→tools map), be runner-preinstalled (committed allowlist), be a shell builtin, or carry an inline `# tool-check: ok <cmd>` waiver.
- **G9 — extras validity** (the nonexistent-`[ai,api,collectors]` class): any `pkg[extras]` install-spec in a workflow naming a *workspace* package must only use extras declared in that package's pyproject manifest — pip warns and exits 0 on unknown extras, so nothing downstream catches this.

Wired as a new job **`Check workflow tools (strict)`** in `verify-workflow-perms.yml` (same trigger surface as the existing permissions audit: push:main / PR / merge_group / dispatch).

## How it reads workflows

Quote-aware first-token extraction: quoted-string content is masked with cross-line state (multi-line `python -c "…"` bodies are opaque), heredoc bodies and `case…esac` arms are skipped, `VAR=value` prefixes are stripped, backslash continuations fold. 33 unit tests (fixture-based, mirroring `test_audit_workflow_permissions.py`) pin the heuristic, including regression tests for every false-positive class found while bringing the real tree clean.

## Waiver policy (enforced in review)

Waivers are ONLY for verified false-positives. This PR adds exactly **5**, all for the run-step-installed class (tool curl-installed by a prior step in the same job, checksum-verified there):

- `osv-scanner` — release.yml, container-build.yml, post-publish-rescan.yml (container job)
- `gitleaks` — secret-scan.yml (×2)

Each waiver comment sits inside the run block directly above first use. Zero genuine gaps found (every job that invokes uv/uvx/cosign/etc. already installs it — the v0.10.15 lesson already applied); zero allowlist stretches.

## Scope v1 (stated in the script header)

Top-level workflow files only (composite/reusable actions out of scope); the preinstalled allowlist approximates ubuntu-latest; variable-/path-invoked tools and mid-line substitutions are a disclosed false-negative surface.

## Not in this PR

Flipping `Check workflow tools (strict)` to a **required check** on the main ruleset is a separate, deliberate post-merge step — after the job has been observed green on main (lesson 9: a gate is not real until observed firing).

## Validation

- 33/33 unit tests; TDD per task (RED→GREEN evidence in the dev ledger)
- `check_workflow_tools.py --strict` exit 0 on the real tree (26 workflows)
- `audit_workflow_permissions.py --strict` PASS; zizmor 1.26.1 (CI-pinned version, repo config) no findings
- Full local gate: pytest 4713 passed (4 pre-existing environmental collector failures, identical on main), mypy strict-optional ×7 packages, ruff, version-consistency, docs-health --strict, frontend typecheck+build+vitest — all green
