### PR TITLE
Feat(api): DAST-driven schema + error-contract hardening (Horizon-A H-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unauthenticated 500 on `POST /api/ai-gov/register`** — a
+  whitespace-only `provider`/`owner` passed the request model's raw
+  `min_length` but failed the whitespace-stripping registry model,
+  raising an uncaught `ValidationError`. Now normalized to a structured
+  400, matching the sibling update handler. Found by the new DAST work.
+
 ### Added
 
+- **DAST-driven API schema + error-contract hardening** — several
+  fixes surfaced while building the stateful-DAST harness: OpenAPI
+  `links` on the ai-gov register→get/put/delete and catalog
+  import→delete lifecycles; `UpdateSystemRequest` and `EvidenceRef`
+  cross-field rules mirrored into the published schema (`anyOf`);
+  a non-whitespace `pattern` on the AI-system descriptor
+  `name`/`purpose` so the schema matches the strip+`min_length`
+  runtime; the `system_id` UUID shape documented on the lifecycle ops;
+  and an app-wide handler normalizing FastAPI's hardcoded body-decode
+  400 to the structured `ErrorEnvelope` shape every other deliberate
+  error already carries.
 - **`EvidenceRef` two-mode contract in the published schema** — the
   at-least-one-of (`artifact_id`, `file_path`) and `file_path`→`sha256`
   business rules, previously enforced only by a Pydantic model validator,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DAST-driven API schema + error-contract hardening** — several
   fixes surfaced while building the stateful-DAST harness: OpenAPI
   `links` on the ai-gov register→get/put/delete and catalog
-  import→delete lifecycles; `UpdateSystemRequest` and `EvidenceRef`
-  cross-field rules mirrored into the published schema (`anyOf`);
+  import→delete lifecycles; `UpdateSystemRequest`'s
+  at-least-one-field rule mirrored into the published schema (`anyOf`);
   a non-whitespace `pattern` on the AI-system descriptor
   `name`/`purpose` so the schema matches the strip+`min_length`
   runtime; the `system_id` UUID shape documented on the lifecycle ops;

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,8 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unauthenticated 500 on `POST /api/ai-gov/register`** — a
+  whitespace-only `provider`/`owner` passed the request model's raw
+  `min_length` but failed the whitespace-stripping registry model,
+  raising an uncaught `ValidationError`. Now normalized to a structured
+  400, matching the sibling update handler. Found by the new DAST work.
+
 ### Added
 
+- **DAST-driven API schema + error-contract hardening** — several
+  fixes surfaced while building the stateful-DAST harness: OpenAPI
+  `links` on the ai-gov register→get/put/delete and catalog
+  import→delete lifecycles; `UpdateSystemRequest` and `EvidenceRef`
+  cross-field rules mirrored into the published schema (`anyOf`);
+  a non-whitespace `pattern` on the AI-system descriptor
+  `name`/`purpose` so the schema matches the strip+`min_length`
+  runtime; the `system_id` UUID shape documented on the lifecycle ops;
+  and an app-wide handler normalizing FastAPI's hardcoded body-decode
+  400 to the structured `ErrorEnvelope` shape every other deliberate
+  error already carries.
 - **`EvidenceRef` two-mode contract in the published schema** — the
   at-least-one-of (`artifact_id`, `file_path`) and `file_path`→`sha256`
   business rules, previously enforced only by a Pydantic model validator,

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DAST-driven API schema + error-contract hardening** — several
   fixes surfaced while building the stateful-DAST harness: OpenAPI
   `links` on the ai-gov register→get/put/delete and catalog
-  import→delete lifecycles; `UpdateSystemRequest` and `EvidenceRef`
-  cross-field rules mirrored into the published schema (`anyOf`);
+  import→delete lifecycles; `UpdateSystemRequest`'s
+  at-least-one-field rule mirrored into the published schema (`anyOf`);
   a non-whitespace `pattern` on the AI-system descriptor
   `name`/`purpose` so the schema matches the strip+`min_length`
   runtime; the `system_id` UUID shape documented on the lifecycle ops;

--- a/packages/evidentia-api/src/evidentia_api/app.py
+++ b/packages/evidentia-api/src/evidentia_api/app.py
@@ -37,8 +37,10 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from evidentia_api import __version__
+from evidentia_api.errors import body_parse_error_handler
 
 if TYPE_CHECKING:
     from evidentia_core.plugins.auth import AuthProvider
@@ -220,6 +222,21 @@ def create_app(
         # the explicit-injection path didn't pre-populate it).
         lifespan=_auth_lifespan,
     )
+
+    # 2026-07-06 stateful-DAST finding (H-2 Step 4): normalize FastAPI's
+    # own hardcoded body-decode 400 ("There was an error parsing the
+    # body", raised from fastapi.routing's generic Exception catch-all
+    # before any route code runs) to the same structured ErrorEnvelope
+    # shape every deliberate api_error(...) 400 in this API carries. See
+    # evidentia_api.errors.body_parse_error_handler's docstring for the
+    # full mechanism. MUST register under starlette.exceptions.
+    # HTTPException (not fastapi.HTTPException) — that generic-Exception
+    # catch-all in fastapi/routing.py raises the STARLETTE base class
+    # directly, and FastAPI's own default handler is itself registered
+    # under that same base-class key (fastapi/applications.py imports
+    # HTTPException from starlette.exceptions), so this is the exact
+    # dict key that must be overwritten for the handler to fire at all.
+    app.add_exception_handler(StarletteHTTPException, body_parse_error_handler)
 
     # v0.8.2 F-V81-S2: pre-populate app.state.auth_provider with
     # the explicit-injection value (if any). The lifespan only

--- a/packages/evidentia-api/src/evidentia_api/errors.py
+++ b/packages/evidentia-api/src/evidentia_api/errors.py
@@ -94,8 +94,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 
 class ErrorDetail(BaseModel):
@@ -219,3 +221,78 @@ RATE_LIMITED_429 = (
     "Carries a ``Retry-After`` header."
 )
 """Shared ``responses`` description for rate-limited paths."""
+
+BODY_PARSE_ERROR_400 = (
+    "Request body could not be decoded (e.g. invalid UTF-8) before "
+    "route-level validation ran (``error: body_parse_error``)."
+)
+"""Shared ``responses`` description for the app-wide body-parse-error 400.
+
+Route decorators on body-bearing operations should include this in
+their ``error_responses()`` call alongside their own domain-specific
+400s so the documented response set matches what FastAPI can actually
+return (see :func:`body_parse_error_handler`).
+"""
+
+
+async def body_parse_error_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Normalize FastAPI's own body-decode 400 to the structured shape.
+
+    2026-07-06 stateful-DAST finding (Step 4 of the H-2 deliverable):
+    when a request body fails to decode (e.g. invalid UTF-8 bytes sent
+    with a ``Content-Type: application/json`` header), FastAPI's routing
+    layer raises a hardcoded ``HTTPException(400, "There was an error
+    parsing the body")`` from its own ``except Exception`` catch-all in
+    ``fastapi.routing`` — BEFORE any route code (or its documented
+    ``responses=``) ever runs. That bare string violates the
+    :class:`ErrorEnvelope` shape every OTHER deliberate 400 in this API
+    carries, so schemathesis's ``response_schema_conformance`` check
+    flagged it as a schema violation on ``PUT
+    /api/ai-gov/systems/{system_id}`` (and it is reachable identically
+    on every body-bearing route in the API — not specific to ai-gov).
+
+    Registering a handler on ``starlette.exceptions.HTTPException``
+    REPLACES FastAPI's own default handler app-wide (Starlette allows
+    exactly one handler per exception class, keyed by exact class
+    identity — NOT ``fastapi.HTTPException``, which is a subclass and
+    would never match: the ``except Exception`` catch-all in
+    ``fastapi/routing.py`` raises the STARLETTE base class directly,
+    and FastAPI's own default handler is itself registered under that
+    same base-class key per ``fastapi/applications.py``) — so every
+    OTHER deliberate ``api_error(...)`` raise (a ``fastapi.HTTPException``,
+    which IS an instance of the Starlette base class via inheritance)
+    also flows through here. Non-matching exceptions are handled by
+    delegating to ``fastapi.exception_handlers.http_exception_handler``
+    (FastAPI's own default) rather than re-raising — re-raising here
+    would escape Starlette's exception middleware entirely and crash
+    the request instead of falling through to the default behavior.
+    """
+    if (
+        isinstance(exc, StarletteHTTPException)
+        and exc.status_code == 400
+        and exc.detail == "There was an error parsing the body"
+    ):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "detail": {
+                    "error": "body_parse_error",
+                    "message": (
+                        "Request body could not be decoded (invalid "
+                        "encoding or malformed content)."
+                    ),
+                }
+            },
+        )
+    # Not our target shape — delegate to FastAPI's own default
+    # HTTPException handler so every other deliberate api_error(...)
+    # raise (and any other HTTPException) behaves exactly as if this
+    # handler were never registered.
+    from fastapi.exception_handlers import (
+        http_exception_handler as _default_http_exception_handler,
+    )
+
+    assert isinstance(exc, StarletteHTTPException)  # narrows for the call
+    return await _default_http_exception_handler(request, exc)  # type: ignore[return-value]

--- a/packages/evidentia-api/src/evidentia_api/routers/ai_gov.py
+++ b/packages/evidentia-api/src/evidentia_api/routers/ai_gov.py
@@ -61,9 +61,11 @@ from evidentia_core.ai_governance.registry_store import (
 from evidentia_core.audit import EventAction, EventOutcome, get_logger
 from evidentia_core.security import FileLock, atomic_write_text
 from fastapi import APIRouter, Header, Query
-from pydantic import BaseModel, Field, ValidationError
+from fastapi import Path as FastAPIPath
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from evidentia_api.errors import (
+    BODY_PARSE_ERROR_400,
     RATE_LIMITED_429,
     RBAC_DENIED_403,
     api_error,
@@ -81,7 +83,60 @@ _log = get_logger("evidentia_api.routers.ai_gov")
 # ── request / response models ─────────────────────────────────────
 
 
+_SYSTEM_ID_UUID_PATTERN = (
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+    r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+_SYSTEM_ID_PATH = FastAPIPath(
+    description="Registered AI system ID (UUID).",
+    # 2026-07-06 stateful-DAST finding (H-2 Step 4): the path param was
+    # undecorated ``str`` — any string is "positive data" per the
+    # published schema, so schemathesis's positive_data_acceptance
+    # check flagged the route's legitimate 400 (``invalid_id``, via
+    # ``_validate_id_shape``'s ``UUID(system_id)`` parse) as rejecting
+    # schema-valid data. ``json_schema_extra`` (NOT ``pattern=``,
+    # which Pydantic would enforce as an ACTUAL request-validation
+    # constraint, turning today's manual 400/404 into an automatic
+    # 422 — a real behavior change this deliverable must not make)
+    # documents the shape for schemathesis/the OpenAPI doc with zero
+    # runtime effect, mirroring the docs-only json_schema_extra
+    # pattern used elsewhere (EvidenceRef, UpdateSystemRequest). The
+    # pattern mirrors the DOMINANT accepted shape (canonical hyphenated
+    # UUID); it's narrower than ``uuid.UUID()`` itself (which also
+    # accepts hyphen-less/URN/brace-wrapped forms) but that's fine —
+    # the goal is to steer generation toward realistic positive
+    # examples, not exhaustively enumerate every tolerated textual
+    # form. Applied only to the three ops this DAST suite's OpenAPI
+    # links target (GET/PUT/DELETE); the other system_id-bearing verbs
+    # (retire/categorize-fips/set-omb-impact/set-high-impact) are out
+    # of this deliverable's scope.
+    json_schema_extra={"pattern": _SYSTEM_ID_UUID_PATTERN},
+)
+
+
 class RegisterRequest(BaseModel):
+    # A documented valid example: seeds schemathesis's explicit phase so
+    # the stateful DAST suite can reliably create a system (the complex
+    # descriptor body is otherwise rarely generated valid) and then walk
+    # the register -> get/put/delete lifecycle. Also improves the
+    # generated OpenAPI docs / UI "try it out" defaults.
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "descriptor": {
+                        "name": "resume-screener",
+                        "purpose": "Score job applicants for interview shortlisting",
+                    },
+                    "provider": "acme-corp",
+                    "owner": "risk-team",
+                    "deployment_status": "production",
+                }
+            ]
+        }
+    )
+
     descriptor: AISystemDescriptor
     provider: str = Field(min_length=1, max_length=256)
     owner: str = Field(min_length=1, max_length=256)
@@ -247,6 +302,11 @@ async def ai_gov_classify(
     "/ai-gov/register",
     responses=error_responses(
         {
+            400: (
+                "Body-content/id validation failure "
+                "(``error: invalid_body``), or an undecodable request "
+                f"body ({BODY_PARSE_ERROR_400})."
+            ),
             409: (
                 "``X-Idempotency-Key`` reuse with a different body "
                 "(``error: idempotency_key_conflict``)."
@@ -254,6 +314,48 @@ async def ai_gov_classify(
             429: RATE_LIMITED_429,
         }
     ),
+    # 2026-07-06 stateful-DAST prep (Step 2): OpenAPI ``links`` giving
+    # schemathesis's stateful state machine real create -> read/update/
+    # delete transitions to walk over the ai-gov lifecycle, chaining off
+    # this response's ``system_id``. FastAPI deep-merges ``openapi_extra``
+    # onto the operation object, so this coexists with the ``responses=``
+    # 4xx documentation above rather than clobbering it (verified via
+    # ``scripts/dump_openapi.py`` post-merge).
+    openapi_extra={
+        "responses": {
+            "200": {
+                "links": {
+                    "GetSystem": {
+                        "operationId": (
+                            "ai_gov_get_system_api_ai_gov_systems"
+                            "__system_id__get"
+                        ),
+                        "parameters": {
+                            "system_id": "$response.body#/system_id"
+                        },
+                    },
+                    "UpdateSystem": {
+                        "operationId": (
+                            "ai_gov_update_system_api_ai_gov_systems"
+                            "__system_id__put"
+                        ),
+                        "parameters": {
+                            "system_id": "$response.body#/system_id"
+                        },
+                    },
+                    "DeleteSystem": {
+                        "operationId": (
+                            "ai_gov_delete_system_api_ai_gov_systems"
+                            "__system_id__delete"
+                        ),
+                        "parameters": {
+                            "system_id": "$response.body#/system_id"
+                        },
+                    },
+                }
+            }
+        }
+    },
 )
 async def ai_gov_register(
     body: RegisterRequest,
@@ -331,13 +433,20 @@ async def ai_gov_register(
 
             # Fresh key path: create entry, then record.
             classification = classify(body.descriptor)
-            entry = AISystemRegistryEntry(
-                descriptor=body.descriptor,
-                classification=classification,
-                provider=body.provider,
-                owner=body.owner,
-                deployment_status=body.deployment_status,
-            )
+            try:
+                entry = AISystemRegistryEntry(
+                    descriptor=body.descriptor,
+                    classification=classification,
+                    provider=body.provider,
+                    owner=body.owner,
+                    deployment_status=body.deployment_status,
+                )
+            except (ValidationError, ValueError) as exc:
+                # A field that passes RegisterRequest's raw min_length
+                # but fails the registry model's post-strip validation
+                # (e.g. whitespace-only provider/owner) must normalize
+                # to 400, not crash to 500 — mirrors the PUT handler.
+                raise api_error(400, "invalid_body", str(exc)) from exc
             AIRegistryStore().save(entry)
             store[x_idempotency_key] = {
                 "body_hash": body_hash,
@@ -348,13 +457,18 @@ async def ai_gov_register(
     else:
         # No idempotency key: standard create path.
         classification = classify(body.descriptor)
-        entry = AISystemRegistryEntry(
-            descriptor=body.descriptor,
-            classification=classification,
-            provider=body.provider,
-            owner=body.owner,
-            deployment_status=body.deployment_status,
-        )
+        try:
+            entry = AISystemRegistryEntry(
+                descriptor=body.descriptor,
+                classification=classification,
+                provider=body.provider,
+                owner=body.owner,
+                deployment_status=body.deployment_status,
+            )
+        except (ValidationError, ValueError) as exc:
+            # See the fresh-key path above: post-strip validation
+            # failure normalizes to 400, not a 500.
+            raise api_error(400, "invalid_body", str(exc)) from exc
         AIRegistryStore().save(entry)
 
     _log.info(
@@ -447,7 +561,9 @@ async def ai_gov_list_systems(
         }
     ),
 )
-async def ai_gov_get_system(system_id: str) -> dict[str, Any]:
+async def ai_gov_get_system(
+    system_id: str = _SYSTEM_ID_PATH,
+) -> dict[str, Any]:
     """Fetch a single registered AI system by ID."""
     try:
         entry = AIRegistryStore().load(system_id)
@@ -475,7 +591,9 @@ async def ai_gov_get_system(system_id: str) -> dict[str, Any]:
         {400: "Malformed ``system_id`` (``error: invalid_id``)."}
     ),
 )
-async def ai_gov_delete_system(system_id: str) -> dict[str, Any]:
+async def ai_gov_delete_system(
+    system_id: str = _SYSTEM_ID_PATH,
+) -> dict[str, Any]:
     """Remove a registered AI system. Returns whether a record was
     actually removed (idempotent: no-op on unknown ID)."""
     try:
@@ -542,6 +660,48 @@ class UpdateSystemRequest(BaseModel):
     (partial-update semantics matching the ``ai-gov update`` CLI verb).
     An empty body (no fields) is a 400 (nothing to update).
     """
+
+    # 2026-07-06 stateful-DAST prep (Step 3): JSON-Schema mirror of the
+    # handler's ``if not updates: raise api_error(400, "invalid_body",
+    # ...)`` check (``ai_gov_update_system``, ~line 656-664 pre-Step-3) —
+    # "at least one of these 4 fields must be present and non-null" isn't
+    # otherwise expressible in vanilla JSON Schema (every field here is
+    # optional/nullable), so schemathesis generated ``{}`` as schema-valid
+    # positive data and flagged the handler's 400 as a
+    # ``positive_data_acceptance`` violation on PUT
+    # /api/ai-gov/systems/{system_id} (the analogous EvidenceRef fix in
+    # ``evidentia_core.models.tprm`` cites the same finding shape on POST
+    # /api/model-risk/models). Each branch uses ``{"not": {"type":
+    # "null"}}`` rather than a type re-assertion (cf. EvidenceRef) because
+    # ``deployment_status`` is an enum $ref, not a plain string — "present
+    # AND non-null" is the uniform semantics that matches the handler's
+    # ``is not None`` checks across all 4 fields. Keep both in sync.
+    model_config = ConfigDict(
+        json_schema_extra={
+            "anyOf": [
+                {
+                    "required": ["owner"],
+                    "properties": {"owner": {"not": {"type": "null"}}},
+                },
+                {
+                    "required": ["provider"],
+                    "properties": {"provider": {"not": {"type": "null"}}},
+                },
+                {
+                    "required": ["deployment_status"],
+                    "properties": {
+                        "deployment_status": {"not": {"type": "null"}}
+                    },
+                },
+                {
+                    "required": ["ssp_reference"],
+                    "properties": {
+                        "ssp_reference": {"not": {"type": "null"}}
+                    },
+                },
+            ]
+        }
+    )
 
     owner: str | None = Field(default=None, min_length=1, max_length=256)
     provider: str | None = Field(default=None, min_length=1, max_length=256)
@@ -624,7 +784,8 @@ class HighImpactRequest(BaseModel):
         {
             400: (
                 "Empty update or domain-validation failure "
-                "(``error: invalid_body``)."
+                "(``error: invalid_body``), or an undecodable request "
+                f"body ({BODY_PARSE_ERROR_400})."
             ),
             403: RBAC_DENIED_403,
             404: "No such registered system (``error: not_found``).",
@@ -632,7 +793,7 @@ class HighImpactRequest(BaseModel):
     ),
 )
 async def ai_gov_update_system(
-    system_id: str, body: UpdateSystemRequest
+    body: UpdateSystemRequest, system_id: str = _SYSTEM_ID_PATH
 ) -> dict[str, Any]:
     """Partially update a registered AI system.
 

--- a/packages/evidentia-api/src/evidentia_api/routers/catalog.py
+++ b/packages/evidentia-api/src/evidentia_api/routers/catalog.py
@@ -64,6 +64,7 @@ from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
 from evidentia_api.errors import (
+    BODY_PARSE_ERROR_400,
     RBAC_DENIED_403,
     api_error,
     error_responses,
@@ -292,14 +293,35 @@ class CatalogImportPayload(BaseModel):
             400: (
                 "Malformed ``framework_id``, invalid ``tier``, "
                 "unsupported ``format``, unparseable/invalid catalog "
-                "content, or a duplicate import without ``force`` "
+                "content, a duplicate import without ``force``, or an "
+                "undecodable request body "
                 "(``error: invalid_id`` / ``invalid_field`` / "
                 "``unsupported_format`` / ``invalid_body`` / "
-                "``already_exists``)."
+                f"``already_exists``; {BODY_PARSE_ERROR_400})."
             ),
             403: RBAC_DENIED_403,
         }
     ),
+    # 2026-07-06 stateful-DAST prep (Step 2): OpenAPI link chaining this
+    # response's ``framework_id`` into the DELETE lifecycle op, mirroring
+    # the ai-gov register links above.
+    openapi_extra={
+        "responses": {
+            "201": {
+                "links": {
+                    "DeleteCatalog": {
+                        "operationId": (
+                            "remove_catalog_api_catalog"
+                            "__framework_id__delete"
+                        ),
+                        "parameters": {
+                            "framework_id": "$response.body#/framework_id"
+                        },
+                    }
+                }
+            }
+        }
+    },
 )
 async def import_catalog(payload: CatalogImportPayload) -> dict[str, object]:
     """Import a user-supplied catalog into the local user catalog dir.

--- a/packages/evidentia-core/src/evidentia_core/ai_governance/classification.py
+++ b/packages/evidentia-core/src/evidentia_core/ai_governance/classification.py
@@ -129,11 +129,26 @@ class AISystemDescriptor(EvidentiaModel):
     name: str = Field(
         min_length=1,
         max_length=256,
+        # 2026-07-06 stateful-DAST finding (H-2 Step 4): EvidentiaModel
+        # sets str_strip_whitespace=True, so a whitespace-only value
+        # (e.g. "\t") passes this raw min_length=1 in the PUBLISHED
+        # schema but fails post-strip validation at runtime -> a
+        # schema-valid-per-the-doc request gets rejected, which
+        # schemathesis's positive_data_acceptance check (correctly)
+        # flags as RejectedPositiveData on POST /api/ai-gov/register
+        # (AISystemDescriptor is RegisterRequest.descriptor). ``\S``
+        # (unanchored — JSON Schema ``pattern`` is a search, not a
+        # fullmatch) mirrors "at least one non-whitespace character"
+        # so the published schema matches the strip+min_length runtime
+        # behavior instead of over-promising. Mirror in ``purpose``
+        # below; keep both in sync with EvidentiaModel's strip config.
+        pattern=r"\S",
         description="Human-readable AI system name (free text).",
     )
     purpose: str = Field(
         min_length=1,
         max_length=2048,
+        pattern=r"\S",
         description="Plain-English description of what the system does.",
     )
     annex_iii_domain: AnnexIIIDomain = Field(

--- a/packages/evidentia-ui/openapi.json
+++ b/packages/evidentia-ui/openapi.json
@@ -6315,10 +6315,13 @@
         "operationId": "ai_gov_delete_system_api_ai_gov_systems__system_id__delete",
         "parameters": [
           {
+            "description": "Registered AI system ID (UUID).",
             "in": "path",
             "name": "system_id",
             "required": true,
             "schema": {
+              "description": "Registered AI system ID (UUID).",
+              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
               "title": "System Id",
               "type": "string"
             }
@@ -6368,10 +6371,13 @@
         "operationId": "ai_gov_get_system_api_ai_gov_systems__system_id__get",
         "parameters": [
           {
+            "description": "Registered AI system ID (UUID).",
             "in": "path",
             "name": "system_id",
             "required": true,
             "schema": {
+              "description": "Registered AI system ID (UUID).",
+              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
               "title": "System Id",
               "type": "string"
             }
@@ -6431,10 +6437,13 @@
         "operationId": "ai_gov_update_system_api_ai_gov_systems__system_id__put",
         "parameters": [
           {
+            "description": "Registered AI system ID (UUID).",
             "in": "path",
             "name": "system_id",
             "required": true,
             "schema": {
+              "description": "Registered AI system ID (UUID).",
+              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
               "title": "System Id",
               "type": "string"
             }

--- a/packages/evidentia-ui/openapi.json
+++ b/packages/evidentia-ui/openapi.json
@@ -87,6 +87,7 @@
             "description": "Human-readable AI system name (free text).",
             "maxLength": 256,
             "minLength": 1,
+            "pattern": "\\S",
             "title": "Name",
             "type": "string"
           },
@@ -94,6 +95,7 @@
             "description": "Plain-English description of what the system does.",
             "maxLength": 2048,
             "minLength": 1,
+            "pattern": "\\S",
             "title": "Purpose",
             "type": "string"
           }
@@ -4456,6 +4458,17 @@
         "type": "string"
       },
       "RegisterRequest": {
+        "examples": [
+          {
+            "deployment_status": "production",
+            "descriptor": {
+              "name": "resume-screener",
+              "purpose": "Score job applicants for interview shortlisting"
+            },
+            "owner": "risk-team",
+            "provider": "acme-corp"
+          }
+        ],
         "properties": {
           "deployment_status": {
             "$ref": "#/components/schemas/DeploymentStatus",
@@ -5165,6 +5178,56 @@
         "type": "object"
       },
       "UpdateSystemRequest": {
+        "anyOf": [
+          {
+            "properties": {
+              "owner": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "owner"
+            ]
+          },
+          {
+            "properties": {
+              "provider": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          {
+            "properties": {
+              "deployment_status": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "deployment_status"
+            ]
+          },
+          {
+            "properties": {
+              "ssp_reference": {
+                "not": {
+                  "type": "null"
+                }
+              }
+            },
+            "required": [
+              "ssp_reference"
+            ]
+          }
+        ],
         "description": "Body for ``PUT /ai-gov/systems/{system_id}`` (partial update).\n\nAll fields optional — only the supplied ones are changed\n(partial-update semantics matching the ``ai-gov update`` CLI verb).\nAn empty body (no fields) is a 400 (nothing to update).",
         "properties": {
           "deployment_status": {
@@ -6110,7 +6173,37 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Successful Response",
+            "links": {
+              "DeleteSystem": {
+                "operationId": "ai_gov_delete_system_api_ai_gov_systems__system_id__delete",
+                "parameters": {
+                  "system_id": "$response.body#/system_id"
+                }
+              },
+              "GetSystem": {
+                "operationId": "ai_gov_get_system_api_ai_gov_systems__system_id__get",
+                "parameters": {
+                  "system_id": "$response.body#/system_id"
+                }
+              },
+              "UpdateSystem": {
+                "operationId": "ai_gov_update_system_api_ai_gov_systems__system_id__put",
+                "parameters": {
+                  "system_id": "$response.body#/system_id"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Body-content/id validation failure (``error: invalid_body``), or an undecodable request body (Request body could not be decoded (e.g. invalid UTF-8) before route-level validation ran (``error: body_parse_error``).)."
           },
           "409": {
             "content": {
@@ -6378,7 +6471,7 @@
                 }
               }
             },
-            "description": "Empty update or domain-validation failure (``error: invalid_body``)."
+            "description": "Empty update or domain-validation failure (``error: invalid_body``), or an undecodable request body (Request body could not be decoded (e.g. invalid UTF-8) before route-level validation ran (``error: body_parse_error``).)."
           },
           "403": {
             "content": {
@@ -6821,7 +6914,15 @@
                 }
               }
             },
-            "description": "Successful Response"
+            "description": "Successful Response",
+            "links": {
+              "DeleteCatalog": {
+                "operationId": "remove_catalog_api_catalog__framework_id__delete",
+                "parameters": {
+                  "framework_id": "$response.body#/framework_id"
+                }
+              }
+            }
           },
           "400": {
             "content": {
@@ -6831,7 +6932,7 @@
                 }
               }
             },
-            "description": "Malformed ``framework_id``, invalid ``tier``, unsupported ``format``, unparseable/invalid catalog content, or a duplicate import without ``force`` (``error: invalid_id`` / ``invalid_field`` / ``unsupported_format`` / ``invalid_body`` / ``already_exists``)."
+            "description": "Malformed ``framework_id``, invalid ``tier``, unsupported ``format``, unparseable/invalid catalog content, a duplicate import without ``force``, or an undecodable request body (``error: invalid_id`` / ``invalid_field`` / ``unsupported_format`` / ``invalid_body`` / ``already_exists``; Request body could not be decoded (e.g. invalid UTF-8) before route-level validation ran (``error: body_parse_error``).)."
           },
           "403": {
             "content": {

--- a/packages/evidentia-ui/src/types/openapi.ts
+++ b/packages/evidentia-ui/src/types/openapi.ts
@@ -6318,6 +6318,14 @@ export interface components {
             provider?: string | null;
             /** Ssp Reference */
             ssp_reference?: string | null;
+        } | {
+            owner: unknown;
+        } | {
+            provider: unknown;
+        } | {
+            deployment_status: unknown;
+        } | {
+            ssp_reference: unknown;
         };
         /** ValidationError */
         ValidationError: {
@@ -6871,6 +6879,15 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     };
+                };
+            };
+            /** @description Body-content/id validation failure (``error: invalid_body``). */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
             /** @description ``X-Idempotency-Key`` reuse with a different body (``error: idempotency_key_conflict``). */

--- a/packages/evidentia-ui/src/types/openapi.ts
+++ b/packages/evidentia-ui/src/types/openapi.ts
@@ -5856,7 +5856,18 @@ export interface components {
          * @enum {string}
          */
         QuestionnaireFormat: "evidentia-generic" | "caiq-lite" | "caiq-full" | "sig" | "sig-lite";
-        /** RegisterRequest */
+        /**
+         * RegisterRequest
+         * @example {
+         *       "deployment_status": "production",
+         *       "descriptor": {
+         *         "name": "resume-screener",
+         *         "purpose": "Score job applicants for interview shortlisting"
+         *       },
+         *       "owner": "risk-team",
+         *       "provider": "acme-corp"
+         *     }
+         */
         RegisterRequest: {
             /** @default proposed */
             deployment_status: components["schemas"]["DeploymentStatus"];
@@ -6881,7 +6892,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description Body-content/id validation failure (``error: invalid_body``). */
+            /** @description Body-content/id validation failure (``error: invalid_body``), or an undecodable request body (Request body could not be decoded (e.g. invalid UTF-8) before route-level validation ran (``error: body_parse_error``).). */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -6967,6 +6978,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description Registered AI system ID (UUID). */
                 system_id: string;
             };
             cookie?: never;
@@ -7018,6 +7030,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description Registered AI system ID (UUID). */
                 system_id: string;
             };
             cookie?: never;
@@ -7039,7 +7052,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description Empty update or domain-validation failure (``error: invalid_body``). */
+            /** @description Empty update or domain-validation failure (``error: invalid_body``), or an undecodable request body (Request body could not be decoded (e.g. invalid UTF-8) before route-level validation ran (``error: body_parse_error``).). */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -7082,6 +7095,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                /** @description Registered AI system ID (UUID). */
                 system_id: string;
             };
             cookie?: never;
@@ -7415,7 +7429,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description Malformed ``framework_id``, invalid ``tier``, unsupported ``format``, unparseable/invalid catalog content, or a duplicate import without ``force`` (``error: invalid_id`` / ``invalid_field`` / ``unsupported_format`` / ``invalid_body`` / ``already_exists``). */
+            /** @description Malformed ``framework_id``, invalid ``tier``, unsupported ``format``, unparseable/invalid catalog content, a duplicate import without ``force``, or an undecodable request body (``error: invalid_id`` / ``invalid_field`` / ``unsupported_format`` / ``invalid_body`` / ``already_exists``; Request body could not be decoded (e.g. invalid UTF-8) before route-level validation ran (``error: body_parse_error``).). */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/tests/integration/test_api/test_ai_gov.py
+++ b/tests/integration/test_api/test_ai_gov.py
@@ -228,6 +228,166 @@ class TestRegisterListGetDelete:
         assert resp.json()["removed"] is False
 
 
+class TestRegisterWhitespaceOnlyFields:
+    """2026-07-06 stateful-DAST prep (Step 1): whitespace-only
+    ``provider``/``owner`` pass ``RegisterRequest``'s raw
+    ``Field(min_length=1, ...)`` (no ``str_strip_whitespace`` on that
+    model) but then fail ``AISystemRegistryEntry`` construction, whose
+    base ``EvidentiaModel`` DOES set ``str_strip_whitespace=True`` — the
+    stripped string is empty, violating its own ``min_length=1``. That
+    raised a ``pydantic.ValidationError`` with no try/except around
+    either ``AISystemRegistryEntry(...)`` call site in
+    ``ai_gov_register``, surfacing as an unauthenticated 500. Fixed by
+    wrapping both construction sites in the same
+    ``except (ValidationError, ValueError)`` idiom the PUT handler
+    (``ai_gov_update_system``) already uses."""
+
+    _BASE_DESCRIPTOR: ClassVar[dict] = {
+        "name": "resume-screener",
+        "purpose": "Score job applicants",
+        "annex_iii_domain": "employment",
+    }
+
+    def test_whitespace_only_provider_no_idempotency_key_returns_400(
+        self, api_client: TestClient
+    ) -> None:
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": self._BASE_DESCRIPTOR,
+                "provider": "   ",
+                "owner": "hr-team",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_body"
+
+    def test_whitespace_only_owner_no_idempotency_key_returns_400(
+        self, api_client: TestClient
+    ) -> None:
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": self._BASE_DESCRIPTOR,
+                "provider": "acme-ai",
+                "owner": "\n",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_body"
+
+    def test_whitespace_only_provider_via_idempotent_fresh_create_returns_400(
+        self, api_client: TestClient
+    ) -> None:
+        """Same bug, but through the ``with FileLock(...)`` fresh-create
+        branch (i.e. a request carrying a never-seen-before
+        ``X-Idempotency-Key``) rather than the no-idempotency-key
+        standard-create path."""
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": self._BASE_DESCRIPTOR,
+                "provider": "   ",
+                "owner": "hr-team",
+            },
+            headers={"X-Idempotency-Key": "whitespace-fresh-key"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_body"
+
+    def test_normal_register_still_succeeds(
+        self, api_client: TestClient
+    ) -> None:
+        """No-regression check: a well-formed register still 200s."""
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": self._BASE_DESCRIPTOR,
+                "provider": "acme-ai",
+                "owner": "hr-team",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["system_id"]
+
+
+class TestBodyParseErrorNormalization:
+    """2026-07-06 stateful-DAST finding (H-2 Step 4): FastAPI's own
+    hardcoded body-decode 400 ("There was an error parsing the body",
+    raised from its routing catch-all BEFORE route code runs) is
+    normalized app-wide to the structured ``ErrorEnvelope`` shape by
+    ``evidentia_api.errors.body_parse_error_handler`` — while every
+    OTHER deliberate ``api_error(...)`` 400 still flows through FastAPI's
+    default handler unchanged (the handler delegates non-target cases)."""
+
+    def test_undecodable_body_returns_structured_400(
+        self, api_client: TestClient
+    ) -> None:
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            # High bytes that fail the body UTF-8 decode BEFORE JSON
+            # parsing, hitting FastAPI's "There was an error parsing the
+            # body" catch-all (a later json_invalid instead surfaces as a
+            # normal 422 array — a different, already-correct path).
+            content=b"\x80\x81",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["error"] == "body_parse_error"
+
+    def test_other_400s_keep_their_own_error_key(
+        self, api_client: TestClient
+    ) -> None:
+        """The handler must DELEGATE non-target HTTPExceptions: a normal
+        domain 400 keeps its own key, proving the app-wide handler does
+        not hijack every 400."""
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": {"name": "x", "purpose": "y"},
+                "provider": "   ",
+                "owner": "hr-team",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"]["error"] == "invalid_body"
+
+
+class TestRegisterDescriptorWhitespaceRejected:
+    """2026-07-06 stateful-DAST true-fix (H-2 Step 3): ``pattern=r"\\S"``
+    on ``AISystemDescriptor.name``/``purpose`` mirrors the
+    ``str_strip_whitespace`` + ``min_length`` runtime behaviour into the
+    published schema, so a whitespace-only value is rejected (Pydantic
+    request-validation 422, array-shape detail) instead of over-promising
+    acceptance in the schema."""
+
+    def test_whitespace_only_descriptor_name_rejected(
+        self, api_client: TestClient
+    ) -> None:
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": {"name": "\t", "purpose": "Score applicants"},
+                "provider": "acme-ai",
+                "owner": "hr-team",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_whitespace_only_descriptor_purpose_rejected(
+        self, api_client: TestClient
+    ) -> None:
+        resp = api_client.post(
+            "/api/ai-gov/register",
+            json={
+                "descriptor": {"name": "resume-screener", "purpose": "\n"},
+                "provider": "acme-ai",
+                "owner": "hr-team",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+
 # ── v0.9.4 P1.3: rate-limit + idempotency on register ───────────────
 
 

--- a/tests/unit/test_openapi_links.py
+++ b/tests/unit/test_openapi_links.py
@@ -1,0 +1,162 @@
+"""Unit tests for the stateful-DAST-prep OpenAPI surface (2026-07-06,
+Steps 2 + 3 of the H-2 stateful DAST deliverable).
+
+Step 2: asserts the ``openapi_extra``-declared ``links`` on the ai-gov
+register and catalog import operations survive FastAPI's deep-merge
+with the pre-existing ``responses=error_responses({...})`` 4xx
+documentation — i.e. neither clobbers the other. These links are the
+substrate ``tests/dast/test_openapi_stateful.py``'s state machine walks
+to chain create -> read/update/delete transitions.
+
+Step 3: asserts ``UpdateSystemRequest``'s ``json_schema_extra`` mirrors
+the "at least one field" business rule its handler enforces at
+runtime, closing a schemathesis ``positive_data_acceptance`` finding on
+PUT /api/ai-gov/systems/{system_id}.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def openapi_schema() -> dict[str, Any]:
+    """Build the OpenAPI schema with an isolated AI registry dir.
+
+    Mirrors the isolation pattern used elsewhere (an isolated
+    ``EVIDENTIA_AI_REGISTRY_DIR`` set before app construction) so this
+    test never touches a developer's real registry store.
+    """
+    os.environ["EVIDENTIA_AI_REGISTRY_DIR"] = tempfile.mkdtemp(
+        prefix="evidentia-openapi-links-test-"
+    )
+    from evidentia_api.app import create_app
+
+    return create_app(offline=True).openapi()
+
+
+class TestAiGovRegisterLinks:
+    def test_links_present_with_correct_operation_ids_and_parameters(
+        self, openapi_schema: dict[str, Any]
+    ) -> None:
+        register_op = openapi_schema["paths"]["/api/ai-gov/register"]["post"]
+        links = register_op["responses"]["200"]["links"]
+
+        assert set(links.keys()) == {
+            "GetSystem",
+            "UpdateSystem",
+            "DeleteSystem",
+        }
+
+        # Derive expected operationIds from the schema itself (the GET/PUT/
+        # DELETE ops on the same resource) so this assertion is robust to
+        # operationId spelling drift rather than hardcoding a duplicate.
+        system_id_path = openapi_schema["paths"][
+            "/api/ai-gov/systems/{system_id}"
+        ]
+        expected_get_op_id = system_id_path["get"]["operationId"]
+        expected_put_op_id = system_id_path["put"]["operationId"]
+        expected_delete_op_id = system_id_path["delete"]["operationId"]
+
+        assert links["GetSystem"]["operationId"] == expected_get_op_id
+        assert links["UpdateSystem"]["operationId"] == expected_put_op_id
+        assert links["DeleteSystem"]["operationId"] == expected_delete_op_id
+
+        for name in ("GetSystem", "UpdateSystem", "DeleteSystem"):
+            assert links[name]["parameters"] == {
+                "system_id": "$response.body#/system_id"
+            }
+
+    def test_existing_4xx_responses_unchanged_after_openapi_extra_merge(
+        self, openapi_schema: dict[str, Any]
+    ) -> None:
+        """Proves the ``openapi_extra`` link merge didn't clobber the
+        ``error_responses()`` 4xx documentation already on the route."""
+        register_responses = openapi_schema["paths"]["/api/ai-gov/register"][
+            "post"
+        ]["responses"]
+        assert "400" in register_responses
+        assert "409" in register_responses
+        assert "429" in register_responses
+        # Sanity: the descriptions still carry the documented error keys.
+        assert "invalid_body" in register_responses["400"]["description"]
+        assert (
+            "idempotency_key_conflict"
+            in register_responses["409"]["description"]
+        )
+
+
+class TestCatalogImportLinks:
+    def test_delete_link_present_with_correct_operation_id_and_parameters(
+        self, openapi_schema: dict[str, Any]
+    ) -> None:
+        import_op = openapi_schema["paths"]["/api/catalog/import"]["post"]
+        links = import_op["responses"]["201"]["links"]
+
+        assert len(links) == 1
+        (_link_name, link) = next(iter(links.items()))
+
+        expected_delete_op_id = openapi_schema["paths"][
+            "/api/catalog/{framework_id}"
+        ]["delete"]["operationId"]
+        assert link["operationId"] == expected_delete_op_id
+        assert link["parameters"] == {
+            "framework_id": "$response.body#/framework_id"
+        }
+
+    def test_existing_4xx_responses_unchanged_after_openapi_extra_merge(
+        self, openapi_schema: dict[str, Any]
+    ) -> None:
+        import_responses = openapi_schema["paths"]["/api/catalog/import"][
+            "post"
+        ]["responses"]
+        assert "400" in import_responses
+        assert "403" in import_responses
+        assert "invalid_id" in import_responses["400"]["description"]
+        assert "already_exists" in import_responses["400"]["description"]
+
+
+class TestUpdateSystemRequestAtLeastOneFieldSchema:
+    """Step 3: ``UpdateSystemRequest.model_json_schema()`` must mirror the
+    handler's ``if not updates: raise api_error(400, "invalid_body", ...)``
+    rule via a top-level ``anyOf`` of 4 branches (one per optional field),
+    each requiring that field present AND non-null — otherwise
+    schemathesis treats ``{}`` as schema-valid positive data and flags the
+    handler's 400 as a ``positive_data_acceptance`` violation."""
+
+    def test_any_of_has_exactly_4_branches_one_per_field(self) -> None:
+        from evidentia_api.routers.ai_gov import UpdateSystemRequest
+
+        schema = UpdateSystemRequest.model_json_schema()
+        any_of = schema["anyOf"]
+        assert len(any_of) == 4
+
+        expected_fields = {
+            "owner",
+            "provider",
+            "deployment_status",
+            "ssp_reference",
+        }
+        seen_fields = set()
+        for branch in any_of:
+            assert len(branch["required"]) == 1
+            (field,) = branch["required"]
+            seen_fields.add(field)
+            assert branch["properties"][field] == {"not": {"type": "null"}}
+        assert seen_fields == expected_fields
+
+    def test_schema_appears_verbatim_in_dumped_openapi_doc(
+        self, openapi_schema: dict[str, Any]
+    ) -> None:
+        """The same ``anyOf`` shape must also show up in the dumped
+        OpenAPI doc's component schema (not just the standalone
+        ``model_json_schema()`` call) — this is what schemathesis
+        actually reads to generate request bodies."""
+        component = openapi_schema["components"]["schemas"][
+            "UpdateSystemRequest"
+        ]
+        assert len(component["anyOf"]) == 4

--- a/tests/unit/test_openapi_links.py
+++ b/tests/unit/test_openapi_links.py
@@ -16,24 +16,25 @@ PUT /api/ai-gov/systems/{system_id}.
 
 from __future__ import annotations
 
-import os
-import tempfile
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 
 @pytest.fixture
-def openapi_schema() -> dict[str, Any]:
+def openapi_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Any]:
     """Build the OpenAPI schema with an isolated AI registry dir.
 
     Mirrors the isolation pattern used elsewhere (an isolated
     ``EVIDENTIA_AI_REGISTRY_DIR`` set before app construction) so this
-    test never touches a developer's real registry store.
+    test never touches a developer's real registry store. Uses
+    ``monkeypatch`` so the env var is restored after the test rather
+    than leaking process-wide.
     """
-    os.environ["EVIDENTIA_AI_REGISTRY_DIR"] = tempfile.mkdtemp(
-        prefix="evidentia-openapi-links-test-"
-    )
+    monkeypatch.setenv("EVIDENTIA_AI_REGISTRY_DIR", str(tmp_path / "ai_registry"))
     from evidentia_api.app import create_app
 
     return create_app(offline=True).openapi()


### PR DESCRIPTION
Fixes surfaced while building a schemathesis stateful-DAST harness for the ai-gov + catalog lifecycles. The harness itself is **deferred** (a schemathesis-4.x stateful generation-tuning issue over these complex-bodied lifecycles — tracked follow-up); the substrate + true-fixes land here.

## Fixed
- **Unauthenticated 500 on `POST /api/ai-gov/register`** — a whitespace-only `provider`/`owner` passed `RegisterRequest`'s raw `min_length` then failed the whitespace-stripping registry model (uncaught `ValidationError`). Normalized to a structured 400, mirroring the sibling PUT handler. 4 regression tests.

## Added
- **OpenAPI links** — register→get/put/delete (`system_id`) + catalog import→delete (`framework_id`), deep-merged onto the documented 4xx responses (4 tests).
- **Schema mirrors** of rules the OpenAPI contract couldn't express (`positive_data_acceptance` true-fixes): `UpdateSystemRequest` `anyOf` (at-least-one-field); `AISystemDescriptor` `name`/`purpose` `pattern=\S` (matches the `str_strip_whitespace` + `min_length` runtime); `system_id` UUID shape documented on the lifecycle ops (docs-only, no runtime change).
- **App-wide `body_parse_error_handler`** — normalizes FastAPI's hardcoded body-decode 400 to the structured `ErrorEnvelope` shape (`response_schema_conformance`), delegating every other `HTTPException` to the default handler unchanged.
- `RegisterRequest` example (docs + future harness seeding).

## Validation
Full local gate green: pytest 4796/0, ruff, mypy strict-optional ×7 (287 files), consistency 7/7 (incl. wiki drift), openapi + UI-types drift clean, frontend typecheck + vitest. A whole-branch review (with adversarial TestClient probes on the app-wide handler — delegation, 422-class separation, `python -O` safety) came back clean after regenerating the schema for the `system_id` docs.

The deferred stateful harness is tracked as a follow-up.