### PR TITLE
Security(audit): Escape log CR/LF + scrub error field; correct CodeQL barrier framing

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,30 +1,36 @@
 # CodeQL config for Evidentia advanced setup.
 #
-# Loads the security-extended query suite (matching what default setup
-# runs) PLUS a local Models-as-Data (MaD) data extension that models
-# Evidentia's path-containment helpers as `py/path-injection` barriers
-# at the analysis layer — so the whole `validate_within` /
-# `resolve_catalog_path` false-positive class clears in the query
-# results instead of relying on per-instance dismissals.
+# Loads the security-extended query suite (matching what default setup runs)
+# PLUS a local Models-as-Data (MaD) data extension that models Evidentia's
+# path-containment helpers as `py/path-injection` barriers.
+#
+# IMPORTANT — the barrier model is currently INERT (forward-looking):
+#   The stock `py/path-injection` query does NOT consume MaD `barrierModel`
+#   rows (verified empirically 2026-07-08 on CodeQL 2.26.0). It recognizes
+#   sanitizers only via QL classes (PathInjection::Sanitizer /
+#   PathNormalization::Range / SafeAccessCheck::Range). So the
+#   validate_within / resolve_catalog_path py/path-injection false-positive
+#   class is NOT cleared at the analysis layer today — it is managed by
+#   per-instance dismissal with a written rationale. The model.yml is kept as
+#   a forward-looking hook (see its header) and loads cleanly.
 #
 # HISTORY / why MaD and not a `.qll` sanitizer pack:
-#   The earlier approach shipped a custom QL pack of
-#   `PathInjection::Sanitizer` subclasses and referenced it via
-#   `packs: - ./.github/codeql/python-sanitizers`. That never worked, for
-#   TWO reasons: (1) the `packs:` key only accepts published registry pack
-#   specs (`scope/name[@range]`), so a local path was logged as an
-#   "Invalid CodeQL pack specification" and ignored; (2) even loaded, an
-#   external library pack cannot inject a sanitizer into the stock
-#   `py/path-injection` query — a query only applies barriers it imports.
-#   The supported no-fork fix is a data extension the stock query consumes
-#   at analysis time (`barrierModel`, GA in CodeQL 2.25.2; runner 2.25.6).
+#   The earlier approach shipped a custom QL pack of PathInjection::Sanitizer
+#   subclasses and referenced it via `packs: - ./.github/codeql/python-sanitizers`.
+#   That never worked: (1) `packs:` accepts only published registry specs, so
+#   the local path was logged as an "Invalid CodeQL pack specification" and
+#   ignored; (2) an external library pack cannot inject a sanitizer into the
+#   stock `py/path-injection` query (a query applies only barriers it imports).
+#   The `.qll` Sanitizer subclass was the correct MECHANISM for path-injection,
+#   but there is no no-fork way to load it into the stock query — hence the
+#   forward-looking MaD model + dismissal-managed FP class today.
 #
 # `dataExtensions:` takes repo-local paths (relative to this config file);
-# see path-injection-barriers.model.yml for the modeled helpers.
+# see path-injection-barriers.model.yml.
 #
 # Default setup must be disabled in repo Settings -> Code security and
 # analysis; the advanced workflow (.github/workflows/codeql.yml) owns the
-# canonical alert stream.
+# canonical alert stream (and the paths-ignore below).
 #
 # References:
 # - https://github.blog/changelog/2026-04-21-codeql-now-supports-sanitizers-and-validators-in-models-as-data/

--- a/.github/codeql/path-injection-barriers.model.yml
+++ b/.github/codeql/path-injection-barriers.model.yml
@@ -1,28 +1,31 @@
-# CodeQL Models-as-Data (MaD) — path-injection barriers for Evidentia.
+# CodeQL Models-as-Data (MaD) — path-injection barrier models for Evidentia.
 #
-# Replaces the never-loading `.qll` sanitizer pack. An external library
-# pack of `PathInjection::Sanitizer` subclasses can NOT inject sanitizers
-# into the stock `py/path-injection` query: a query only applies barriers
-# it transitively imports, and the stock query does not import our pack.
-# The supported no-fork mechanism is a data extension consumed by the
-# stock query at analysis time (`barrierModel`, GA in CodeQL 2.25.2; our
-# code-scanning runner is 2.25.6). This file is loaded by the
-# `dataExtensions:` key in codeql-config.yml (a local, in-repo path — the
-# `packs:` key only accepts published registry specs, which is why the old
-# `packs: ./.github/codeql/python-sanitizers` was logged as an "Invalid
-# CodeQL pack specification" and silently ignored).
+# STATUS: forward-looking / currently INERT for py/path-injection.
+# This data extension loads cleanly (the `barrierModel` predicate is GA in
+# CodeQL 2.25.2+; our code-scanning runner is 2.26.0), BUT the stock
+# `py/path-injection` query does NOT yet consume MaD `barrierModel` rows: it
+# recognizes sanitizers only via the QL classes `PathInjection::Sanitizer`,
+# `Path::PathNormalization::Range`, and `Path::SafeAccessCheck::Range` (see
+# the PathInjectionCustomizations module, which states it deliberately does
+# not expose a simple Sanitizer for MaD). Empirically verified 2026-07-08:
+# these rows do NOT clear the validate_within / resolve_catalog_path
+# py/path-injection false positives — that class is managed by per-instance
+# dismissal with a written rationale. The model is kept as a forward-looking
+# hook: if/when CodeQL wires py/path-injection to consume MaD barriers, it
+# activates with no further change. Loaded via the config `dataExtensions:` key.
 #
-# `barrierModel(type, path, kind)` marks the value at `type`/`path` as a
-# taint barrier for the given query `kind`. `kind: path-injection` matches
-# the sink kind the `py/path-injection` query uses.
+# (History: this replaced a custom `.qll` PathInjection::Sanitizer pack that
+# NEVER loaded — `packs:` accepts only published registry specs, so the local
+# path was logged as an "Invalid CodeQL pack specification" and ignored; and
+# an external library pack cannot inject a sanitizer into a stock query it
+# does not compile. The `.qll` Sanitizer subclass was actually the RIGHT
+# mechanism for path-injection, but there is no no-fork way to load it into
+# the stock query — hence dismissal-managed today.)
 #
-# Modeled barriers:
-#   - evidentia_core.security.paths.validate_within(candidate, safe_root)
-#     resolves the candidate and raises PathTraversalError unless it is
-#     is_relative_to(safe_root); its return is a containment-checked Path.
-#   - evidentia_core.catalogs.user_dir.resolve_catalog_path(...) returns
-#     (path, entry, source); the path (element 0) is either derived from
-#     the trusted package manifest or is_relative_to-checked before return.
+# `barrierModel(type, path, kind)` marks the value at `type`/`path` as a taint
+# barrier for query `kind` (here `path-injection`):
+#   - validate_within(candidate, safe_root) -> containment-checked Path.
+#   - resolve_catalog_path(...) -> (path, entry, source); the path is element 0.
 extensions:
   - addsTo:
       pack: codeql/python-all

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,11 @@
 #
 # Replaces GitHub's default CodeQL setup with an advanced workflow so a
 # config-file can load a local Models-as-Data data extension
-# (.github/codeql/path-injection-barriers.model.yml) that models
-# `validate_within` / `resolve_catalog_path` as `py/path-injection`
-# barriers — clearing that false-positive class at the analysis layer
-# rather than by per-instance dismissal. See codeql-config.yml for why
-# MaD replaced the earlier (never-loading) custom `.qll` sanitizer pack.
+# (.github/codeql/path-injection-barriers.model.yml) plus own the
+# paths-ignore filter. NOTE: py/path-injection does NOT yet consume MaD
+# barrierModel (verified 2026-07-08), so that FP class is dismissal-managed
+# today and the model is a forward-looking hook — see codeql-config.yml for
+# the full history (and why the earlier `.qll` sanitizer pack never loaded).
 #
 # Default setup must be disabled in repo Settings -> Code security
 # and analysis BEFORE this workflow takes over. While both are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Audit log CR/LF injection + credential leakage hardened**
+  (`evidentia_core.audit.logger`). Two defects surfaced by an
+  adversarial review of CodeQL 2.26.0 findings: (1) CWE-117 — in the
+  default (non-JSON) logging mode the message is rendered verbatim by
+  the stdlib formatter, so attacker-controlled CR/LF (e.g. a `Metric`
+  `name` via `POST /api/governance/metrics`) could forge log lines;
+  the plaintext-rendered message now escapes newlines. (2) CWE-312 —
+  the secret scrubber covered only the free-text `message`, leaving a
+  credential inlined in an exception string (`error.message =
+  str(exc)`) in cleartext in the structured record; the `error` field's
+  string values are now scrubbed too. Structured JSON emission was
+  already newline-safe via `json.dumps` and is unchanged.
+
 ### Fixed
 
-- **CodeQL custom path-injection barrier now actually loads** — the
-  `validate_within` / `resolve_catalog_path` `py/path-injection`
-  false-positive class was being held down by per-instance dismissals
-  because the custom `.qll` sanitizer pack never loaded: `packs:` only
-  accepts published registry specs (a local path was logged as an
-  "Invalid CodeQL pack specification" and ignored), and an external
-  library pack cannot inject a barrier into a stock query anyway.
-  Replaced it with a Models-as-Data data extension (`barrierModel`,
-  loaded via the config's `dataExtensions:` key) that the stock
-  `py/path-injection` query consumes at analysis time, clearing the
-  class at the analysis layer instead of by dismissal.
+- **CodeQL custom path-injection sanitizer pack removed (never loaded)**
+  — the `validate_within` / `resolve_catalog_path` `py/path-injection`
+  false-positive class was held down by per-instance dismissals because
+  the custom `.qll` sanitizer pack never loaded: `packs:` accepts only
+  published registry specs (a local path was logged as "Invalid CodeQL
+  pack specification" and ignored), and an external library pack cannot
+  inject a barrier into a stock query anyway. Replaced with a
+  Models-as-Data `barrierModel` extension (loaded via the config's
+  `dataExtensions:` key, which does resolve cleanly). NOTE:
+  `py/path-injection` does not yet consume MaD `barrierModel`, so the
+  model is a forward-looking hook and this FP class remains
+  dismissal-managed for now.
 - **Unauthenticated 500 on `POST /api/ai-gov/register`** — a
   whitespace-only `provider`/`owner` passed the request model's raw
   `min_length` but failed the whitespace-stripping registry model,

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,19 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Audit log CR/LF injection + credential leakage hardened**
+  (`evidentia_core.audit.logger`). Two defects surfaced by an
+  adversarial review of CodeQL 2.26.0 findings: (1) CWE-117 — in the
+  default (non-JSON) logging mode the message is rendered verbatim by
+  the stdlib formatter, so attacker-controlled CR/LF (e.g. a `Metric`
+  `name` via `POST /api/governance/metrics`) could forge log lines;
+  the plaintext-rendered message now escapes newlines. (2) CWE-312 —
+  the secret scrubber covered only the free-text `message`, leaving a
+  credential inlined in an exception string (`error.message =
+  str(exc)`) in cleartext in the structured record; the `error` field's
+  string values are now scrubbed too. Structured JSON emission was
+  already newline-safe via `json.dumps` and is unchanged.
+
 ### Fixed
 
-- **CodeQL custom path-injection barrier now actually loads** — the
-  `validate_within` / `resolve_catalog_path` `py/path-injection`
-  false-positive class was being held down by per-instance dismissals
-  because the custom `.qll` sanitizer pack never loaded: `packs:` only
-  accepts published registry specs (a local path was logged as an
-  "Invalid CodeQL pack specification" and ignored), and an external
-  library pack cannot inject a barrier into a stock query anyway.
-  Replaced it with a Models-as-Data data extension (`barrierModel`,
-  loaded via the config's `dataExtensions:` key) that the stock
-  `py/path-injection` query consumes at analysis time, clearing the
-  class at the analysis layer instead of by dismissal.
+- **CodeQL custom path-injection sanitizer pack removed (never loaded)**
+  — the `validate_within` / `resolve_catalog_path` `py/path-injection`
+  false-positive class was held down by per-instance dismissals because
+  the custom `.qll` sanitizer pack never loaded: `packs:` accepts only
+  published registry specs (a local path was logged as "Invalid CodeQL
+  pack specification" and ignored), and an external library pack cannot
+  inject a barrier into a stock query anyway. Replaced with a
+  Models-as-Data `barrierModel` extension (loaded via the config's
+  `dataExtensions:` key, which does resolve cleanly). NOTE:
+  `py/path-injection` does not yet consume MaD `barrierModel`, so the
+  model is a forward-looking hook and this FP class remains
+  dismissal-managed for now.
 - **Unauthenticated 500 on `POST /api/ai-gov/register`** — a
   whitespace-only `provider`/`owner` passed the request model's raw
   `min_length` but failed the whitespace-stripping registry model,

--- a/packages/evidentia-api/src/evidentia_api/routers/catalog.py
+++ b/packages/evidentia-api/src/evidentia_api/routers/catalog.py
@@ -96,11 +96,11 @@ def _validate_framework_id(framework_id: str) -> str:
     first-line *shape* guard (fast 400 on a malformed id). It is NOT the
     CodeQL barrier for the import write-path: CodeQL's ``py/path-injection``
     traces ``payload.framework_id`` THROUGH this helper (it returns its arg)
-    into ``out_path``. The actual modeled barrier is downstream — ``out_path``
-    is routed through ``evidentia_core.security.paths.validate_within``
-    (write-path containment), which is modeled as a ``path-injection``
-    barrier via the Models-as-Data data extension
-    ``.github/codeql/path-injection-barriers.model.yml``.
+    into ``out_path``. Runtime containment is downstream — ``out_path`` is
+    routed through ``evidentia_core.security.paths.validate_within``
+    (resolve + assert is_relative_to). CodeQL's ``py/path-injection`` still
+    flags this class (path-injection does not consume the MaD barrier model);
+    the finding is a dismissed false positive.
     """
     if ".." in framework_id or not _FRAMEWORK_ID_RE.match(framework_id):
         raise api_error(
@@ -384,20 +384,16 @@ async def import_catalog(payload: CatalogImportPayload) -> dict[str, object]:
     placeholder = bool(data.get("placeholder", False))
 
     user_dir = ensure_user_dir()
-    # Write-path containment (CWE-22) — defense-in-depth AND the CodeQL barrier.
+    # Write-path containment (CWE-22) — runtime defense-in-depth.
     # ``framework_id`` is regex-validated above (no '..', no separators), so the
     # join already lands inside the user catalog dir; wrapping it in
     # ``validate_within`` (resolve() + assert is_relative_to(user_dir)) makes that
     # containment EXPLICIT and is the write-side analog of the resolve_catalog_path
-    # read-side guard. Because validate_within is modeled as a py/path-injection
-    # barrier via Models-as-Data (.github/codeql/path-injection-barriers.model.yml,
-    # barrierModel), routing out_path through it clears the
-    # py/path-injection finding on the read-back loader at the analysis layer
+    # read-side guard for the read-back loader path
     # (alert #164: payload.framework_id -> out_path -> load_evidentia_catalog ->
-    # _load_catalog_data -> read_text). NB: a *raw* ``.resolve()`` here would
-    # instead be flagged by CodeQL as a path op on caller input — using the
-    # modeled helper is what makes the guard a barrier, not a new finding.
-    # validate_within returns the resolved path.
+    # _load_catalog_data -> read_text). CodeQL's py/path-injection does not
+    # recognize this guard (it ignores the MaD barrier model), so the finding is
+    # a dismissed false positive; validate_within returns the resolved path.
     out_path = validate_within(user_dir / f"{framework_id}.json", user_dir)
     if out_path.exists() and not payload.force:
         raise api_error(

--- a/packages/evidentia-core/src/evidentia_core/audit/logger.py
+++ b/packages/evidentia-core/src/evidentia_core/audit/logger.py
@@ -133,14 +133,41 @@ _SECRET_PATTERNS = [
 def _scrub(message: str) -> str:
     """Replace well-known secret patterns in free-text with ``[REDACTED]``.
 
-    Operates on message strings only. Structured field values are the
-    collector's responsibility — the scrubber is a safety net for
-    exception stringification and ad-hoc log lines that might inline a
-    credential accidentally.
+    A safety net for exception stringification and ad-hoc log lines that
+    might inline a credential accidentally. Applied to the free-text
+    ``message`` and (via :func:`_scrub_structured`) to the ``error`` field's
+    string values.
     """
     for pattern in _SECRET_PATTERNS:
         message = pattern.sub("[REDACTED]", message)
     return message
+
+
+def _escape_newlines(message: str) -> str:
+    """Neutralize CR/LF so attacker-controlled content cannot forge a second
+    log line (CWE-117 log injection) when the message is rendered by a
+    plaintext formatter (the default, non-JSON stdlib handler uses
+    ``%(message)s`` verbatim). JSON emission via :class:`ECSFormatter`
+    already escapes newlines through ``json.dumps``; this covers the
+    plaintext path where the raw message argument becomes the log line.
+    """
+    return message.replace("\r", "\\r").replace("\n", "\\n")
+
+
+def _scrub_structured(obj: Any) -> Any:
+    """Recursively apply :func:`_scrub` to the string leaves of a JSON-like
+    structure (dict / list / str). Used for the ``error`` field so a
+    credential inlined into an exception string is redacted in the structured
+    record too — ``_scrub`` on the free-text ``message`` alone left the
+    sibling ``error.message`` (``str(exc)``) in cleartext (CWE-312).
+    """
+    if isinstance(obj, str):
+        return _scrub(obj)
+    if isinstance(obj, dict):
+        return {k: _scrub_structured(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_scrub_structured(v) for v in obj]
+    return obj
 
 
 def _build_ecs_record(
@@ -231,7 +258,10 @@ def _build_ecs_record(
         record["cloud"] = scope["cloud"]
 
     if error is not None:
-        record["error"] = error
+        # Scrub credentials that may be inlined in an exception string
+        # (error.message = str(exc)) — the free-text ``message`` above is
+        # scrubbed, but the structured error mirror was not (CWE-312).
+        record["error"] = _scrub_structured(error)
 
     evidentia_payload: dict[str, Any] = {}
     if "evidentia" in scope:
@@ -363,9 +393,14 @@ class EvidentiaLogger:
         # stream stay in sync. The level check is identical to
         # what stdlib `Logger.log` does internally before emit.
         if self._stdlib.isEnabledFor(stdlib_level):
+            # Escape CR/LF on the plaintext-rendered message argument so a
+            # crafted message cannot forge a log line (CWE-117). The
+            # structured ``ecs_record`` is emitted only via json.dumps
+            # (ECSFormatter), which is already newline-safe, so it keeps the
+            # message verbatim.
             self._stdlib.log(
                 stdlib_level,
-                _scrub(message),
+                _escape_newlines(_scrub(message)),
                 extra={"ecs_record": ecs_record},
             )
             # v0.8.0 P1 G3 / v0.8.1 F-V08-CR-1: tap event into the

--- a/packages/evidentia-core/src/evidentia_core/catalogs/user_dir.py
+++ b/packages/evidentia-core/src/evidentia_core/catalogs/user_dir.py
@@ -129,9 +129,10 @@ def resolve_catalog_path(
         # checked is what lets CodeQL's built-in ``py/path-injection`` barrier
         # recognize the guard — previously the check ran on ``path.resolve()``
         # but the *unchecked* ``path`` was returned, so the loader's
-        # ``read_text`` was flagged (alert #164). The return is ALSO modeled as a
-        # py/path-injection barrier via Models-as-Data
-        # (.github/codeql/path-injection-barriers.model.yml, barrierModel).
+        # ``read_text`` was flagged (alert #164). The returned value is the
+        # containment-checked path; CodeQL's py/path-injection does not
+        # recognize the guard (it ignores the MaD barrier model), so the
+        # finding is a dismissed false positive.
         resolved = path.resolve()
         if not resolved.is_relative_to(user_dir.resolve()):
             raise ValueError(

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -76,9 +76,10 @@ repository:
           Threat model: docs/threat-model.md (NORMATIVE). OSPS Baseline
           conformance tracked in OSPS-CONFORMANCE.md (Maturity 3, CI-gated).
           OpenSSF Best Practices: Silver (project 12724). Additional CI security
-          tooling beyond the SCA entries below: CodeQL (security-extended +
-          custom path-injection barrier models via Models-as-Data data
-          extensions), OpenSSF Scorecard, and gitleaks secret scanning.
+          tooling beyond the SCA entries below: CodeQL (security-extended;
+          a forward-looking Models-as-Data path-injection barrier model is
+          committed, though py/path-injection does not yet consume it),
+          OpenSSF Scorecard, and gitleaks secret scanning.
     tools:
       - name: osv-scanner
         type: SCA

--- a/tests/unit/test_audit/test_logger.py
+++ b/tests/unit/test_audit/test_logger.py
@@ -16,6 +16,7 @@ from evidentia_core.audit.events import (
 from evidentia_core.audit.logger import (
     ECS_VERSION,
     ECSFormatter,
+    _build_ecs_record,
     _reset_for_tests,
     _scrub,
     enable_json_logs,
@@ -276,3 +277,45 @@ def test_formatter_output_is_single_line() -> None:
     assert "\n" not in output
     parsed = json.loads(output)
     assert parsed["message"] == "multi\nline\nmessage"
+
+
+def test_plaintext_emit_escapes_newlines_preventing_log_forging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CWE-117: in the default (non-JSON) mode the audit message is rendered
+    raw by the stdlib formatter (``%(message)s``), so attacker-controlled
+    CR/LF in the message could forge a second log line. The emitted message
+    must have its newlines neutralized (escaped), not passed through raw.
+    """
+    log = get_logger("evidentia.test")
+    with caplog.at_level(logging.INFO, logger="evidentia.test"):
+        log.info(
+            action=EventAction.COLLECT_STARTED,
+            message="ok\n2026-01-01 [ERROR] evidentia: FORGED admin action\rx",
+        )
+    rendered = caplog.records[-1].getMessage()
+    assert "\n" not in rendered
+    assert "\r" not in rendered
+    assert "\\n" in rendered  # newline preserved as an escaped literal
+
+
+def test_build_ecs_record_scrubs_secrets_in_error_field() -> None:
+    """CWE-312: ``_scrub`` covered only ``message``; a credential embedded in
+    an exception string reaches the log verbatim via ``error.message``. The
+    error dict's string values must also be scrubbed before emit.
+    """
+    record = _build_ecs_record(
+        level="error",
+        logger_name="evidentia.test",
+        message="collector failed",
+        action=EventAction.COLLECT_FAILED,
+        outcome=EventOutcome.FAILURE,
+        error={
+            "message": "provider rejected: token=leakedsecretvalue99",
+            "type": "APIError",
+        },
+    )
+    assert "leakedsecretvalue99" not in json.dumps(record)
+    assert "[REDACTED]" in record["error"]["message"]
+    # Non-secret structured fields are preserved verbatim.
+    assert record["error"]["type"] == "APIError"


### PR DESCRIPTION
## Summary

An adversarial review of the 7 CodeQL 2.26.0 findings (runner auto-upgraded 2.25.6→2.26.0) confirmed **2 real audit-logger defects**; the other 5 were verified as false positives of known guarded classes and dismissed with written reasons.

## Security fixes (`evidentia_core.audit.logger`)

- **CWE-117 (log injection)** — in the default non-JSON mode the message is rendered verbatim by the stdlib formatter (`%(message)s`), so attacker-controlled CR/LF could forge log lines. Concrete path: a `Metric` `name` (no `pattern`/`max_length`) via `POST /api/governance/metrics` → `message=f"Metric defined via API: {name}"`. The plaintext-rendered message argument now escapes newlines (`_escape_newlines`). Structured JSON emission was already newline-safe via `json.dumps` and is unchanged.
- **CWE-312 (cleartext sensitive data)** — the secret scrubber covered only the free-text `message`; a credential inlined in an exception string (`error.message = str(exc)`, e.g. an AI-provider/httpx error) reached the structured record verbatim. The `error` field's string values are now scrubbed (`_scrub_structured`); intended audit-identity fields (`user`/`cloud`/`evidentia`) are untouched.

Both fixes are **TDD** (failing-first tests); full tree **4798 passed**.

## Also: correct the #163 barrier over-claim

#163 shipped comments/CHANGELOG claiming the MaD `barrierModel` clears the `validate_within` / `resolve_catalog_path` `py/path-injection` FP class at the analysis layer. **Verified empirically wrong** (the alert instance persisted on the post-merge full scan) and by primary source: `py/path-injection` does not consume MaD `barrierModel` — it uses the QL `PathInjection::Sanitizer` / `PathNormalization::Range` classes. So that class stays **dismissal-managed** and the `model.yml` is a forward-looking hook. Reworded `codeql-config.yml`, `codeql.yml`, `catalog.py`, `user_dir.py`, `security-insights.yml`, and the CHANGELOG to state this accurately.

## Post-merge

The 4 open audit-logger alerts (#172/#173/#177/#178) should clear on main's re-scan now that the sanitizers are in the sink path; any residual is a genuine FP (vuln fixed, CodeQL not modeling the new sanitizer) to dismiss with reason → 0 open alerts.