### PR TITLE
Feat(ci): Workflow-liveness sentinel (G10) + smoke workflow_run fix

### DIFF
--- a/.github/workflows/base-freshness.yml
+++ b/.github/workflows/base-freshness.yml
@@ -5,7 +5,9 @@
 # provides: a TIME-based staleness nudge. When the pinned DHI base digest drifts
 # from the current dhi.io/python:3.13, or the latest GitHub Release is older than
 # 90 days, it opens/updates a single tracking issue: "cut a patch release to
-# rebuild on the fresh base".
+# rebuild on the fresh base". It also detects dead or never-fired workflow
+# trigger events (lesson 9, G10), and its own liveness is in turn asserted
+# weekly by post-publish-rescan.yml's sentinel-liveness job.
 name: base freshness
 
 on:
@@ -13,10 +15,10 @@ on:
     - cron: "23 8 * * 2"   # Tuesdays 08:23 UTC (offset from the Mon rescan)
   workflow_dispatch: {}
 
-# JUSTIFIED: bot opens/updates one tracking issue when the base drifts or ages out
+# Write scopes are JOB-scoped below (zizmor excessive-permissions: a multi-job
+# workflow must not hold workflow-level write).
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: base-freshness
@@ -25,6 +27,10 @@ concurrency:
 jobs:
   sentinel:
     runs-on: ubuntu-latest
+    # Opens/updates the freshness tracking issue.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout (Dockerfile pin)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -84,6 +90,63 @@ jobs:
           BODY=$(printf '%b\n\n%s\n' \
             "The DHI container base or the published image is stale:\n\n${REASONS}" \
             "Action: cut a patch release to rebuild on the fresh base (Dependabot may already have a digest-bump PR open). This is a scheduled sentinel — not a gate. See docs/engineering-practices.md (Continuous security assurance).")
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title \"$TITLE\"" --json number -q '.[0].number' || echo "")
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+            echo "Updated issue #$existing"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body "$BODY"
+          fi
+
+  # G10 (engineering-practices lesson 9): a gate is not real until observed
+  # firing. Flags (i) structurally dead trigger events (a `release:` trigger
+  # in a repo whose Releases are GITHUB_TOKEN-created) and (ii) declared
+  # automatic triggers with zero runs ever after a 30-day grace window.
+  # Detect-and-nudge only — findings go to one tracking issue, never a red run.
+  workflow-liveness:
+    name: Workflow liveness (dead / never-fired triggers)
+    runs-on: ubuntu-latest
+    # Opens/updates the liveness tracking issue; reads the runs API.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      - name: Checkout (workflow files)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Detect dead / never-fired trigger events
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run --no-sync python scripts/check_workflow_liveness.py \
+            --repo "$GITHUB_REPOSITORY" --output liveness-findings.md
+
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -s liveness-findings.md ]; then
+            echo "No liveness findings — nothing to do."
+            exit 0
+          fi
+          TITLE="Workflow liveness: dead or never-fired triggers"
+          BODY=$(printf '%s\n\n%s\n' \
+            "$(cat liveness-findings.md)" \
+            "Action: rewire or remove the dead trigger (see docs/engineering-practices.md lesson 9). This is a scheduled sentinel — not a gate.")
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
             --search "in:title \"$TITLE\"" --json number -q '.[0].number' || echo "")
           if [ -n "$existing" ]; then

--- a/.github/workflows/post-publish-rescan.yml
+++ b/.github/workflows/post-publish-rescan.yml
@@ -29,6 +29,11 @@
 # maintainer is notified — the project's own continuous-attestation thesis,
 # applied to its OWN shipped artifacts. workflow_dispatch allows an on-demand
 # rescan of any version.
+#
+# A third job, sentinel-liveness, independently guards the base-freshness
+# sentinel itself: it goes RED if that workflow has not produced a run in 14
+# days, so a silently auto-disabled or broken sentinel schedule is caught here
+# rather than staying an invisible coverage gap.
 
 name: post-publish rescan
 
@@ -233,3 +238,36 @@ jobs:
           python scripts/check_osv_fixable.py rescan.json \
             --image "${IMAGE}" \
             --summary-file "$GITHUB_STEP_SUMMARY"
+
+  # Sentinel self-liveness (G10 companion): the liveness detector's HOST must
+  # not be its own blind spot. This independent weekly job goes RED if the
+  # base-freshness sentinel has not produced a run in 14 days (e.g. GitHub's
+  # 60-day scheduled-workflow auto-disable, or a broken cron).
+  sentinel-liveness:
+    name: Sentinel self-liveness (base-freshness ran within 14 days)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Assert base-freshness ran within 14 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! last=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/base-freshness.yml/runs?per_page=1" \
+            -q '.workflow_runs[0].created_at'); then
+            echo "::error::runs API unreachable — cannot assert sentinel liveness (transient failure? re-run this job)."
+            exit 1
+          fi
+          if [ -z "$last" ] || [ "$last" = "null" ]; then
+            echo "::error::base-freshness has NO runs at all — the sentinel is dead (lesson 9)."
+            exit 1
+          fi
+          age_days=$(( ( $(date -u +%s) - $(date -u -d "$last" +%s) ) / 86400 ))
+          echo "base-freshness last ran ${last} (${age_days}d ago)"
+          if [ "$age_days" -gt 14 ]; then
+            echo "::error::base-freshness sentinel silent for ${age_days}d (>14d) — investigate (auto-disabled schedule? broken cron?)."
+            exit 1
+          fi

--- a/.github/workflows/post-publish-smoke.yml
+++ b/.github/workflows/post-publish-smoke.yml
@@ -7,19 +7,34 @@
 # dependency-resolution / registry-propagation issue that bites a real
 # consumer doing a clean `pip install` or `docker pull`.
 #
-# This workflow is that final check. It fires after a Release is published
-# (the last step of release.yml's publish-container job), waits for the
-# package/image to propagate, and confirms both install + run `evidentia
-# version` from a clean environment. On failure it goes red so a maintainer is
-# notified. Auto-yank is intentionally NOT automated — yank-vs-hotfix is a
-# human call (and an unverified-publish false positive must never yank a good
-# release). `workflow_dispatch` allows re-running the smoke for any version.
+# This workflow is that final check. It fires when the `release` workflow
+# COMPLETES (a Release created with GITHUB_TOKEN never fires `release:`
+# triggers — GitHub anti-recursion — so the old `release: [published]` trigger
+# was structurally dead and had ZERO automatic runs in its lifetime; lesson 9).
+# `workflow_run` on the release workflow's completion IS delivered even for
+# GITHUB_TOKEN-driven runs, and its `head_branch` carries the tag name for
+# tag-push-triggered runs. It waits for the package/image to propagate, then
+# confirms both install + run `evidentia version` from a clean environment. On
+# failure it goes red so a maintainer is notified. Auto-yank is intentionally
+# NOT automated — yank-vs-hotfix is a human call (and an unverified-publish
+# false positive must never yank a good release). `workflow_dispatch` allows
+# re-running the smoke for any version.
 
 name: post-publish smoke
 
-on:
-  release:
-    types: [published]
+# A Release created with GITHUB_TOKEN never fires `release:` triggers
+# (GitHub anti-recursion) — this workflow had ZERO automatic runs in its
+# lifetime under the old `release:` trigger (lesson 9). workflow_run on the
+# release workflow's completion IS delivered, and head_branch carries the
+# tag name for tag-push-triggered runs (verified on the v0.10.16 run).
+# zizmor's dangerous-triggers audit flags ANY workflow_run usage; ignored
+# with justification: this workflow checks out NO code, both jobs gate on
+# conclusion=='success' + a strict-semver head_branch, and head_branch is
+# consumed exclusively via env vars (no template injection into run:).
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: [release]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -30,37 +45,50 @@ permissions:
   contents: read
 
 concurrency:
-  group: post-publish-smoke-${{ github.event.release.tag_name || github.event.inputs.version }}
+  group: post-publish-smoke-${{ github.event.workflow_run.head_branch || github.event.inputs.version }}
   cancel-in-progress: false
 
 jobs:
   pypi-install-smoke:
     name: PyPI fresh-install smoke
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - name: Resolve version
         id: ver
+        env:
+          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${GITHUB_EVENT_INPUTS_VERSION}"
           else
-            REF="${GITHUB_EVENT_RELEASE_TAG_NAME}"   # e.g. v0.10.13
+            REF="${WORKFLOW_RUN_HEAD_BRANCH}"   # tag name, e.g. v0.10.16
+            if ! printf '%s' "$REF" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              # Non-canonical v-tag: release.yml's tag-guard skipped publishing,
+              # so there is nothing live to smoke. Skip green, don't go red.
+              echo "Non-canonical ref '${REF}' — nothing was published, skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             VERSION="${REF#v}"
           fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Smoke-testing evidentia==${VERSION}"
-        env:
-          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Set up Python
+        if: steps.ver.outputs.skip != 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.13"
 
       - name: Wait for PyPI propagation
+        if: steps.ver.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
@@ -77,6 +105,7 @@ jobs:
           exit 1
 
       - name: Fresh-install (base) + run `evidentia version`
+        if: steps.ver.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
@@ -93,6 +122,7 @@ jobs:
             || { echo "::error::base 'evidentia version' did not report ${VERSION}"; exit 1; }
 
       - name: Fresh-install (all extras) — verify every published package resolves
+        if: steps.ver.outputs.skip != 'true'
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
@@ -114,26 +144,38 @@ jobs:
   container-smoke:
     name: GHCR container pull smoke
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     permissions:
       contents: read
       packages: read
     steps:
       - name: Resolve tag
         id: tag
+        env:
+          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG="v${GITHUB_EVENT_INPUTS_VERSION}"
           else
-            TAG="${GITHUB_EVENT_RELEASE_TAG_NAME}"
+            TAG="${WORKFLOW_RUN_HEAD_BRANCH}"   # tag name, e.g. v0.10.16
+            if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              # Non-canonical v-tag: release.yml's tag-guard skipped publishing,
+              # so there is nothing live to smoke. Skip green, don't go red.
+              echo "Non-canonical ref '${TAG}' — nothing was published, skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_EVENT_INPUTS_VERSION: ${{ github.event.inputs.version }}
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
       - name: Log in to GHCR
+        if: steps.tag.outputs.skip != 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
@@ -141,6 +183,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull published container (with propagation retry) + run `version`
+        if: steps.tag.outputs.skip != 'true'
         env:
           IMAGE: ghcr.io/polycentric-labs/evidentia:${{ steps.tag.outputs.tag }}
           TAG: ${{ steps.tag.outputs.tag }}

--- a/scripts/check_workflow_liveness.py
+++ b/scripts/check_workflow_liveness.py
@@ -25,11 +25,14 @@ internal errors.
 
 from __future__ import annotations
 
+import argparse
 import json
+import os
+import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -143,3 +146,53 @@ def check_never_fired(
                     f"a never-fired gate is a dead gate (lesson 9)."
                 )
     return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="OWNER/NAME")
+    ap.add_argument("--output", required=True, help="findings markdown path")
+    ap.add_argument(
+        "--skip-api",
+        action="store_true",
+        help="rule (i) only — no network (local/test use)",
+    )
+    args = ap.parse_args(argv)
+
+    triggers_by_path: dict[str, set[str]] = {}
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(
+        WORKFLOWS_DIR.glob("*.yaml")
+    ):
+        try:
+            triggers_by_path[f".github/workflows/{path.name}"] = workflow_triggers(
+                path.read_text(encoding="utf-8")
+            )
+        except yaml.YAMLError as exc:
+            print(f"WARN: could not parse {path.name}: {exc}", file=sys.stderr)
+
+    findings = check_dead_triggers(
+        {Path(p).name: t for p, t in triggers_by_path.items()}
+    )
+    if not args.skip_api:
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        api = GitHubAPI(args.repo, token)
+        try:
+            findings += check_never_fired(api, triggers_by_path, datetime.now(UTC))
+        except (OSError, ValueError, KeyError) as exc:
+            # Fail-soft (lesson 2: a chronically-red sentinel trains people to
+            # ignore it). OSError covers URLError/HTTPError/read-phase
+            # TimeoutError; ValueError covers JSONDecodeError + shape checks.
+            # Rule (i) findings above still stand.
+            print(f"WARN: runs-API check skipped: {exc}", file=sys.stderr)
+
+    Path(args.output).write_text(
+        "\n".join(findings) + ("\n" if findings else ""), encoding="utf-8"
+    )
+    for line in findings:
+        print(line)
+    print(f"check_workflow_liveness: {len(findings)} finding(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_workflow_liveness.py
+++ b/scripts/check_workflow_liveness.py
@@ -25,6 +25,11 @@ internal errors.
 
 from __future__ import annotations
 
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -69,4 +74,72 @@ def check_dead_triggers(triggers_by_file: dict[str, set[str]]) -> list[str]:
                 f"- **`{name}`** declares a structurally dead `on: {event}` "
                 f"trigger: {DEAD_TRIGGER_RULES[event]}"
             )
+    return findings
+
+
+def _parse_gh_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+class GitHubAPI:
+    """Tiny REST client. Paths are RELATIVE to /repos/{repo} (e.g.
+    ``/actions/workflows``); auth via GITHUB_TOKEN/GH_TOKEN."""
+
+    def __init__(self, repo: str, token: str | None) -> None:
+        self.base = f"https://api.github.com/repos/{repo}"
+        self.token = token
+
+    def get(self, path: str, params: dict[str, str] | None = None) -> object:
+        url = self.base + path
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                **({"Authorization": f"Bearer {self.token}"} if self.token else {}),
+            },
+        )
+        # Fixed https host (api.github.com); 30s covers connect, but a
+        # read-phase stall raises bare TimeoutError — callers catch OSError.
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+
+
+def check_never_fired(
+    api: GitHubAPI, triggers_by_path: dict[str, set[str]], now: datetime
+) -> list[str]:
+    findings: list[str] = []
+    listing = api.get("/actions/workflows", params={"per_page": "100"})
+    if not isinstance(listing, dict):
+        raise ValueError("unexpected /actions/workflows response shape")
+    for wf in listing.get("workflows", []):
+        if wf.get("state") != "active":
+            continue
+        path = wf.get("path", "")
+        triggers = triggers_by_path.get(path)
+        if not triggers:
+            continue  # not a local top-level workflow file we parsed
+        anchor = _parse_gh_datetime(wf["created_at"])
+        commits = api.get("/commits", params={"path": path, "per_page": "1"})
+        if isinstance(commits, list) and commits:
+            touched = _parse_gh_datetime(commits[0]["commit"]["committer"]["date"])
+            anchor = max(anchor, touched)
+        age = now - anchor
+        if age < timedelta(days=GRACE_DAYS):
+            continue
+        for event in sorted(triggers - EXEMPT_EVENTS):
+            runs = api.get(
+                f"/actions/workflows/{wf['id']}/runs",
+                params={"event": event, "per_page": "1"},
+            )
+            if not isinstance(runs, dict):
+                raise ValueError(f"unexpected runs response shape for {path}")
+            if runs.get("total_count", 0) == 0:
+                findings.append(
+                    f"- **`{Path(path).name}`** trigger `on: {event}` has ZERO "
+                    f"runs ever in {age.days}d (grace window {GRACE_DAYS}d) — "
+                    f"a never-fired gate is a dead gate (lesson 9)."
+                )
     return findings

--- a/scripts/check_workflow_liveness.py
+++ b/scripts/check_workflow_liveness.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""G10 workflow-liveness detector (engineering-practices lesson 9).
+
+Rule (i) — statically dead TRIGGER EVENTS: flag any declared trigger event
+that can never fire given how this repo emits it. v1 rule: ``release:`` —
+Releases here are created exclusively by release.yml using GITHUB_TOKEN, and
+GITHUB_TOKEN-created events never trigger workflows (GitHub anti-recursion).
+The rule targets EVENTS, not workflows: a workflow with a live
+``workflow_dispatch`` and a dead ``release:`` still has a dead trigger
+(exactly how post-publish-smoke sat un-fired for its whole lifetime).
+
+Rule (ii) — never-fired automatic triggers: for each ACTIVE workflow, for
+each declared trigger event other than workflow_dispatch/workflow_call, flag
+the event if the workflow has ZERO runs of that event type — but only after a
+30-day grace window anchored on the NEWER of the workflow's created_at and
+the last commit touching its file (an edited workflow gets fresh grace, so a
+just-added trigger is not flagged before it has had a chance to fire).
+
+Posture: detect-and-nudge. Findings are written as markdown for the calling
+job to post as a tracking issue; this script exits 0 on findings (the
+sentinel must not go chronically red — lesson 2). Rule (ii) is fail-soft on
+API errors (skipped with a warning); rule (i) always runs. Exit 1 only on
+internal errors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+GRACE_DAYS = 30
+# Events that are manual/callee-side and never expected to self-fire.
+EXEMPT_EVENTS = {"workflow_dispatch", "workflow_call"}
+
+DEAD_TRIGGER_RULES: dict[str, str] = {
+    "release": (
+        "Releases in this repo are created by release.yml using GITHUB_TOKEN; "
+        "GITHUB_TOKEN-created events never trigger workflows (GitHub "
+        "anti-recursion), so a `release:` trigger here can never fire. Use "
+        "`workflow_run` on the release workflow instead."
+    ),
+}
+
+
+def workflow_triggers(text: str) -> set[str]:
+    """Declared trigger event names. NB: PyYAML parses bare `on:` as True."""
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        return set()
+    on = data.get("on", data.get(True))
+    if isinstance(on, str):
+        return {on}
+    if isinstance(on, list):
+        return {str(e) for e in on}
+    if isinstance(on, dict):
+        return {str(e) for e in on}
+    return set()
+
+
+def check_dead_triggers(triggers_by_file: dict[str, set[str]]) -> list[str]:
+    findings: list[str] = []
+    for name in sorted(triggers_by_file):
+        for event in sorted(triggers_by_file[name] & set(DEAD_TRIGGER_RULES)):
+            findings.append(
+                f"- **`{name}`** declares a structurally dead `on: {event}` "
+                f"trigger: {DEAD_TRIGGER_RULES[event]}"
+            )
+    return findings

--- a/tests/unit/test_check_workflow_liveness.py
+++ b/tests/unit/test_check_workflow_liveness.py
@@ -127,3 +127,31 @@ def test_dispatch_and_call_events_exempt(cwl: Any) -> None:
         NOW,
     )
     assert findings == []
+
+
+def test_main_skip_api_writes_dead_trigger_findings(
+    cwl: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    wf_dir = tmp_path / "wf"
+    wf_dir.mkdir()
+    (wf_dir / "smoke.yml").write_text(
+        "name: s\non:\n  release:\n    types: [published]\njobs: {}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cwl, "WORKFLOWS_DIR", wf_dir)
+    out = tmp_path / "findings.md"
+    rc = cwl.main(["--repo", "o/r", "--output", str(out), "--skip-api"])
+    assert rc == 0
+    assert "release" in out.read_text(encoding="utf-8")
+
+
+def test_main_skip_api_clean_writes_empty_file(
+    cwl: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    wf_dir = tmp_path / "wf"
+    wf_dir.mkdir()
+    (wf_dir / "ok.yml").write_text("name: k\non: [push]\njobs: {}\n", encoding="utf-8")
+    monkeypatch.setattr(cwl, "WORKFLOWS_DIR", wf_dir)
+    out = tmp_path / "findings.md"
+    assert cwl.main(["--repo", "o/r", "--output", str(out), "--skip-api"]) == 0
+    assert out.read_text(encoding="utf-8") == ""

--- a/tests/unit/test_check_workflow_liveness.py
+++ b/tests/unit/test_check_workflow_liveness.py
@@ -1,0 +1,61 @@
+"""Tests for ``scripts/check_workflow_liveness.py`` (G10; lesson 9 —
+"a gate is not real until it has been observed firing").
+
+Rule (i): statically dead trigger EVENTS (a ``release:`` trigger in a repo
+whose Releases are created with GITHUB_TOKEN can never fire).
+Rule (ii): declared automatic trigger events with ZERO runs ever, after a
+30-day grace window anchored on the newer of workflow created_at / last
+commit touching the file (so freshly-edited workflows get fresh grace).
+
+All API access goes through an injected fake; no network in unit tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_workflow_liveness.py"
+
+
+@pytest.fixture(scope="module")
+def cwl() -> Any:
+    spec = importlib.util.spec_from_file_location("check_workflow_liveness", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_workflow_liveness"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_on_key_parsed_despite_yaml_true_gotcha(cwl: Any) -> None:
+    # PyYAML parses bare `on:` as boolean True (YAML 1.1) — must still work.
+    text = "name: x\non:\n  release:\n    types: [published]\n  workflow_dispatch: {}\njobs: {}\n"
+    assert cwl.workflow_triggers(text) == {"release", "workflow_dispatch"}
+
+
+def test_on_as_string_and_list(cwl: Any) -> None:
+    assert cwl.workflow_triggers("on: push\njobs: {}\n") == {"push"}
+    assert cwl.workflow_triggers("on: [push, pull_request]\njobs: {}\n") == {
+        "push",
+        "pull_request",
+    }
+
+
+def test_dead_release_trigger_flagged_even_with_dispatch(cwl: Any) -> None:
+    findings = cwl.check_dead_triggers(
+        {"post-publish-smoke.yml": {"release", "workflow_dispatch"}}
+    )
+    assert len(findings) == 1
+    assert "release" in findings[0] and "post-publish-smoke.yml" in findings[0]
+
+
+def test_no_dead_trigger_no_finding(cwl: Any) -> None:
+    assert cwl.check_dead_triggers({"test.yml": {"push", "pull_request"}}) == []

--- a/tests/unit/test_check_workflow_liveness.py
+++ b/tests/unit/test_check_workflow_liveness.py
@@ -59,3 +59,71 @@ def test_dead_release_trigger_flagged_even_with_dispatch(cwl: Any) -> None:
 
 def test_no_dead_trigger_no_finding(cwl: Any) -> None:
     assert cwl.check_dead_triggers({"test.yml": {"push", "pull_request"}}) == []
+
+
+class FakeAPI:
+    """Minimal stand-in for GitHubAPI.get keyed on (path, frozen params)."""
+
+    def __init__(self, responses: dict[tuple[str, str], Any]) -> None:
+        self.responses = responses
+
+    def get(self, path: str, params: dict[str, str] | None = None) -> Any:
+        key = (path, json.dumps(params or {}, sort_keys=True))
+        return self.responses[key]
+
+
+NOW = datetime(2026, 7, 2, tzinfo=UTC)
+OLD = "2026-01-01T00:00:00Z"
+RECENT = "2026-06-25T00:00:00Z"
+
+
+def _api(created: str, touched: str, total: int) -> FakeAPI:
+    wf_path = ".github/workflows/w.yml"
+    return FakeAPI(
+        {
+            ("/actions/workflows", json.dumps({"per_page": "100"}, sort_keys=True)): {
+                "total_count": 1,
+                "workflows": [
+                    {"id": 7, "path": wf_path, "state": "active", "created_at": created}
+                ],
+            },
+            (
+                "/commits",
+                json.dumps({"path": wf_path, "per_page": "1"}, sort_keys=True),
+            ): [{"commit": {"committer": {"date": touched}}}],
+            (
+                "/actions/workflows/7/runs",
+                json.dumps({"event": "schedule", "per_page": "1"}, sort_keys=True),
+            ): {"total_count": total},
+        }
+    )
+
+
+def test_zero_runs_past_grace_flagged(cwl: Any) -> None:
+    findings = cwl.check_never_fired(
+        _api(OLD, OLD, 0), {".github/workflows/w.yml": {"schedule"}}, NOW
+    )
+    assert len(findings) == 1 and "schedule" in findings[0]
+
+
+def test_recently_touched_file_gets_fresh_grace(cwl: Any) -> None:
+    findings = cwl.check_never_fired(
+        _api(OLD, RECENT, 0), {".github/workflows/w.yml": {"schedule"}}, NOW
+    )
+    assert findings == []
+
+
+def test_nonzero_runs_not_flagged(cwl: Any) -> None:
+    findings = cwl.check_never_fired(
+        _api(OLD, OLD, 3), {".github/workflows/w.yml": {"schedule"}}, NOW
+    )
+    assert findings == []
+
+
+def test_dispatch_and_call_events_exempt(cwl: Any) -> None:
+    findings = cwl.check_never_fired(
+        _api(OLD, OLD, 0),
+        {".github/workflows/w.yml": {"workflow_dispatch", "workflow_call"}},
+        NOW,
+    )
+    assert findings == []


### PR DESCRIPTION
## What

Completes the G8–G10 guardrail trio (engineering-practices lessons 8–9) with **G10 — workflow liveness detection** — plus the fix for the exact defect G10 exists to catch, bundled deliberately so the detector's first run is clean.

1. **`scripts/check_workflow_liveness.py`** (10 unit tests): weekly detection of
   - **rule (i) — structurally dead trigger events**: a `release:` trigger can never fire in this repo because Releases are created with `GITHUB_TOKEN` (GitHub anti-recursion). The rule targets *events*, not workflows — a workflow with a live `workflow_dispatch` and a dead `release:` still has a dead trigger, which is exactly how post-publish-smoke sat un-fired for its entire lifetime with zero runs.
   - **rule (ii) — never-fired automatic triggers**: any declared non-dispatch trigger with zero runs ever, after a 30-day grace window anchored on the *newer* of workflow creation and last file-touch (an edited workflow gets fresh grace).
   Posture: detect-and-nudge — findings go to a single tracking issue; the sentinel never goes red on findings (lesson 2: a chronically-red gate trains people to ignore it). Rule (ii) is fail-soft on API errors.
2. **`base-freshness.yml`** gains the `workflow-liveness` job (Tuesdays, alongside the base-digest sentinel). Permissions are now **job-scoped** (zizmor's `excessive-permissions` audit rejects workflow-level write in multi-job files): top-level drops to `contents: read`; each job elevates only what it uses — `actions: read` exists only on the liveness job.
3. **`post-publish-rescan.yml`** gains `sentinel-liveness` (Mondays): goes **red** if base-freshness hasn't run in 14 days — the detector's host must not be its own blind spot. API-unreachable and sentinel-dead produce distinct diagnostics.
4. **`post-publish-smoke.yml` rewired: `release:` → `workflow_run`** on the release workflow's completion. The old trigger had ZERO automatic runs ever. Gating: both jobs require `conclusion == 'success'` + `startsWith(head_branch, 'v')`, then a strict `^v[0-9]+\.[0-9]+\.[0-9]+$` check that **skips green** on non-canonical refs (the tag-guard published nothing, so there is nothing to smoke — and no red noise). `head_branch` is consumed exclusively via `env:` mappings (no template interpolation into `run:` bodies). Verified live: `head_branch` carries the tag name on tag-push-triggered runs (checked against the v0.10.16 release run).

## Why workflow_run and not a dispatch step in release.yml

- **Least privilege**: a dispatch step would add `actions: write` to the most security-sensitive workflow in the repo; this adds no write scope anywhere.
- **G10-clean by G10's own definition**: dispatch-driven smoke runs would all be `workflow_dispatch` events — rule (ii) would flag the smoke workflow as never-fired forever.
- **Failure isolation**: a trigger failure can't fail the publish job.

## zizmor note (deliberate, justified inline-ignore)

zizmor 1.26.1 flags *any* `workflow_run` trigger as `dangerous-triggers` (HIGH) regardless of checkout behavior. This workflow checks out **no code**, gates on success + strict semver, and consumes `head_branch` only via env vars — the pwn-request preconditions don't exist. Suppressed with the repo's sanctioned inline-ignore pattern (`.github/zizmor.yml` is rules:{} / inline-only; precedent: release.yml's two existing ignores). Repo-wide zizmor: "No findings (3 ignored)".

## Observed-firing evidence (lesson 9)

- The liveness detector was proven against the real tree mid-development: with the old trigger present, `--skip-api` emitted exactly the post-publish-smoke dead-`release:` finding; after the rewire, zero findings — the bundle is coherent.
- Post-merge, the sentinel will be dispatched once (separate approval) to observe G10's first live run clean and to seed a base-freshness run before Monday's new `sentinel-liveness` guard.
- The `workflow_run` trigger itself proves out at the next real release. If no release ships within 30 days, rule (ii) will nudge on it — that issue is expected and gets closed, not "fixed".

## Validation

- 10/10 unit tests (TDD per task); ruff clean
- `check_workflow_liveness.py --skip-api` on this tree: ZERO findings
- `check_workflow_tools.py --strict`: 0 findings across all workflows (the new jobs pass the G8 checker landed in #141)
- `audit_workflow_permissions.py --strict`: PASS (top-level JUSTIFIED exceptions 5→4 — base-freshness no longer needs one)
- zizmor 1.26.1 (CI-pinned, repo config, online): No findings (3 ignored)
- Full local gate: pytest (4 pre-existing environmental collector failures only, identical on main), mypy strict-optional ×7, version-consistency, docs-health --strict, frontend typecheck+build+vitest
