### PR TITLE
Feat(docs): Airtight freshness guardrails + face-stale honesty fixes (closeout #0a)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,20 +24,29 @@
 #   2. check_secrets              (NEVER prints the secret value)
 #   3. check_changelog_present
 #   4. check_docs_health  (--strict; reused)
-#   5. check_workflow_perms (audit_workflow_permissions.py --strict; reused)
-#   6. check_uv_lock_pin_drift
-#   7. check_osps_crosswalk_drift (only when OSPS files are in range)
-#   8. check_version_consistency  (v0.10.7 E4 "never-skip-a-version-reference":
+#   5. check_wiki_mirrors_drift    (sync_mirrors.py --check; docs-airtightness
+#                                  A1.1 — the 13 canonical-source -> wiki-mirror
+#                                  pages must match; pure-filesystem)
+#   6. check_wiki_reference_drift  (sync_reference.py --check; imports the
+#                                  Typer app to regenerate the CLI reference
+#                                  pages in memory and byte-compare)
+#   7. check_wiki_api_docs_drift   (sync_api_docs.py --check; reads each
+#                                  package's source to regenerate the API
+#                                  wiki pages in memory and byte-compare)
+#   8. check_workflow_perms (audit_workflow_permissions.py --strict; reused)
+#   9. check_uv_lock_pin_drift
+#  10. check_osps_crosswalk_drift (only when OSPS files are in range)
+#  11. check_version_consistency  (v0.10.7 E4 "never-skip-a-version-reference":
 #                                  coverage of tracked files + hard-fail on any
 #                                  unclassified project-version literal; reused)
-#   9. check_commit_signatures    (every commit in the push range must be
+#  12. check_commit_signatures    (every commit in the push range must be
 #                                  signed; closes the F-V107-1 unsigned-commit
 #                                  admin-bypass path. Blocks on %G? N/B.)
-#  10. check_readme_regen         (regenerate the Recent-Releases block; FAIL
+#  13. check_readme_regen         (regenerate the Recent-Releases block; FAIL
 #                                  if it changed in the working tree)
-#  11. check_doc_counts           (README at-a-glance counts ==
+#  14. check_doc_counts           (README at-a-glance counts ==
 #                                  code-derived truth; v0.10.12 Wave 0)
-#  12. check_ruff                 (`ruff check . --no-cache` — fast lint
+#  15. check_ruff                 (`ruff check . --no-cache` — fast lint
 #                                  shifted left from CI so a cached-pass lint
 #                                  break is caught pre-push, not in the queue)
 #
@@ -280,15 +289,32 @@ run_check "check_changelog_present" \
 run_check "check_docs_health" \
     run_py "${REPO_ROOT}/scripts/check_docs_health.py" --strict || true
 
-# 5. workflow permissions (reused; --strict exits 2 on FAIL).
+# 5. wiki mirror drift (docs-airtightness A1.1): regenerates the 13
+#    canonical-source -> wiki-mirror pages in memory and byte-compares them
+#    against the committed copies. Pure-filesystem (no app import).
+run_check "check_wiki_mirrors_drift" \
+    run_py "${REPO_ROOT}/scripts/wiki/sync_mirrors.py" --check || true
+
+# 6. wiki CLI-reference drift (docs-airtightness A1.1): imports the Typer app
+#    to regenerate the CLI reference wiki pages and byte-compares. Requires
+#    the dev venv (`uv run`), which provides the app import.
+run_check "check_wiki_reference_drift" \
+    run_py "${REPO_ROOT}/scripts/wiki/sync_reference.py" --check || true
+
+# 7. wiki API-docs drift (docs-airtightness A1.1): reads each package's source
+#    to regenerate the API wiki pages and byte-compares.
+run_check "check_wiki_api_docs_drift" \
+    run_py "${REPO_ROOT}/scripts/wiki/sync_api_docs.py" --check || true
+
+# 8. workflow permissions (reused; --strict exits 2 on FAIL).
 run_check "check_workflow_perms" \
     run_py "${REPO_ROOT}/scripts/audit_workflow_permissions.py" --strict || true
 
-# 6. uv.lock third-party pin drift on workspace bump.
+# 9. uv.lock third-party pin drift on workspace bump.
 run_check "check_uv_lock_pin_drift" \
     run_py "${SCRIPTS_DIR}/check_uv_lock_pin_drift.py" "${RANGE_BASE}" "${RANGE_TIP}" || true
 
-# 7. OSPS crosswalk drift — only when OSPS files are in the push range.
+# 10. OSPS crosswalk drift — only when OSPS files are in the push range.
 if printf '%s\n' "${CHANGED_FILES}" | grep -Eq 'mappings/osps-baseline_.*\.json$|/_osps_upstream\.py$'; then
     run_check "check_osps_crosswalk_drift" \
         run_py "${REPO_ROOT}/scripts/catalogs/gen_osps_crosswalks.py" --check || true
@@ -298,22 +324,22 @@ else
     echo "SKIP check_osps_crosswalk_drift (no OSPS mapping/_osps_upstream files in range)"
 fi
 
-# 8. version consistency (v0.10.7 E4): every tracked file holds the current
-#    version + no git-tracked file carries an unclassified project-version
-#    literal. Reads scripts/version_tracked_files.yaml (the same manifest
-#    bump_version.py drives off). Always runs (not range-gated) — a stale
-#    tracked file or an unclassified literal anywhere is a push blocker.
+# 11. version consistency (v0.10.7 E4): every tracked file holds the current
+#     version + no git-tracked file carries an unclassified project-version
+#     literal. Reads scripts/version_tracked_files.yaml (the same manifest
+#     bump_version.py drives off). Always runs (not range-gated) — a stale
+#     tracked file or an unclassified literal anywhere is a push blocker.
 run_check "check_version_consistency" \
     run_py "${REPO_ROOT}/scripts/check_version_consistency.py" || true
 
-# 9. commit signatures (v0.10.7 follow-up; closes F-V107-1): every commit in
-#    the push range must be signed. Catches the unsigned-commit path that the
-#    main-branch admin-bypass admitted (eedde81/5f44982/458a94c). Blocks on
-#    %G? == N (none) or B (bad); range-aware via RANGE_BASE..RANGE_TIP.
+# 12. commit signatures (v0.10.7 follow-up; closes F-V107-1): every commit in
+#     the push range must be signed. Catches the unsigned-commit path that the
+#     main-branch admin-bypass admitted (eedde81/5f44982/458a94c). Blocks on
+#     %G? == N (none) or B (bad); range-aware via RANGE_BASE..RANGE_TIP.
 run_check "check_commit_signatures" \
     run_py "${SCRIPTS_DIR}/check_commit_signatures.py" "${RANGE_BASE}" "${RANGE_TIP}" || true
 
-# 10. README auto-regen (A3): regenerate the Recent-Releases block from
+# 13. README auto-regen (A3): regenerate the Recent-Releases block from
 #     CHANGELOG; FAIL if it changed in the working tree (commit the regen).
 check_readme_regen() {
     run_py "${REPO_ROOT}/scripts/gen_readme_releases.py" || return 1
@@ -328,14 +354,14 @@ check_readme_regen() {
 }
 run_check "check_readme_regen" check_readme_regen || true
 
-# 11. README capability-count drift (v0.10.12 Wave 0): the at-a-glance counts
+# 14. README capability-count drift (v0.10.12 Wave 0): the at-a-glance counts
 #     (catalogs / crosswalks / collectors / MCP-tools) must equal the
 #     code-derived truth (catalogs manifest + openapi.json + MCP server
 #     source). Pure-filesystem; always runs.
 run_check "check_doc_counts" \
     run_py "${REPO_ROOT}/scripts/check_doc_counts.py" || true
 
-# 12. ruff lint — shifted left from CI-only. `--no-cache` so the gate matches
+# 15. ruff lint — shifted left from CI-only. `--no-cache` so the gate matches
 #     CI's fresh runner exactly: a *cached* pass can mask a lint break (e.g. an
 #     unused `# noqa` for a non-enabled rule → RUF100) that CI then catches,
 #     causing avoidable merge-queue churn. ruff is fast (~1-2s), so it fits the

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -59,3 +59,38 @@ jobs:
 
       - name: Run consistency gate suite (SSOT)
         run: uv run python scripts/run_gate_suite.py --scope consistency
+
+  # PR-scoped strict docs build (docs-airtightness A1.4). `mkdocs build
+  # --strict` fails on a broken internal wiki link or an orphaned (not-in-nav)
+  # page. It previously ran ONLY in pages.yml, which triggers on push:[main] +
+  # tags — i.e. AFTER merge. So a wiki-breaking PR merged green and only THEN
+  # reddened main's Pages build, violating the green-checks MUST. Running the
+  # same build here (on pull_request + merge_group) moves that gate before the
+  # merge. Build-only: no artifact upload, no deploy — pages.yml still owns the
+  # publish. The invocation + docs toolchain mirror pages.yml's build job
+  # verbatim (uv sync --group docs -> uv run --no-sync mkdocs build --strict) so
+  # the pre-merge gate and the deploy gate can never diverge. Kept a SIBLING job
+  # (not a step in `consistency`) so the fast Node-free staleness guards are not
+  # slowed by the mkdocs-material install, and so a docs-build failure is
+  # attributable on its own line.
+  docs-build:
+    name: docs build (strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: false
+          python-version: "3.12"
+
+      - name: Install docs toolchain
+        run: uv sync --group docs
+
+      - name: Build site (strict)
+        run: uv run --no-sync mkdocs build --strict

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -43,13 +43,47 @@ name: sync-wiki
 on:
   push:
     branches: [main]
+    # The paths filter MUST cover the FULL input set of the three generators
+    # this workflow runs, not just docs/wiki/ + the scripts. A canon-only push
+    # (e.g. editing docs/ROADMAP.md or a package's public surface WITHOUT
+    # touching docs/wiki/) regenerates a DIFFERENT wiki page — omitting those
+    # inputs is a partial dead-trigger (the wiki sync never fires, so the live
+    # wiki goes stale). Rule: a paths filter must cover the full input set —
+    # partial dead-trigger class (docs-airtightness A1.2). The required
+    # sync_*.py --check drift gates in consistency.yml (A1.1) are the safety net
+    # if this list ever misses one, but the correct fix is to keep it complete.
     paths:
+      # The wiki source tree + the sync/generator scripts + this workflow.
       - "docs/wiki/**"
       - "scripts/sync_wiki_to_github.py"
       - "scripts/wiki/sync_mirrors.py"
       - "scripts/wiki/sync_reference.py"
       - "scripts/wiki/sync_api_docs.py"
       - ".github/workflows/sync-wiki.yml"
+      # sync_mirrors.py inputs: the 13 canonical mirror sources (MIRRORS tuple).
+      #   6-project (9):
+      - "docs/ROADMAP.md"
+      - "CHANGELOG.md"
+      - "docs/api-stability.md"
+      - "docs/deprecation-calendar.md"
+      - "GOVERNANCE.md"
+      - "SECURITY.md"
+      - "CONTRIBUTING.md"
+      - "EOL.md"
+      - "docs/verification.md"
+      #   5-compliance (4):
+      - "docs/ocsf-mapping.md"
+      - "docs/gemara-mapping.md"
+      - "docs/financial-sector-overlay.md"
+      - "docs/contributing-a-catalog.md"
+      # sync_reference.py + sync_api_docs.py inputs: the live package surface
+      # (Typer CLI app, MCP server, config models, catalogs/mappings data, and
+      # every package's public __init__/pyproject) that the reference + per-
+      # package API pages are generated from. A code-only push that changes a
+      # CLI verb / MCP tool / env var / catalog must re-fire the wiki sync.
+      - "packages/**/*.py"
+      - "packages/**/pyproject.toml"
+      - "packages/evidentia-core/src/evidentia_core/catalogs/data/**"
   workflow_dispatch:
 
 # Top-level defaults: read-only. The push to <repo>.wiki.git needs

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -45,8 +45,11 @@ and search:
 - **Security decisions** — handled per the disclosure policy in
   [`SECURITY.md`](SECURITY.md) using GitHub Private Vulnerability
   Reporting + the per-release [`docs/release-checklist.md`](docs/release-checklist.md)
-  security gate. Per-release security reviews are published as
-  `docs/security-review-vX.Y.Z.md`.
+  security gate. Every release gets a review sized to its change
+  surface via the `/pre-release-review` right-sizing rubric: a full
+  review (published as `docs/security-review-vX.Y.Z.md`) when the
+  attack surface changes, or a right-sized reuse-based review
+  (logged in the release's per-run record) otherwise.
 - **Release decisions** — gated by the 11-step
   [`docs/release-checklist.md`](docs/release-checklist.md) (pre-release
   scope confirmation through post-release verification).

--- a/check-docs-health-patterns.yaml
+++ b/check-docs-health-patterns.yaml
@@ -1,0 +1,85 @@
+# Committed base config for scripts/check_docs_health.py (docs-airtightness A1.5).
+#
+# This is the PUBLIC, non-sensitive layer of the doc-health phrase config. It
+# ships in the repo so the reclaimable-vendor-host check runs in EVERY
+# environment — CI runners, fresh clones, collaborators — not only on a machine
+# that happens to hold the gitignored private overlay.
+#
+# Layering
+# --------
+# check_docs_health.py loads THIS file as the base, then merges the private
+# overlay `private/check-docs-health-patterns.yaml` on top if it is present.
+# The private overlay WINS / EXTENDS: its forbidden_patterns are appended, and
+# its scalar/list keys (commit_cutoff_sha, tag_allowlist, file_allowlist,
+# line_allowlist) override or extend the base. The base intentionally sets only
+# `forbidden_patterns` (the vendor-host set) and leaves the audit-scoping keys
+# empty, so on a runner WITHOUT the overlay the commit/tag/release-body phrase
+# audits degrade to their advisory-WARN "config incomplete" behavior while the
+# vendor-host grep over tracked .md files still runs and BLOCKS on a match.
+#
+# Why vendor hosts are here (and only here)
+# -----------------------------------------
+# Reclaimable vendor-preview subdomains (e.g. *.vercel.app) can be taken over
+# by an unrelated party once the originating deployment is deleted
+# (dangling-subdomain / link-takeover). Real incident (2026-06-17): the
+# README's "Live Demo" linked evidentia-demo.vercel.app, which had been
+# reclaimed and was serving a DIFFERENT company — caught only in a manual
+# pre-send review. This gate makes any such host in a tracked .md file a
+# blocking FAIL. Use owned domains instead (evidentiagrc.com,
+# polycentriclabs.com, allenfbyrd.com, and their subdomains).
+#
+# Each pattern below is a deterministic, network-free regex applied by the
+# `phrase_audit` check to every tracked public .md file (outside the
+# file_allowlist). `flags: [IGNORECASE]` makes host matching case-insensitive.
+
+forbidden_patterns:
+  - name: vendor_host_vercel_app
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.vercel\.app\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  - name: vendor_host_netlify_app
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.netlify\.app\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  - name: vendor_host_pages_dev
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.pages\.dev\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  - name: vendor_host_herokuapp_com
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.herokuapp\.com\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  - name: vendor_host_web_app
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.web\.app\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  - name: vendor_host_fly_dev
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.fly\.dev\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  - name: vendor_host_onrender_com
+    regex: '\bhttps?://[a-z0-9-]+(?:\.[a-z0-9-]+)*\.onrender\.com\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains"
+
+  # github.io: any *.github.io project/user page is reclaimable if the account
+  # or repo is deleted, so it is flagged by default — EXCEPT two allowlisted,
+  # stable pages this repo legitimately cites:
+  #   * polycentric-labs.github.io — the project's OWN Pages host (mkdocs.yml,
+  #     pages.yml, the generated wiki API pages). Owned by us.
+  #   * squidfunk.github.io — the canonical docs homepage of the Material for
+  #     MkDocs upstream tool the wiki is built with (a maintained OSS project's
+  #     own page, not a reclaimable deploy-preview). Cited in docs/wiki/index.md.
+  # The negative lookahead allowlists exactly those two hosts and flags every
+  # other github.io host. (Deploy-preview hosts like *.vercel.app have no such
+  # legitimate-upstream-citation case, so they carry no allowlist.)
+  - name: vendor_host_github_io
+    regex: '\bhttps?://(?!(?:polycentric-labs|squidfunk)\.github\.io)[a-z0-9-]+(?:\.[a-z0-9-]+)*\.github\.io\b'
+    flags: [IGNORECASE]
+    reason: "reclaimable vendor-preview host — takeover risk; use owned domains (polycentric-labs.github.io + squidfunk.github.io allowlisted)"

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -1,4 +1,4 @@
-# Evidentia v0.7.0 — capability matrix
+# Evidentia capability matrix (v0.7.0 baseline · re-validated through v0.10.12)
 
 > Step-4 deliverable from the v0.7.0 comprehensive review (2026-04-25).
 > Functional + code-review + adversarial smoke testing of every public

--- a/docs/deprecation-calendar.md
+++ b/docs/deprecation-calendar.md
@@ -22,7 +22,7 @@
 | `evidentia conmon check --last-completed-file` (CLI flag) | `--state-file` | v0.9.6 (2026-05-18) | **v1.0.0** | Normalized to match `conmon watch`, `conmon health`, `conmon mark-completed`. DeprecationWarning emitted when used; specifying both flags exits with code 2. |
 | `evidentia_core.models.finding.SecurityFinding` (library class name) | `evidentia_core.models.finding.Finding` (same class, new canonical name) | v0.10.1 (2026-05-23) | **v1.0.0** (earliest major bump) | The `SecurityFinding` name is kept as a backward-compatible alias for ≥ 1 minor cycle per the deprecation policy. Both names refer to the same class — no runtime difference, no behavior change, `isinstance(obj, SecurityFinding)` and `isinstance(obj, Finding)` both succeed. The rename aligns with OCSF's "Finding" terminology (Compliance Finding, Detection Finding). No `DeprecationWarning` is emitted in v0.10.1 to avoid spamming the ~50+ existing call sites — the alias is silent. Operators / integrators are encouraged to switch to `Finding` in new code; existing code keeps working unchanged. |
 
-No other surfaces are currently deprecated as of v0.10.1.
+No other surfaces are currently deprecated as of v0.10.16.
 
 ---
 

--- a/docs/design-partner-program.md
+++ b/docs/design-partner-program.md
@@ -1,0 +1,10 @@
+# Design partner program — withdrawn
+
+This page has been withdrawn; the design partner program it described
+never launched publicly. It's kept here only so existing links to this
+path keep resolving instead of 404ing.
+
+For partnership or engagement inquiries, contact
+[Allen Byrd](mailto:allen@allenfbyrd.com) (see [`SECURITY.md`](../SECURITY.md)
+for the same contact) or open a discussion via
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/engineering-practices.md
+++ b/docs/engineering-practices.md
@@ -98,11 +98,22 @@ Evidentia's releases are designed to be independently verifiable end to end:
   inspection, never an input to a release. The publish path also runs
   **cache-free**: a PR-writable Actions cache read inside an artifact-producing
   job is a cache-poisoning vector, so the release builds every layer and
-  toolchain from source-of-truth references.
+  toolchain from source-of-truth references. A release build must also use a
+  version distinct from every published one: if artifacts are built at a
+  version that already exists on the index, the resolver sources dependency
+  metadata from the *index*, not the freshly-built local wheels, so a
+  newly-added core dependency silently vanishes from the pinned closure —
+  which is why a same-version committed hash file is structurally infeasible
+  before publication.
 - **Vulnerability scanning** runs `osv-scanner` against the resolved dependency
   closure — including the container's independently-resolved closure — on every
   pull request, surfacing transitive and disputed advisories the standard alert
-  feed suppresses.
+  feed suppresses. Each requirements/lock artifact represents exactly one
+  dependency closure — the container's closure is not the published package's
+  closure — so expected drift between them is not a defect to "fix";
+  regeneration consumes the committed input file (never overwriting it, which
+  would drop manually-added security floors) and asserts the expected pins are
+  present afterward.
 - **Dependency updates are automated with guardrails.** Dependabot proposes
   weekly, grouped, cooldown-delayed version updates (a freshly-published release
   is held a few days, so a yanked or hot-fixed bad release is superseded before it
@@ -168,7 +179,11 @@ publicly.
   advisories) — and removing `curl` is not egress denial (Python
   `socket`/`urllib` remain).
 - **Secret scanning.** A pinned gitleaks binary scans the full history on every
-  push and pull request, complementing a local pre-push secret scan.
+  push and pull request, complementing a local pre-push secret scan. Systemic
+  secret-scanner false positives are encoded the same way — as value-precise
+  allowlist regexes in committed config, matched against the flagged secret
+  *value*, never as a path allowlist over source directories — and verified
+  locally before landing.
 - **Defensive guards in the code itself.** Network-egress paths enforce a
   public-host SSRF guard that fires *before* any optional driver import, so the
   security property holds even with zero optional extras installed — a property
@@ -256,6 +271,14 @@ real defects before any of it reached the release pipeline.
   reviewed in pull requests, and are guarded by automated consistency checks:
   the version is consistent across every source, capability counts match the
   code, and cross-document links resolve.
+- **Doc moves are airtight.** Because GitHub does not redirect moved document
+  paths, any doc cited by a frozen external surface (an immutable release
+  body, a per-version package README, a tool config pointer) 404s the instant
+  it moves; before a reorganization, frozen-cited paths are enumerated, left
+  as stub redirects with an index map, and the citing gates are updated
+  atomically in the move commit. Link-resolution checks sweep config-embedded
+  and workflow-embedded doc pointers, not only tracked Markdown, since a
+  phantom pointer shipped in code reaches the package index as a live 404.
 
 ---
 
@@ -401,6 +424,44 @@ structurally dead trigger events and automatic triggers that have never
 produced a run (`scripts/check_workflow_liveness.py`), and the same strict CI
 check that guards tool availability validates install-spec extras against the
 package manifests.
+
+**10. An open-ended version bound let the resolver explore an impossible
+world.** The project declared its Python floor with no upper bound, while a
+transitive AI-stack dependency capped a core library well below the newest
+Python. That combination is not merely cosmetic: the dependency updater runs a
+*universal* resolver that solves across every Python version the bound admits,
+so it explored future interpreter versions where the transitive cap became
+mathematically unsatisfiable — and every updater run then failed with
+"requirements unsatisfiable." The visible symptom was oblique: the build stayed
+green, but *every* open dependency pull request silently stopped rebasing, so
+none could ever pick up a newly-required status check — a whole class of
+updates wedged behind a resolver error nobody was watching. The guardrail that
+should have caught the underlying base-image drift earlier was itself dead: an
+ignore rule written to block *major* base-image bumps assumed a `3.13 → 3.14`
+step was a major change, but the updater classifies it as *minor* (the leading
+component stays `3`), so the rule never matched the class it was written to
+stop — the same incident, one layer up. *Root cause:* a version bound was
+treated as honesty metadata rather than a load-bearing input to resolution, and
+a guardrail's matching semantics were never checked against how the tool
+actually classifies the change it was meant to catch — a rule that looks
+protective but can never fire. *Prevention:* **declare the true supported
+ceiling** — cap the floor's upper bound to the tightest transitive cap the
+project actually inherits, with a comment stating *why* and the *condition
+that removes it*; in a workspace where members intersect, a single root cap
+prunes the unsatisfiable resolver fork *during* resolution, unblocking the
+updater immediately. Use a plain comparator, never a compatible-release
+operator, which the updater's dependency graph cannot parse. And because a cap
+set on someone else's constraint should not become permanent by neglect, pair
+it with a scheduled watcher (`scripts/check_python_ceiling.py` in
+`python-ceiling-watch.yml`) that reads the blocking package's published
+metadata, evaluates it with real version-set containment rather than brittle
+string matching, and opens a single tracking issue proposing the lift when the
+ecosystem is ready — while the lift itself stays human-gated behind a real lock
+trial, because an upstream relaxing its own bound is necessary but not
+sufficient when other transitive gates remain. The same audit applies to every
+ignore/ceiling rule in the dependency-update config: state the exact class it
+is meant to catch, and verify that class against the tool's actual
+classification of the change, not an assumption about what "major" means.
 
 ---
 

--- a/docs/enterprise-grade.md
+++ b/docs/enterprise-grade.md
@@ -1,4 +1,4 @@
-# Enterprise-grade credibility checklist (v0.7.0 baseline · maintained through v0.10.12)
+# Enterprise-grade credibility checklist (v0.7.0 baseline · maintenance summary last refreshed v0.10.12, current release v0.10.16)
 
 Evidentia's v0.7.0 release established the quality bar that Big-4 audit
 firms (Deloitte, PwC, KPMG, EY), FedRAMP Third-Party Assessor

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -13,9 +13,9 @@
 > Cross-link to: [testing-playbook.md](testing-playbook.md) (the
 > operational test loop), [enterprise-grade.md](enterprise-grade.md)
 > (the quality bar), [capability-matrix.md](capability-matrix.md)
-> (last release's test snapshot), [v0.7.2-plan.md](v0.7.2-plan.md)
-> (the next release's scope), [v0.7.1-plan.md](v0.7.1-plan.md)
-> (the prior release's scope, SHIPPED 2026-04-26).
+> (last release's test snapshot), [ROADMAP.md](ROADMAP.md) (the
+> current dev cycle and its scope; the top PLANNED entry links the
+> active `docs/v<x>-plan.md` when one exists for the cycle).
 
 ---
 
@@ -232,7 +232,7 @@ Acceptance:
 - [ ] mypy: `Success: no issues found in N source files`
 - [ ] pytest: ≥ 857 passed (the v0.7.0 baseline; will grow over
       time), ≤ 8 skipped, 16 benign Tier-C warnings
-- [ ] `uv build --all-packages`: 6 evidentia-* wheels + sdists at the
+- [ ] `uv build --all-packages`: 8 evidentia-* wheels + sdists at the
       new version (no shim wheels)
 - [ ] `uvx twine check dist/*`: every distribution PASSED
 - [ ] (v0.9.9+) `scripts/run_osv_scan.py`: `PASS: osv-scanner found no

--- a/docs/v1.0-transition.md
+++ b/docs/v1.0-transition.md
@@ -278,7 +278,7 @@ direction TBD per landscape evolution.
 
 Timeline TBD; not blocking v0.9.x or v1.0 OSS work.
 
-## Current best-guess timing
+## Best-guess timing (as estimated at authoring time, v0.8.6)
 
 v0.9.0 SHIPPED 2026-05-15. v0.9.x cycle has 3-4 remaining
 releases. v1.0 sits 1-2 cycles past the final v0.9.x release

--- a/docs/wiki/6-project/deprecation-policy.md
+++ b/docs/wiki/6-project/deprecation-policy.md
@@ -25,7 +25,7 @@
 | `evidentia conmon check --last-completed-file` (CLI flag) | `--state-file` | v0.9.6 (2026-05-18) | **v1.0.0** | Normalized to match `conmon watch`, `conmon health`, `conmon mark-completed`. DeprecationWarning emitted when used; specifying both flags exits with code 2. |
 | `evidentia_core.models.finding.SecurityFinding` (library class name) | `evidentia_core.models.finding.Finding` (same class, new canonical name) | v0.10.1 (2026-05-23) | **v1.0.0** (earliest major bump) | The `SecurityFinding` name is kept as a backward-compatible alias for ≥ 1 minor cycle per the deprecation policy. Both names refer to the same class — no runtime difference, no behavior change, `isinstance(obj, SecurityFinding)` and `isinstance(obj, Finding)` both succeed. The rename aligns with OCSF's "Finding" terminology (Compliance Finding, Detection Finding). No `DeprecationWarning` is emitted in v0.10.1 to avoid spamming the ~50+ existing call sites — the alias is silent. Operators / integrators are encouraged to switch to `Finding` in new code; existing code keeps working unchanged. |
 
-No other surfaces are currently deprecated as of v0.10.1.
+No other surfaces are currently deprecated as of v0.10.16.
 
 ---
 

--- a/docs/wiki/6-project/governance.md
+++ b/docs/wiki/6-project/governance.md
@@ -48,8 +48,11 @@ and search:
 - **Security decisions** — handled per the disclosure policy in
   [`SECURITY.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/SECURITY.md) using GitHub Private Vulnerability
   Reporting + the per-release [`docs/release-checklist.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/release-checklist.md)
-  security gate. Per-release security reviews are published as
-  `docs/security-review-vX.Y.Z.md`.
+  security gate. Every release gets a review sized to its change
+  surface via the `/pre-release-review` right-sizing rubric: a full
+  review (published as `docs/security-review-vX.Y.Z.md`) when the
+  attack surface changes, or a right-sized reuse-based review
+  (logged in the release's per-run record) otherwise.
 - **Release decisions** — gated by the 11-step
   [`docs/release-checklist.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/release-checklist.md) (pre-release
   scope confirmation through post-release verification).

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -49,7 +49,11 @@ reason = "torch 2.11.0 (CVE-2025-3000 / PYSEC-2025-194, CVSS3.1 5.3 AV:L, CWE-11
 # READ in the OpenSSL statically bundled into cryptography's PyPI wheels (wheel-only --
 # sdist builds use system OpenSSL). This entry is retained ONLY because the full-extras
 # DEV resolution (sigstore+ocsf+collectors) is still capped below the fix by py-ocsf-models.
-# Full reachability proof: docs/security-review-v0.10.10.md.
+# Full reachability proof: CHANGELOG.md `## [0.10.10]` (original acceptance
+# rationale) + `## [0.10.16]` (shipped-container fix confirmation, P2 DHI
+# migration) -- v0.10.10 was a skip-by-reuse cycle with no standalone
+# docs/security-review-v0.10.10.md; the nearest full review is
+# docs/security-review-v0.10.12.md.
 [[IgnoredVulns]]
 id = "GHSA-537c-gmf6-5ccf"
 ignoreUntil = 2026-09-15

--- a/scripts/check_docs_health.py
+++ b/scripts/check_docs_health.py
@@ -31,11 +31,14 @@ DOC HEALTH (always runs):
                               ``gen_readme_releases.py --check``; can't
                               ship a stale releases list). Added E5c.
 
-PHRASE AUDIT (config-driven; runs only if private config present):
+PHRASE AUDIT (config-driven; layered base + private overlay):
 
-7. **phrase_audit**         — no forbidden phrases (per the project's
-                              private phrase config) in tracked public
-                              files outside the per-file allowlist.
+7. **phrase_audit**         — no forbidden phrases (per the layered phrase
+                              config) in tracked public files outside the
+                              per-file allowlist. This includes the committed
+                              base's reclaimable-vendor-host patterns
+                              (*.vercel.app / *.netlify.app / *.pages.dev / …)
+                              plus any private-overlay phrases.
 8. **commit_msg_audit**     — same forbidden-phrase set, applied to
                               commit messages in the range
                               ``cutoff..HEAD`` (cutoff loaded from
@@ -51,10 +54,19 @@ PHRASE AUDIT (config-driven; runs only if private config present):
                               (gracefully WARNs if gh is unauthenticated
                               or returns empty).
 
-Config: ``private/check-docs-health-patterns.yaml`` (gitignored).
-If absent, the 4 phrase-related checks emit one WARN and skip; the
-4 doc-health checks still run. See ``private/README.md`` for the
-config schema + setup.
+Config (layered, docs-airtightness A1.5):
+  * ``check-docs-health-patterns.yaml`` (repo root) — the committed, PUBLIC
+    base. Ships the reclaimable-vendor-host patterns so that grep runs in
+    EVERY environment (CI, fresh clones).
+  * ``private/check-docs-health-patterns.yaml`` (gitignored) — the PRIVATE
+    overlay: the sensitive phrase set + audit-scoping keys
+    (``commit_cutoff_sha``, ``tag_allowlist``, …). Merged on top of the base;
+    it WINS / EXTENDS.
+If the private overlay is absent, the commit/tag/release-body audits emit an
+advisory WARN and skip (no ``commit_cutoff_sha``), but the base vendor-host
+grep + the 6 always-on doc-health checks still run. If NEITHER layer is
+present, all phrase checks skip with one WARN. See ``private/README.md`` for
+the private-overlay schema + setup.
 
 SPECIAL MODE for the commit-msg git hook:
 
@@ -107,6 +119,14 @@ from enum import Enum
 from pathlib import Path
 
 REPO_ROOT = Path.cwd().resolve()
+# Layered phrase config (docs-airtightness A1.5):
+#   * BASE_CONFIG_PATH — committed, PUBLIC, non-sensitive layer. Ships in the
+#     repo so the reclaimable-vendor-host grep runs in EVERY environment (CI,
+#     fresh clones), never only where the private overlay happens to exist.
+#   * PHRASE_CONFIG_PATH — the gitignored PRIVATE overlay. Merged on top of the
+#     base when present; it WINS/EXTENDS (its patterns append, its scalar/list
+#     keys override the base's). Absent for fresh clones / collaborators.
+BASE_CONFIG_PATH = Path("check-docs-health-patterns.yaml")
 PHRASE_CONFIG_PATH = Path("private/check-docs-health-patterns.yaml")
 
 # ── README header Title-Case invariant (v0.10.7 E5c) ───────────────────────
@@ -192,24 +212,21 @@ class PhraseConfig:
         )
 
 
-def load_phrase_config() -> tuple[PhraseConfig, str | None]:
-    """Load the private phrase-audit config.
+def _parse_config_file(config_path: Path) -> tuple[dict | None, str | None]:
+    """Parse one YAML config file into a raw dict.
 
-    Returns (config, error_message). If config is absent or unparseable,
-    the returned config is the empty placeholder and error_message
-    describes why phrase checks are disabled.
+    Returns ``(data, error)``. ``data`` is ``None`` (with a populated
+    ``error``) when the file is absent, PyYAML is unavailable, the file is
+    unparseable, or its top level is not a mapping. Pure — no compilation or
+    merging happens here (that is :func:`load_phrase_config`'s job).
     """
-    config_path = REPO_ROOT / PHRASE_CONFIG_PATH
     if not config_path.exists():
-        return PhraseConfig.empty(), (
-            f"phrase config not found at {PHRASE_CONFIG_PATH.as_posix()}; "
-            f"phrase checks disabled (see private/README.md for setup)"
-        )
+        return None, f"config not found at {config_path.as_posix()}"
 
     try:
         import yaml  # type: ignore[import-untyped]
     except ImportError:
-        return PhraseConfig.empty(), (
+        return None, (
             "PyYAML not available; phrase checks disabled "
             "(install with `uv sync --all-groups`)"
         )
@@ -217,17 +234,24 @@ def load_phrase_config() -> tuple[PhraseConfig, str | None]:
     try:
         data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except (yaml.YAMLError, OSError) as e:
-        return PhraseConfig.empty(), (
-            f"phrase config at {PHRASE_CONFIG_PATH.as_posix()} unparseable: {e}"
-        )
+        return None, f"config at {config_path.as_posix()} unparseable: {e}"
 
     if not isinstance(data, dict):
-        return PhraseConfig.empty(), (
-            f"phrase config at {PHRASE_CONFIG_PATH.as_posix()} not a dict"
-        )
+        return None, f"config at {config_path.as_posix()} not a dict"
 
-    raw_patterns = data.get("forbidden_patterns", []) or []
+    return data, None
+
+
+def _compile_patterns(raw_patterns: object) -> list[tuple[str, re.Pattern[str]]]:
+    """Compile a raw ``forbidden_patterns`` list into ``(name, pattern)`` pairs.
+
+    Each entry is a mapping with ``name`` + ``regex`` (and optional ``flags`` /
+    ``reason``; ``reason`` is documentation-only and ignored here). Malformed
+    entries and uncompilable regexes are skipped, matching the prior behavior.
+    """
     compiled: list[tuple[str, re.Pattern[str]]] = []
+    if not isinstance(raw_patterns, list):
+        return compiled
     for entry in raw_patterns:
         if not isinstance(entry, dict):
             continue
@@ -242,20 +266,94 @@ def load_phrase_config() -> tuple[PhraseConfig, str | None]:
             compiled.append((name, re.compile(regex, flags)))
         except re.error:
             continue
+    return compiled
 
-    raw_line_allow = data.get("line_allowlist", {}) or {}
+
+def _parse_line_allowlist(raw_line_allow: object) -> dict[str, set[int]]:
+    """Parse a raw ``line_allowlist`` mapping into ``{path: {line, ...}}``."""
     line_allow: dict[str, set[int]] = {}
     if isinstance(raw_line_allow, dict):
         for path_key, lines in raw_line_allow.items():
             if isinstance(lines, list):
                 line_allow[str(path_key)] = {int(n) for n in lines if isinstance(n, int)}
+    return line_allow
+
+
+def load_phrase_config() -> tuple[PhraseConfig, str | None]:
+    """Load the layered doc-health phrase config (base + private overlay).
+
+    Two layers (docs-airtightness A1.5):
+
+      * The committed, public BASE at :data:`BASE_CONFIG_PATH` — ships the
+        reclaimable-vendor-host patterns so that check runs in every
+        environment.
+      * The gitignored PRIVATE overlay at :data:`PHRASE_CONFIG_PATH` — the
+        sensitive phrase set + audit-scoping keys.
+
+    The private overlay WINS / EXTENDS: its ``forbidden_patterns`` are appended
+    to the base's, and its scalar/list keys (``commit_cutoff_sha``,
+    ``tag_allowlist``, ``file_allowlist``, ``line_allowlist``) override or
+    extend the base's. ``is_loaded`` is True if EITHER layer parsed, so the
+    doc-health run treats the config as present whenever the committed base
+    ships (which it always does in-repo).
+
+    Returns ``(config, error_message)``. ``error_message`` is populated only
+    when NEITHER layer could be loaded (so phrase checks are fully disabled) —
+    it describes why. When the base loads but the private overlay is absent,
+    the config is returned with ``error_message=None`` and the commit/tag/
+    release-body audits degrade to their own advisory WARNs (missing
+    ``commit_cutoff_sha`` etc.), while the base vendor-host grep still runs.
+    """
+    # The per-file parse errors are intentionally discarded: a missing/
+    # unparseable single layer is not itself an error as long as the OTHER
+    # layer loaded (handled below); only the both-absent case surfaces a
+    # message, and it builds its own.
+    base_data, _base_err = _parse_config_file(REPO_ROOT / BASE_CONFIG_PATH)
+    priv_data, _priv_err = _parse_config_file(REPO_ROOT / PHRASE_CONFIG_PATH)
+
+    if base_data is None and priv_data is None:
+        # Neither layer available: phrase checks fully disabled. Surface the
+        # private-overlay reason (the historical message) so setup guidance is
+        # unchanged for the common "no config at all" case.
+        return PhraseConfig.empty(), (
+            f"phrase config not found at {PHRASE_CONFIG_PATH.as_posix()} "
+            f"or {BASE_CONFIG_PATH.as_posix()}; phrase checks disabled "
+            f"(see private/README.md for setup)"
+        )
+
+    base_data = base_data or {}
+    priv_data = priv_data or {}
+
+    # forbidden_patterns: base first, then private appended (private extends).
+    compiled = _compile_patterns(base_data.get("forbidden_patterns", []) or [])
+    compiled += _compile_patterns(priv_data.get("forbidden_patterns", []) or [])
+
+    # file_allowlist: union (either layer may exempt a path).
+    file_allow = list(base_data.get("file_allowlist", []) or []) + list(
+        priv_data.get("file_allowlist", []) or []
+    )
+
+    # line_allowlist: merge; private wins on a path collision.
+    line_allow = _parse_line_allowlist(base_data.get("line_allowlist", {}) or {})
+    line_allow.update(_parse_line_allowlist(priv_data.get("line_allowlist", {}) or {}))
+
+    # tag_allowlist: union.
+    tag_allow = set(base_data.get("tag_allowlist", []) or []) | set(
+        priv_data.get("tag_allowlist", []) or []
+    )
+
+    # commit_cutoff_sha: private wins (base leaves it empty).
+    cutoff = str(
+        priv_data.get("commit_cutoff_sha", "")
+        or base_data.get("commit_cutoff_sha", "")
+    )
 
     return PhraseConfig(
         forbidden_patterns=compiled,
-        file_allowlist_globs=list(data.get("file_allowlist", []) or []),
+        file_allowlist_globs=file_allow,
         line_allowlist=line_allow,
-        tag_allowlist=set(data.get("tag_allowlist", []) or []),
-        commit_cutoff_sha=str(data.get("commit_cutoff_sha", "")),
+        tag_allowlist=tag_allow,
+        commit_cutoff_sha=cutoff,
         is_loaded=True,
     ), None
 
@@ -413,14 +511,17 @@ def check_cross_link_resolve(
             if abs_target.is_dir():
                 continue
             if rel_to_repo not in all_tracked:
-                # Downgrade to WARN for any broken link under docs/wiki/.
-                # The wiki is scaffolded in v0.10.7; per-page files fill
-                # in over upcoming cycles. Section indexes legitimately
-                # reference future stubs.
-                under_wiki = rel_to_repo.parts[:2] == ("docs", "wiki")
-                severity = Severity.WARN if under_wiki else Severity.FAIL
+                # A broken relative link always FAILs (docs-airtightness A1.3).
+                # Historically broken links under docs/wiki/ were DOWNGRADED to
+                # WARN on the rationale that the wiki was "scaffolded" in v0.10.7
+                # with per-page stubs filling in over later cycles. The wiki is
+                # now content-complete, so that rationale is dead — a broken
+                # wiki-internal link is real link-rot and must block --strict in
+                # required CI (previously it slipped through to be caught only
+                # post-merge by the Pages `mkdocs build --strict`; A1.4 also
+                # adds a PR-scoped strict build as a second layer).
                 result.add(Finding(
-                    severity, "cross_link_resolve", path.as_posix(), line,
+                    Severity.FAIL, "cross_link_resolve", path.as_posix(), line,
                     f"broken link to {rel_to_repo.as_posix()}",
                 ))
 

--- a/scripts/run_gate_suite.py
+++ b/scripts/run_gate_suite.py
@@ -23,8 +23,9 @@ Scopes
 
 * ``consistency`` — the fast staleness guards (no test/type/scan run):
   ``version_consistency`` + ``docs_health`` + ``readme_releases`` +
-  ``doc_counts``. This is the set the pre-push hook and the push/PR
-  ``consistency.yml`` enforce on every change.
+  ``doc_counts`` + the three wiki drift gates (``wiki_mirrors_drift`` +
+  ``wiki_reference_drift`` + ``wiki_api_docs_drift``). This is the set the
+  pre-push hook and the push/PR ``consistency.yml`` enforce on every change.
 * ``full`` — ``consistency`` PLUS the heavyweight gates
   (``pytest`` + ``mypy`` + ``ruff`` + ``osv`` + ``parity``). This is
   the set the tag-time ``gate`` job runs before any artifact is
@@ -112,6 +113,30 @@ _CONSISTENCY_CHECKS: tuple[Check, ...] = (
     Check(
         "doc_counts",
         ("python", "scripts/check_doc_counts.py"),
+    ),
+    # Wiki mirror/reference/API drift gates (docs-airtightness A1.1). Each
+    # generator has a --check mode that regenerates its wiki pages in memory
+    # and byte-compares them against the committed copies; a non-zero exit is
+    # drift. These previously ran ONLY inside sync-wiki.yml's regenerate steps
+    # (which overwrite + push, so drift was silently corrected at deploy time,
+    # never surfaced as a failing PR/push check) — a mirror drift shipped
+    # undetected this cycle. Wiring them into the consistency scope makes them
+    # blocking in consistency.yml (push/PR/merge_group) AND the pre-push hook,
+    # with no ruleset change. They read the workspace (sync_reference imports
+    # the Typer app; sync_api_docs reads each package's source), which the
+    # `uv run --all-extras --all-packages` env in _run_check + consistency.yml's
+    # `uv sync --all-packages` both provide. All three PASS on HEAD.
+    Check(
+        "wiki_mirrors_drift",
+        ("python", "scripts/wiki/sync_mirrors.py", "--check"),
+    ),
+    Check(
+        "wiki_reference_drift",
+        ("python", "scripts/wiki/sync_reference.py", "--check"),
+    ),
+    Check(
+        "wiki_api_docs_drift",
+        ("python", "scripts/wiki/sync_api_docs.py", "--check"),
     ),
 )
 

--- a/scripts/version_tracked_files.yaml
+++ b/scripts/version_tracked_files.yaml
@@ -337,8 +337,14 @@ frozen:
 #   EXACTLY-ONE rule in the SCHEMA header.
 #
 #   NOTE on mirrors: the wiki "mirror" pages under docs/wiki/6-project/ are
-#   GENERATED from these canonical sources by scripts/wiki/sync_mirrors.py (the
-#   --check drift gate is wired into sync-wiki.yml). We anchor the SOURCE
+#   GENERATED from these canonical sources by scripts/wiki/sync_mirrors.py. Its
+#   --check drift gate is a REQUIRED check: it runs in the `consistency` scope
+#   of scripts/run_gate_suite.py, which consistency.yml (push/PR/merge_group)
+#   and the .githooks/pre-push hook both invoke (docs-airtightness A1.1). (The
+#   sync-wiki.yml workflow regenerates these pages in WRITE mode before the wiki
+#   push — that path auto-corrects drift on deploy but does not GATE it; the
+#   required --check in consistency.yml is what blocks a drifted PR.) We anchor
+#   the SOURCE
 #   (SECURITY.md, docs/ROADMAP.md, docs/verification.md); the corresponding
 #   mirrors (6-project/security.md, /roadmap.md, /verification.md) inherit the
 #   new literal on the next `sync_mirrors.py` run and are deliberately NOT

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -68,7 +68,11 @@ repository:
     assessments:
       self:
         comment: |
-          Per-release security review published as docs/security-review-vX.Y.Z.md.
+          Every release gets a security review sized to its change surface
+          (the /pre-release-review right-sizing rubric): a full review is
+          published as docs/security-review-vX.Y.Z.md when the attack
+          surface changes; otherwise a right-sized reuse-based review is
+          performed and logged in the release's per-run record.
           Threat model: docs/threat-model.md (NORMATIVE). OSPS Baseline
           conformance tracked in OSPS-CONFORMANCE.md (Maturity 3, CI-gated).
           OpenSSF Best Practices: Silver (project 12724). Additional CI security


### PR DESCRIPTION
## What

Closeout item #0a: makes the documentation-freshness guardrails **airtight** and fixes every face-stale claim the docs-hygiene audit surfaced. **Zero file moves** (the scoped `docs/` reorg is a separate follow-up PR).

### Airtightness (the verified gaps, now closed)

1. **Wiki drift-gates are now blocking.** The three wiki generators' `--check` modes (`sync_mirrors` / `sync_reference` / `sync_api_docs`) were wired into **no required check** — a mirror drift shipped undetected this month purely on discipline. They now run in the required `consistency` job (via `run_gate_suite --scope consistency`) **and** in the pre-push hook (gates 5–7), so the long-standing "pre-push and CI enforce this set" claim is now literally true.
2. **`sync-wiki.yml` paths filter covers its full input set.** It omitted the 13 mirror canonical sources — canon-only pushes silently never fired the wiki sync (a *partial* dead trigger that run-count liveness can't catch). The filter now enumerates every input the sync consumes.
3. **Wiki link-rot now FAILS.** Removed the obsolete WARN downgrade (its "scaffolded wiki" rationale died months ago). Zero masked broken links surfaced — the removal is prophylactic, not remedial.
4. **PR-scoped `mkdocs build --strict`.** Previously strict-built only in pages.yml *after* merge, so a docs-breaking PR merged green and then redded main. A `docs-build` job in consistency.yml now mirrors the pages build byte-for-byte (same pins, same invocation), build-only.
5. **The reclaimable-vendor-host gate ships in CI.** A committed `check-docs-health-patterns.yaml` carries the vendor-preview-host patterns (vercel.app/netlify.app/pages.dev/… — the dangling-subdomain takeover class behind a real 2026-06-17 incident); the checker now layers a private overlay (which continues to win) over the committed base, so the deterministic public-safe half of the check runs everywhere, not just on one machine.

### Honesty fixes

- **GOVERNANCE.md + security-insights.yml** no longer claim per-release security reviews (full reviews stopped at v0.10.12); they now describe the actual practice — reviews right-sized to each release's change surface, with per-run records.
- **osv-scanner.toml** no longer cites a nonexistent security-review file; the disposition now points at real artifacts.
- **`docs/design-partner-program.md`** exists as an honest tombstone (it was referenced but absent).
- Stale header/version references fixed on release-checklist, capability-matrix, deprecation-calendar (+ mirror), enterprise-grade, v1.0-transition; SECURITY.md verified already-correct (8 packages).
- **engineering-practices gains lesson 10** — *an open-ended version bound let the resolver explore an impossible world*: the requires-python resolver blockage, the dead major-only Dependabot rule, and the cap+watcher prevention (the #146 machinery), plus four one-line section extensions.

## Follow-ups (not this PR)

The `docs build (strict)` context becomes *required* via the ruleset only after it's observed green on main (the add→observe→flip runbook). The scoped `docs/releases/` reorg (with frozen-cited stubs + index) is PR-B. Content-currency updates to deprecation-calendar (OMB M-25-21 row) and enterprise-grade's body are queued with it.

## Validation

- Full local gate: **pytest 4749 passed, 0 failed** (the 4 environmental collector failures cleared after #145's runtime bumps), mypy strict-optional ×7, ruff, `run_gate_suite --scope consistency` 7/7 (including the three new wiki gates), workflow-tools + perms audits, zizmor (repo config, no findings), frontend typecheck+build+vitest
- `mkdocs build --strict` passes PR-scoped; `sync_mirrors --check` 13/13
- Per-task adversarial reviews ×3 (all approved), including an explicit secrecy-boundary verification that the committed pattern file contains only constructed public-safe vendor-host patterns — the private overlay was never read
