### PR TITLE
Chore(deps): Cap member requires-python <3.14 + in-sync consistency check

### DIFF
--- a/packages/evidentia-ai/pyproject.toml
+++ b/packages/evidentia-ai/pyproject.toml
@@ -5,7 +5,8 @@ description = "LLM-powered risk statement generator and evidence validator for E
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "llm", "risk-statement", "nist-800-30", "litellm", "instructor"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia-api/pyproject.toml
+++ b/packages/evidentia-api/pyproject.toml
@@ -5,7 +5,8 @@ description = "FastAPI REST server + bundled React web UI for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "fastapi", "web-ui", "oscal", "rest-api"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia-collectors/pyproject.toml
+++ b/packages/evidentia-collectors/pyproject.toml
@@ -5,7 +5,8 @@ description = "Evidence collection agents for AWS, Databricks, GitHub, Okta, Sno
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "evidence-collection", "aws", "databricks", "github", "okta", "snowflake", "sql", "tprm", "vendor-risk", "vanta", "drata", "bitsight", "securityscorecard"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia-core/pyproject.toml
+++ b/packages/evidentia-core/pyproject.toml
@@ -5,7 +5,8 @@ description = "Core data models, catalog loading, and gap analysis engine for Ev
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "oscal", "nist", "soc2", "risk", "gap-analysis", "pydantic"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia-eval/pyproject.toml
+++ b/packages/evidentia-eval/pyproject.toml
@@ -5,7 +5,8 @@ description = "DFAH (Decision-Faithfulness Assessment Harness) determinism + fai
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "llm-eval", "dfah", "determinism", "faithfulness", "ai-quality"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia-integrations/pyproject.toml
+++ b/packages/evidentia-integrations/pyproject.toml
@@ -5,7 +5,8 @@ description = "Output integrations for Jira and ServiceNow"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "jira", "servicenow", "ticketing"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia-mcp/pyproject.toml
+++ b/packages/evidentia-mcp/pyproject.toml
@@ -5,7 +5,8 @@ description = "Model Context Protocol (MCP) server for Evidentia — exposes gap
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "mcp", "model-context-protocol", "ai-agent"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/packages/evidentia/pyproject.toml
+++ b/packages/evidentia/pyproject.toml
@@ -5,7 +5,8 @@ description = "Open-source GRC tool: gap analysis, risk statements, evidence col
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
 license = "Apache-2.0"
-requires-python = ">=3.12"
+# Ceiling tracks the workspace root cap (litellm <3.14) — see root pyproject.toml for the full rationale + removal trigger; kept in sync by check_version_consistency.py.
+requires-python = ">=3.12,<3.14"
 keywords = ["grc", "compliance", "governance", "risk", "oscal", "nist", "soc2", "iso27001"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -58,6 +58,7 @@ import importlib.util
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -379,6 +380,71 @@ def check_frontend_no_hardcoded_version(bump: Any) -> list[str]:
     return failures
 
 
+def check_requires_python_in_sync(bump: Any) -> list[str]:
+    """Assert the root + every ``packages/*/pyproject.toml`` declare an
+    IDENTICAL ``requires-python`` string.
+
+    The root cap (litellm's ``<3.14`` transitive ceiling) is sufficient for
+    uv workspace RESOLUTION alone (uv workspaces take the intersection of all
+    members' ``requires-python``), but the 8 member packages still publish
+    their own wheel metadata to PyPI — an open-ended member spec would tell a
+    downstream 3.14 consumer "compatible" right up until the litellm wall at
+    install-resolve time. Members are capped to match the root for honest
+    published metadata (see root ``pyproject.toml`` for the full rationale).
+    This check guards that cap against drift: any member whose
+    ``requires-python`` diverges from the root's is a HARD FAIL naming the
+    offending file(s), so the eventual cap-lift (root pyproject.toml's
+    REMOVAL TRIGGER) is atomic across all 9 files rather than silently
+    leaving a member behind.
+
+    Returns a list of human-readable failure strings (empty == pass).
+    """
+    failures: list[str] = []
+    root_path = REPO_ROOT / "pyproject.toml"
+    try:
+        root_data = tomllib.loads(root_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        return [f"cannot read/parse root pyproject.toml: {exc}"]
+    root_requires_python = root_data.get("project", {}).get("requires-python")
+    if not isinstance(root_requires_python, str) or not root_requires_python:
+        return [
+            "root pyproject.toml is missing a [project] requires-python string"
+        ]
+
+    all_tracked = bump.tracked_files()
+    member_files = sorted(
+        bump.expand_manifest_path("packages/*/pyproject.toml", all_tracked)
+    )
+    if not member_files:
+        failures.append(
+            "no packages/*/pyproject.toml files found — fix the glob or the "
+            "workspace layout"
+        )
+        return failures
+
+    for p in member_files:
+        posix = p.as_posix()
+        try:
+            data = tomllib.loads(p.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            failures.append(f"cannot read/parse {posix}: {exc}")
+            continue
+        member_requires_python = data.get("project", {}).get("requires-python")
+        if not isinstance(member_requires_python, str) or not member_requires_python:
+            failures.append(
+                f"{posix} is missing a [project] requires-python string"
+            )
+            continue
+        if member_requires_python != root_requires_python:
+            failures.append(
+                f"requires-python mismatch in {posix}: has "
+                f"{member_requires_python!r}, root pyproject.toml has "
+                f"{root_requires_python!r} — align it so the workspace cap "
+                "stays honest in published wheel metadata"
+            )
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -395,12 +461,14 @@ def main(argv: list[str] | None = None) -> int:
     anchor_failures = check_anchors(bump, manifest, current)
     decisions_failures = check_decisions_documented(manifest)
     frontend_failures = check_frontend_no_hardcoded_version(bump)
+    requires_python_failures = check_requires_python_in_sync(bump)
     all_failures = (
         coverage_failures
         + never_skip_failures
         + anchor_failures
         + decisions_failures
         + frontend_failures
+        + requires_python_failures
     )
 
     if args.json:
@@ -412,6 +480,7 @@ def main(argv: list[str] | None = None) -> int:
             "anchor_failures": anchor_failures,
             "decisions_failures": decisions_failures,
             "frontend_failures": frontend_failures,
+            "requires_python_failures": requires_python_failures,
         }
         print(json.dumps(report, indent=2))
         return 0 if not all_failures else 1
@@ -463,6 +532,16 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(
             "  frontend: PASS — no hardcoded project-version literal in the UI."
+        )
+
+    if requires_python_failures:
+        print()
+        print(f"REQUIRES-PYTHON-IN-SYNC FAILURES ({len(requires_python_failures)}):")
+        for f in requires_python_failures:
+            print(f"  - {f}")
+    else:
+        print(
+            "  requires-python: PASS — root + all member packages agree."
         )
 
     print()

--- a/tests/unit/test_check_version_consistency.py
+++ b/tests/unit/test_check_version_consistency.py
@@ -689,3 +689,106 @@ def test_real_repo_decisions_documented_passes(check: Any) -> None:
     bump = check._load_bump_module()
     manifest = bump.load_manifest()
     assert check.check_decisions_documented(manifest) == []
+
+
+# ── requires-python in-sync (member caps, 2026-07 closeout) ────────────────
+
+
+def _write_pyproject(path: Path, requires_python: str) -> None:
+    path.write_text(
+        f'[project]\nname = "x"\nrequires-python = "{requires_python}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_requires_python_in_sync_passes_when_identical(
+    check: Any, bump: Any, chdir_tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root + every packages/*/pyproject.toml agreeing on requires-python
+    passes cleanly."""
+    _write_pyproject(chdir_tmp / "pyproject.toml", ">=3.12,<3.14")
+    pkg_dir = chdir_tmp / "packages" / "evidentia-core"
+    pkg_dir.mkdir(parents=True)
+    _write_pyproject(pkg_dir / "pyproject.toml", ">=3.12,<3.14")
+    monkeypatch.setattr(check, "REPO_ROOT", chdir_tmp)
+    _make_bump_with_tracked(
+        bump,
+        monkeypatch,
+        ["pyproject.toml", "packages/evidentia-core/pyproject.toml"],
+        [],
+    )
+    assert check.check_requires_python_in_sync(bump) == []
+
+
+def test_requires_python_in_sync_fails_naming_offending_file(
+    check: Any, bump: Any, chdir_tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A member whose requires-python diverges from the root is a hard fail
+    that NAMES the offending file (the observed-firing contract)."""
+    _write_pyproject(chdir_tmp / "pyproject.toml", ">=3.12,<3.14")
+    ok_dir = chdir_tmp / "packages" / "evidentia-core"
+    ok_dir.mkdir(parents=True)
+    _write_pyproject(ok_dir / "pyproject.toml", ">=3.12,<3.14")
+    bad_dir = chdir_tmp / "packages" / "evidentia-mcp"
+    bad_dir.mkdir(parents=True)
+    _write_pyproject(bad_dir / "pyproject.toml", ">=3.12")  # open-ended -> mismatch
+    monkeypatch.setattr(check, "REPO_ROOT", chdir_tmp)
+    _make_bump_with_tracked(
+        bump,
+        monkeypatch,
+        [
+            "pyproject.toml",
+            "packages/evidentia-core/pyproject.toml",
+            "packages/evidentia-mcp/pyproject.toml",
+        ],
+        [],
+    )
+    failures = check.check_requires_python_in_sync(bump)
+    assert len(failures) == 1
+    assert "packages/evidentia-mcp/pyproject.toml" in failures[0]
+    assert ">=3.12" in failures[0]
+    assert ">=3.12,<3.14" in failures[0]
+
+
+def test_requires_python_in_sync_fails_when_member_missing_field(
+    check: Any, bump: Any, chdir_tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A member pyproject.toml with no requires-python at all is a clean
+    failure, not a crash."""
+    _write_pyproject(chdir_tmp / "pyproject.toml", ">=3.12,<3.14")
+    bad_dir = chdir_tmp / "packages" / "evidentia-core"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "pyproject.toml").write_text(
+        '[project]\nname = "evidentia-core"\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(check, "REPO_ROOT", chdir_tmp)
+    _make_bump_with_tracked(
+        bump,
+        monkeypatch,
+        ["pyproject.toml", "packages/evidentia-core/pyproject.toml"],
+        [],
+    )
+    failures = check.check_requires_python_in_sync(bump)
+    assert len(failures) == 1
+    assert "packages/evidentia-core/pyproject.toml" in failures[0]
+    assert "missing" in failures[0]
+
+
+def test_requires_python_in_sync_fails_when_no_members_found(
+    check: Any, bump: Any, chdir_tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No packages/*/pyproject.toml at all is a config error, not a silent
+    pass."""
+    _write_pyproject(chdir_tmp / "pyproject.toml", ">=3.12,<3.14")
+    monkeypatch.setattr(check, "REPO_ROOT", chdir_tmp)
+    _make_bump_with_tracked(bump, monkeypatch, ["pyproject.toml"], [])
+    failures = check.check_requires_python_in_sync(bump)
+    assert len(failures) == 1
+    assert "no packages/*/pyproject.toml files found" in failures[0]
+
+
+def test_real_repo_requires_python_in_sync_passes(check: Any) -> None:
+    """The committed repo's root + all 8 member packages agree on
+    requires-python (the v2026-07 member-caps closeout acceptance gate)."""
+    bump = check._load_bump_module()
+    assert check.check_requires_python_in_sync(bump) == []


### PR DESCRIPTION
## What

Completes the requires-python honesty work from #146 (Decision 1 option B, deferred): all 8 member packages now publish `requires-python = ">=3.12,<3.14"` in their wheel metadata — a downstream PyPI consumer on Python 3.14 is told *incompatible* up front instead of hitting the litellm wall at install-resolve time.

**Guarded against drift**: `check_version_consistency.py` gains a requires-python in-sync assertion — every member must match the ROOT's declaration exactly, read **dynamically** at check time (no hardcoded cap string), so the eventual cap-lift (nudged by the python-ceiling-watch sentinel) is atomic: edit the 9 pyprojects, and the checker follows the root automatically. Mismatch = FAIL naming the offending file.

## Validation

- Observed-firing proof: broke one member's cap → check FAILed naming the exact file + actual/expected → restored → PASS (reproduced independently in review)
- 5 new unit tests (pass + failure paths); full-tree pytest 4754 passed, 0 failed
- `uv lock` unchanged (root cap already governs resolution via workspace intersection — as designed)
- consistency scope 7/7, ruff, mypy clean