### PR TITLE
Feat(dast): Land the stateful schemathesis suite + weekly dast.yml sentinel (Horizon-A H-2)

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,72 @@
+# Dynamic application security testing (DAST) — Horizon-A H-2.
+#
+# Runs the opt-in schemathesis suites that fuzz the published OpenAPI
+# contract (excluded from the default `pytest tests/` collection via the
+# root addopts `--ignore`, so they never run in the normal test gate):
+#   - tests/dast/test_openapi_fuzz.py      — stateless, per-operation
+#   - tests/dast/test_openapi_stateful.py  — stateful create->read->update
+#     ->delete link chains over the ai-gov + catalog lifecycles (IDOR /
+#     state-leak / stale-ref / sequence-dependent 5xx classes).
+#
+# NON-REQUIRED, observe-first: this is a sentinel, NOT a merge gate — it is
+# deliberately absent from the branch ruleset's required status checks. A
+# finding surfaces as a schemathesis case report (with a curl-replay command)
+# for triage, not an auto-block. Triggers: weekly cron, manual dispatch, and
+# PRs that touch the API surface the suites exercise.
+name: dast
+
+on:
+  schedule:
+    - cron: "37 7 * * 4"   # Thursdays 07:37 UTC (offset from the other sentinels)
+  workflow_dispatch: {}
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/evidentia-api/**"
+      - "packages/evidentia-core/src/evidentia_core/models/**"
+      - "packages/evidentia-core/src/evidentia_core/ai_governance/**"
+      - "packages/evidentia-core/src/evidentia_core/catalogs/**"
+      - "tests/dast/**"
+      - ".github/workflows/dast.yml"
+
+# Read-only: the suites only build the app in-process and fuzz it; no writes.
+permissions:
+  contents: read
+
+concurrency:
+  group: dast-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  dast:
+    name: schemathesis (stateless + stateful)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync workspace
+        # --all-packages so the API + core import for create_app(); skip the
+        # frontend build hook (the suites hit the API only, no SPA).
+        env:
+          EVIDENTIA_SKIP_FRONTEND_BUILD: "1"
+        run: uv sync --all-packages
+
+      - name: Run DAST suites (stateless + stateful schemathesis)
+        env:
+          PYTHONIOENCODING: utf-8
+        run: >-
+          uv run --no-sync python -m pytest
+          tests/dast/test_openapi_fuzz.py
+          tests/dast/test_openapi_stateful.py
+          -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Stateful DAST suite + `dast.yml` sentinel** — a schemathesis
+  state-machine test (`tests/dast/test_openapi_stateful.py`) walks
+  create→read→update→delete link chains over the ai-gov and catalog
+  lifecycles (hunting IDOR / state-leak / stale-reference /
+  sequence-dependent 5xx classes that stateless per-operation fuzzing
+  cannot reach), complementing the existing stateless
+  `test_openapi_fuzz.py`. A new non-required `dast.yml` workflow runs
+  both on a weekly cron, manual dispatch, and API-surface PRs
+  (observe-first; not a merge gate).
 - **DAST-driven API schema + error-contract hardening** — several
   fixes surfaced while building the stateful-DAST harness: OpenAPI
   `links` on the ai-gov register→get/put/delete and catalog

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Stateful DAST suite + `dast.yml` sentinel** — a schemathesis
+  state-machine test (`tests/dast/test_openapi_stateful.py`) walks
+  create→read→update→delete link chains over the ai-gov and catalog
+  lifecycles (hunting IDOR / state-leak / stale-reference /
+  sequence-dependent 5xx classes that stateless per-operation fuzzing
+  cannot reach), complementing the existing stateless
+  `test_openapi_fuzz.py`. A new non-required `dast.yml` workflow runs
+  both on a weekly cron, manual dispatch, and API-surface PRs
+  (observe-first; not a merge gate).
 - **DAST-driven API schema + error-contract hardening** — several
   fixes surfaced while building the stateful-DAST harness: OpenAPI
   `links` on the ai-gov register→get/put/delete and catalog

--- a/tests/dast/README.md
+++ b/tests/dast/README.md
@@ -1,4 +1,4 @@
-# Evidentia DAST tests (v0.9.5 P1.2)
+# Evidentia DAST tests (v0.9.5 P1.2; stateful suite added Horizon-A H-2)
 
 Dynamic Application Security Testing scaffolding for the
 pre-release-review Step 4 capability-matrix DAST sub-step.
@@ -8,6 +8,20 @@ pre-release-review Step 4 capability-matrix DAST sub-step.
 - `test_openapi_fuzz.py` — Schemathesis fuzz the FastAPI OpenAPI
   spec; surfaces input-validation gaps the unit tests don't cover
   (large strings, unicode edge cases, schema-violation requests).
+  STATELESS: each operation is fuzzed independently.
+- `test_openapi_stateful.py` (Horizon-A H-2) — Schemathesis STATEFUL
+  suite: walks create -> read -> update -> delete operation sequences
+  over the ai-gov (`register` -> `GET`/`PUT`/`DELETE
+  /systems/{system_id}`) and catalog (`import` -> `DELETE
+  /{framework_id}`) lifecycles via the OpenAPI `links` this deliverable
+  added to those routes. Runs schemathesis's FULL DEFAULT CHECK SET
+  (no `excluded_checks`) — catches IDOR / state-leak / stale-reference
+  / sequence-dependent 5xx classes that stateless per-operation fuzzing
+  cannot reach, since those require a real prior response's ID to
+  chain off of. See the module docstring for the source-side fixes
+  (whitespace-only field 500, OpenAPI links, schema-mirrored business
+  rules, body-parse-error normalization) this suite's green run
+  depends on.
 - `playwright.config.ts` — Playwright config for end-to-end UI
   probing against a locally-running `evidentia serve` instance.
 
@@ -26,8 +40,11 @@ uv run playwright install        # downloads chromium/firefox/webkit
 ## Running
 
 ```bash
-# OpenAPI fuzz only (faster):
+# OpenAPI fuzz only (faster, stateless):
 uv run pytest tests/dast/test_openapi_fuzz.py -v
+
+# Stateful lifecycle fuzz (ai-gov + catalog link-chains):
+uv run pytest tests/dast/test_openapi_stateful.py -v
 
 # Playwright UI probing only (requires `evidentia serve` running):
 uv run pytest tests/dast/test_playwright_e2e.py -v
@@ -54,6 +71,9 @@ review). It catches:
 - Error-message information leakage (stack traces, file paths)
 - Authentication bypasses through malformed inputs
 - CORS misconfigurations
+- (stateful suite) IDOR / state-leak / stale-reference /
+  sequence-dependent bugs across a create -> read -> update -> delete
+  lifecycle, which stateless per-operation fuzzing cannot reach
 
 It does NOT catch:
 

--- a/tests/dast/test_openapi_stateful.py
+++ b/tests/dast/test_openapi_stateful.py
@@ -85,11 +85,19 @@ schemathesis = pytest.importorskip("schemathesis")
 
 from hypothesis import HealthCheck, Phase, settings  # noqa: E402
 
-# Isolate the AI registry BEFORE the app/schema are constructed below.
-# Module-level, not a fixture: the state machine is built at import time,
-# and AIRegistryStore reads this env var per request.
+# Isolate the AI registry AND the user-catalog store BEFORE the app/schema
+# are constructed below. Module-level, not a fixture: the state machine is
+# built at import time, and both stores read these env vars per request.
+# The state machine walks BOTH lifecycles — ai-gov register (AIRegistryStore,
+# EVIDENTIA_AI_REGISTRY_DIR) and catalog import/delete (get_user_catalog_dir,
+# EVIDENTIA_CATALOG_DIR) — so a run left un-isolated would write fuzz catalogs,
+# rewrite the real frameworks.yaml manifest, and could unlink a real
+# user-imported catalog in the developer's actual store.
 os.environ["EVIDENTIA_AI_REGISTRY_DIR"] = tempfile.mkdtemp(
-    prefix="evidentia-dast-stateful-"
+    prefix="evidentia-dast-stateful-registry-"
+)
+os.environ["EVIDENTIA_CATALOG_DIR"] = tempfile.mkdtemp(
+    prefix="evidentia-dast-stateful-catalog-"
 )
 
 # Neutralize the token-bucket rate limiter for the fuzz. The limiter

--- a/tests/dast/test_openapi_stateful.py
+++ b/tests/dast/test_openapi_stateful.py
@@ -1,0 +1,161 @@
+r"""Schemathesis STATEFUL DAST — operation-sequence fuzzing (Horizon-A H-2).
+
+Complements ``test_openapi_fuzz.py`` (stateless): walks
+create -> read -> update -> delete chains via the OpenAPI ``links``
+this deliverable added to the ai-gov and catalog lifecycles, hunting
+IDOR / state-leak / stale-reference / sequence-dependent 5xx classes
+that operation-by-operation fuzzing cannot reach. Opt-in like the rest
+of ``tests/dast/`` (root ``addopts --ignore``). CI:
+``.github/workflows/dast.yml`` (weekly + dispatch + api-path PRs;
+non-required, observe-first).
+
+Auth/RBAC note (probed 2026-07-06): ``create_app(offline=True)`` builds
+the app under ``RBACPolicy``'s permissive ``DEFAULT_POLICY``, so the
+``require_role(...)`` gates on the mutating routes are inert — all six
+operations in the two linked lifecycles are reachable anonymously
+(the RBAC-enforcement integration tests install a *separate*
+deny-by-default policy to prove the gates bite by contrast). No
+auth-bypass fixture is needed, matching the stateless suite's usage.
+
+Registry isolation: the ai-gov handlers instantiate ``AIRegistryStore``
+per request, which reads ``EVIDENTIA_AI_REGISTRY_DIR`` at construction.
+The state machine and its app are built at MODULE IMPORT (below), before
+any function-scoped fixture could run, so the isolation env var is set
+here at import time to a throwaway temp dir — otherwise the fuzz run
+would read and pollute the developer's real local registry.
+
+Sequencing on this branch (``feat/stateful-dast-v2``): commits
+``dc6c89a`` + ``998271d`` landed the substrate + true-fixes this
+harness needs to run green with schemathesis's FULL DEFAULT CHECK SET:
+
+1. A genuine unauthenticated 500 on ``POST /api/ai-gov/register``
+   (whitespace-only ``provider``/``owner`` passed the request model's
+   raw ``min_length=1`` then failed the whitespace-stripping registry
+   model, uncaught) was fixed — normalized to 400, mirroring the
+   sibling PUT handler.
+2. The OpenAPI ``links`` this state machine walks (the six operations
+   scoped below) were added to the ai-gov + catalog routers.
+3. Schema mirrors of business rules the OpenAPI contract couldn't
+   otherwise express: ``UpdateSystemRequest``'s at-least-one-field
+   ``anyOf``; ``AISystemDescriptor.name``/``.purpose``'s ``pattern=r"\S"``
+   (mirrors ``str_strip_whitespace`` + ``min_length``); ``system_id``'s
+   UUID-shape pattern on the three ``{system_id}`` lifecycle ops;
+   ``RegisterRequest``'s documented example.
+4. An app-wide handler normalizing FastAPI's own hardcoded body-decode
+   400 ("There was an error parsing the body") to the structured
+   ``ErrorEnvelope`` shape (``response_schema_conformance``).
+
+Rate-limit neutralization: the token-bucket limiter (60/min, burst 10
+on POST /ai-gov/register) throttles the hundreds of rapid calls a
+stateful run makes, surfacing 429s that are the limiter working AS
+DESIGNED — not a lifecycle bug — which schemathesis's
+positive_data_acceptance check would (correctly, but unhelpfully here)
+flag as "valid data rejected". A business-logic-sequence fuzzer must
+exercise the routes, not the throttle; rate-limit behavior has its own
+dedicated tests (test_rate_limit.py). Test-side only: clear the
+default rate-limited path set before the app + middleware are
+constructed below — no production code changes, and
+RateLimitMiddleware still installs.
+
+Generation-reliability note: Hypothesis's stateful engine intermittently
+raised ``Unsatisfiable`` ("N of N examples failed a filter/assume
+condition") under ``phases=[Phase.generate]`` with a small example
+budget, because ``AISystemDescriptor``'s multi-constraint nested body
+(``name``/``purpose`` non-blank + ``max_length`` + the enum fields) is
+comparatively hard to hit by unguided random generation within a single
+state-machine step's budget — most generated ``register`` bodies failed
+validation, starving the walk of a live ``system_id`` to chain the
+GET/PUT/DELETE links off of. ``max_examples`` is raised well above the
+original 25 so the run reliably produces at least one valid ``register``
+body per invocation; ``derandomize=True`` (a fixed, version-pinned PRNG
+seed schedule) + ``database=None`` (skip Hypothesis's local example
+cache) keep the run deterministic across CI invocations rather than
+depending on machine-local cached examples or wall-clock-seeded
+randomness.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+schemathesis = pytest.importorskip("schemathesis")
+
+from hypothesis import HealthCheck, Phase, settings  # noqa: E402
+
+# Isolate the AI registry BEFORE the app/schema are constructed below.
+# Module-level, not a fixture: the state machine is built at import time,
+# and AIRegistryStore reads this env var per request.
+os.environ["EVIDENTIA_AI_REGISTRY_DIR"] = tempfile.mkdtemp(
+    prefix="evidentia-dast-stateful-"
+)
+
+# Neutralize the token-bucket rate limiter for the fuzz. The limiter
+# (60/min, burst 10 on POST /ai-gov/register) throttles the hundreds of
+# rapid calls a stateful run makes, surfacing 429s that are the limiter
+# working AS DESIGNED — not a lifecycle bug — which schemathesis's
+# positive_data_acceptance check (correctly) flags as "valid data
+# rejected". A business-logic-sequence fuzzer must exercise the routes,
+# not the throttle; rate-limit behavior has its own dedicated tests
+# (test_rate_limit.py). Test-side only: clear the default rate-limited
+# path set before the app + middleware are constructed below — no
+# production code changes, and RateLimitMiddleware still installs.
+import evidentia_api.rate_limit as _rate_limit  # noqa: E402
+
+_rate_limit.DEFAULT_RATE_LIMITED_PATHS = frozenset()
+
+from evidentia_api.app import create_app  # noqa: E402
+
+# Scope the state machine to exactly the six operations that are sources
+# or targets of this deliverable's two ``links`` blocks. as_state_machine()
+# would otherwise walk the ENTIRE schema and bury link-chain findings
+# under noise from unrelated endpoints (schema-inexpressible cross-field
+# validators, etc.). Resolves to:
+#   POST   /api/ai-gov/register
+#   GET    /api/ai-gov/systems/{system_id}
+#   PUT    /api/ai-gov/systems/{system_id}
+#   DELETE /api/ai-gov/systems/{system_id}
+#   POST   /api/catalog/import
+#   DELETE /api/catalog/{framework_id}
+_LINKED_LIFECYCLES = (
+    r"^/api/(ai-gov/(register|systems/\{system_id\})"
+    r"|catalog/(import|\{framework_id\}))$"
+)
+
+
+def _make_state_machine() -> type:
+    schema = schemathesis.openapi.from_asgi(
+        "/api/openapi.json", create_app(offline=True)
+    )
+    schema = schema.include(path_regex=_LINKED_LIFECYCLES)
+    return schema.as_state_machine()
+
+
+APIWorkflow = _make_state_machine()
+
+
+class BoundedAPIWorkflow(APIWorkflow):  # type: ignore[misc,valid-type]
+    """CI-bounded profile: enough steps to traverse the linked
+    lifecycles, small enough to keep the job in single-digit minutes."""
+
+
+TestStateful = BoundedAPIWorkflow.TestCase
+TestStateful.settings = settings(
+    # Raised from 25: the nested AISystemDescriptor body (name/purpose
+    # non-blank + max_length + enum fields) needs a wider example budget
+    # to reliably produce at least one valid `register` body per run —
+    # see the "Generation-reliability note" above. derandomize=True (a
+    # fixed, version-pinned PRNG seed schedule) + database=None (skip
+    # Hypothesis's local example cache) make this deterministic across
+    # CI invocations instead of depending on machine-local cached
+    # examples or wall-clock-seeded randomness.
+    max_examples=200,
+    stateful_step_count=6,
+    deadline=None,
+    derandomize=True,
+    database=None,
+    phases=[Phase.generate],
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)


### PR DESCRIPTION
## Summary

Completes the Horizon-A **H-2** arc by landing the (previously solved, independently green-verified) stateful DAST suite and wiring it into CI.

- **`tests/dast/test_openapi_stateful.py`** — a schemathesis 4.22.3 state-machine test that walks create→read→update→delete OpenAPI `link` chains over the **ai-gov** and **catalog** lifecycles (6 linked ops), hunting IDOR / state-leak / stale-reference / sequence-dependent 5xx classes that stateless per-operation fuzzing can't reach. Runs the **full default check set** — no `excluded_checks`, no `xfail`, no profile weakening. The `max_examples=200` + `derandomize=True` + `database=None` settings are a generation-budget increase + CI determinism (stronger, not looser); the whitespace class is handled at the schema layer by the true-fixes already merged in #162.
- **`.github/workflows/dast.yml`** — a **non-required, observe-first** sentinel: weekly cron + manual dispatch + API-surface PR trigger. Runs both the stateless (`test_openapi_fuzz.py`) and new stateful suites. Deliberately absent from the branch ruleset's required checks (findings surface as schemathesis case reports with curl-replay, not an auto-block).

## Whole-branch review

An adversarial whole-branch review found and this PR fixes one **HIGH**: the suite isolated only `EVIDENTIA_AI_REGISTRY_DIR`, but it also fuzzes the catalog import/delete lifecycle — so an un-isolated *local* run would write fuzz catalogs, rewrite the real `frameworks.yaml`, and could `unlink()` a real user catalog in the developer's store. Fixed by mirroring the registry isolation (`EVIDENTIA_CATALOG_DIR` → throwaway `mkdtemp` at module import). Suite soundness, scoping (exactly the 6 linked ops), rate-limit test-side neutralization, and `dast.yml` (least-privilege, SHA-pinned, non-required, schemathesis present via the dev group) all verified clean.

## Validation

Both DAST suites pass locally (2 passed); `tests/dast` stays excluded from the default `pytest tests/` collection; ruff, version-consistency, consistency 7/7, wiki mirror, and the full workflow gate suite (zizmor / perms / tools / liveness) all green. This PR's own `dast.yml` PR-trigger self-validates the suites in CI.