### PR TITLE
Ci(supply-chain): uv-audit + uv-malware-check observe-first pilots (Horizon-A H-3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,6 +280,77 @@ jobs:
       - name: Run osv-scanner SBOM gate
         run: uv run --no-sync python scripts/run_osv_scan.py
 
+  # ── Supply-chain pilots (NON-required, observe-first) ────────────────
+  # Layered model: osv-scanner (above) is the AUTHORITATIVE, enforcing SBOM
+  # gate. The two jobs below are uv PREVIEW features run as second opinions
+  # with continue-on-error, so a finding / preview breakage / feed issue is
+  # OBSERVED, never a merge blocker. Neither job name is in the branch
+  # ruleset's required checks. See docs/engineering-practices.md.
+  uv-audit:
+    name: uv audit (pilot, non-blocking)
+    runs-on: ubuntu-latest
+    # uv's native advisory audit (preview) as a second opinion to osv-scanner.
+    # `uv audit` exits non-zero when advisories are present, so continue-on-
+    # error keeps it observe-first. Baseline (accepted): cryptography
+    # GHSA-537c (dev-SBOM-scoped) + torch GHSA-rrmf (no fix upstream).
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: uv audit (locked)
+        # Ignore the accepted baseline so the pilot is GREEN normally and RED
+        # only on a NEW advisory (a perpetually-red continue-on-error job would
+        # mask new findings). Parity with the osv-scanner allowlist for the same
+        # IDs: GHSA-537c (cryptography) is dev-SBOM-scoped + accepted (plain
+        # --ignore); GHSA-rrmf (torch) has no upstream fix, so
+        # --ignore-until-fixed auto-expires and goes red the moment one ships.
+        run: >-
+          uv audit --preview-features audit --locked
+          --ignore GHSA-537c-gmf6-5ccf
+          --ignore-until-fixed GHSA-rrmf-rvhw-rf47
+
+  uv-malware-check:
+    name: uv malware check (pilot, non-blocking)
+    runs-on: ubuntu-latest
+    # Opt-in uv malware check (preview): a sync with UV_MALWARE_CHECK=1 queries
+    # OSV MAL advisories for the locked resolution and aborts before install if
+    # a package matches known malware. Kept OBSERVE-first in this dedicated
+    # non-required job (NOT on the required sync steps) because it's a preview
+    # feature performing a live OSV lookup — a match / false positive / feed
+    # issue surfaces as a visible signal without blocking merges. Graduate to
+    # fail-closed on the required syncs once the feature is GA + observed stable.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync with OSV malware check
+        env:
+          EVIDENTIA_SKIP_FRONTEND_BUILD: "1"
+          UV_MALWARE_CHECK: "1"
+        run: uv sync --all-packages --preview-features malware-check
+
   typecheck:
     name: mypy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`uv` supply-chain pilots (non-required, observe-first)** — two uv
+  preview features run in `test.yml` as second opinions to the
+  authoritative `osv-scanner` SBOM gate, both `continue-on-error` so they
+  never block a merge: a `uv audit` advisory scan, and a
+  `UV_MALWARE_CHECK=1` sync that queries OSV MAL advisories for the locked
+  closure (a resolution-time tripwire for known-malicious packages). The
+  malware check runs in its own non-required job rather than on the
+  required sync steps while the feature is in preview.
 - **Stateful DAST suite + `dast.yml` sentinel** — a schemathesis
   state-machine test (`tests/dast/test_openapi_stateful.py`) walks
   create→read→update→delete link chains over the ai-gov and catalog

--- a/docs/engineering-practices.md
+++ b/docs/engineering-practices.md
@@ -124,6 +124,18 @@ Evidentia's releases are designed to be independently verifiable end to end:
   regeneration consumes the committed input file (never overwriting it, which
   would drop manually-added security floors) and asserts the expected pins are
   present afterward.
+- **Supply-chain scanning is layered, with one authoritative gate.**
+  `osv-scanner` (above) is the single *enforcing* SBOM gate — a required check.
+  Alongside it run two `uv` *preview* features as observe-first pilots
+  (`continue-on-error`, deliberately absent from the required-check set, so a
+  finding, a preview-feature breakage, or an advisory-feed hiccup is surfaced,
+  never a merge blocker): **`uv audit`** — a uv-native advisory audit that is a
+  fast second opinion to `osv-scanner`; and a **`UV_MALWARE_CHECK=1` sync** — a
+  resolution-time tripwire that queries OSV *MAL* advisories for the locked
+  closure and would abort a sync before a known-malicious package installs. The
+  malware check is kept in its own non-required job rather than on the required
+  sync steps precisely because it is preview and performs a live OSV lookup;
+  it graduates to fail-closed on the required syncs once GA and observed stable.
 - **Dependency updates are automated with guardrails.** Dependabot proposes
   weekly, grouped, cooldown-delayed version updates (a freshly-published release
   is held a few days, so a yanked or hot-fixed bad release is superseded before it

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`uv` supply-chain pilots (non-required, observe-first)** — two uv
+  preview features run in `test.yml` as second opinions to the
+  authoritative `osv-scanner` SBOM gate, both `continue-on-error` so they
+  never block a merge: a `uv audit` advisory scan, and a
+  `UV_MALWARE_CHECK=1` sync that queries OSV MAL advisories for the locked
+  closure (a resolution-time tripwire for known-malicious packages). The
+  malware check runs in its own non-required job rather than on the
+  required sync steps while the feature is in preview.
 - **Stateful DAST suite + `dast.yml` sentinel** — a schemathesis
   state-machine test (`tests/dast/test_openapi_stateful.py`) walks
   create→read→update→delete link chains over the ai-gov and catalog


### PR DESCRIPTION
## Summary

Horizon-A **H-3**: two `uv` preview security features wired into `test.yml` as **non-required, `continue-on-error` pilots** — second opinions to the authoritative `osv-scanner` SBOM gate, never merge blockers (neither job name is in the branch ruleset's required checks).

- **`uv-audit`** — `uv audit --locked`, a uv-native advisory scan. The accepted baseline is ignored so the pilot is **green normally, red only on a NEW advisory** (a perpetually-red continue-on-error job would mask new findings): `--ignore GHSA-537c-gmf6-5ccf` (cryptography, dev-SBOM-scoped, accepted) + `--ignore-until-fixed GHSA-rrmf-rvhw-rf47` (torch, no upstream fix — auto-expires + goes red the moment one ships). Matches the existing osv-scanner allowlist for the same IDs. Verified locally: clean after the two ignores.
- **`uv-malware-check`** — a sync with `UV_MALWARE_CHECK=1` that queries OSV **MAL** advisories for the locked closure and would abort before a known-malicious package installs (closes the "lockfile points at object storage after PyPI quarantine" loophole). Kept in its **own non-required job, NOT on the required sync steps**, while the feature is preview + performs a live OSV lookup — a match / false positive / feed issue surfaces as a visible signal without blocking merges. Graduates to fail-closed on the required syncs once GA + observed stable.

## Layered model

`osv-scanner` stays the single enforcing SBOM gate; these two are observe-first pilots. Rationale documented in `docs/engineering-practices.md` (+ CHANGELOG / wiki mirror).

## Validation

All gates green (zizmor / workflow-permissions / workflow-tools / liveness / consistency 7/7). Both pilots **self-validate on this PR** — `test.yml` runs on `pull_request`, so the `uv-audit` and `uv-malware-check` jobs execute here (the empirical check for the malware job, which needs uv 0.11.16+ and can't run on the local 0.11.6). Expected: `uv-audit` green (baseline ignored); `uv-malware-check` green (no malware in the locked closure).