### PR TITLE
Ci(perf): CodSpeed benchmark suite + non-required perf-gate (Horizon-A H-4)

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,61 @@
+# CodSpeed performance-regression gate — Horizon-A H-4.
+#
+# NON-required, observe-first: runs the opt-in pytest-codspeed micro-benchmarks
+# (tests/benchmarks/, excluded from the default collection) under CodSpeed's
+# instruction-counting runner and reports per-PR perf deltas. Never a merge
+# gate (this job name is not in the branch ruleset's required checks, and it is
+# continue-on-error).
+#
+# INERT UNTIL REGISTERED: the benchmarks run + the action executes, but results
+# publish only once the repo is registered on codspeed.io (the CodSpeed GitHub
+# App, free OSS tier). Until then the upload no-ops and continue-on-error keeps
+# the job green. Public repo -> the upload token is omitted (tokenless);
+# id-token: write enables CodSpeed's OpenID Connect authentication.
+name: codspeed
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # workflow_dispatch lets CodSpeed trigger a backtest to seed initial data.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codspeed-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  benchmarks:
+    name: codspeed benchmarks (pilot, non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write  # OpenID Connect auth for the tokenless CodSpeed upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Sync workspace
+        env:
+          EVIDENTIA_SKIP_FRONTEND_BUILD: "1"
+        run: uv sync --all-packages
+
+      - name: Run CodSpeed benchmarks
+        uses: CodSpeedHQ/action@9f3a37ece7abc84992501a7fcd54d1704f3458fa  # v4.18.4
+        with:
+          run: uv run --no-sync python -m pytest tests/benchmarks/ --codspeed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodSpeed performance-regression gate (non-required, observe-first)** —
+  a `pytest-codspeed` micro-benchmark suite (`tests/benchmarks/`, excluded
+  from the default collection) over the hot paths from `docs/benchmarks.md`:
+  gap analysis (1 + 2 frameworks), catalog load, report serialization, and
+  two API request paths (health + gap-reports). A new `codspeed.yml`
+  workflow runs them under CodSpeed's instruction-counting runner and
+  reports per-PR perf deltas. `continue-on-error` and not a required check;
+  it lands inert until the repo is registered on codspeed.io (free OSS
+  tier), then activates with no further change.
 - **`uv` supply-chain pilots (non-required, observe-first)** — two uv
   preview features run in `test.yml` as second opinions to the
   authoritative `osv-scanner` SBOM gate, both `continue-on-error` so they

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -12,6 +12,14 @@ M4 (performance benchmarks). v0.7.7+ runs will add AI generation
 TTFT/P95, AWS/GitHub collector concurrency, and FastAPI sustained-
 load numbers as those surfaces stabilize.
 
+> **Continuous tracking (CodSpeed).** A subset of these paths — gap
+> analysis (1 + 2 frameworks), catalog load, report serialization, and
+> the health + gap-reports API endpoints — is tracked per-PR by
+> `pytest-codspeed` micro-benchmarks (`tests/benchmarks/`) run under the
+> `codspeed.yml` workflow. That gate is non-required and observe-first:
+> it surfaces instruction-count regressions for review, it does not block
+> merges. The tables below remain the wall-clock reference baseline.
+
 ---
 
 ## Hardware + software baseline (v0.7.6 reference run)

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CodSpeed performance-regression gate (non-required, observe-first)** —
+  a `pytest-codspeed` micro-benchmark suite (`tests/benchmarks/`, excluded
+  from the default collection) over the hot paths from `docs/benchmarks.md`:
+  gap analysis (1 + 2 frameworks), catalog load, report serialization, and
+  two API request paths (health + gap-reports). A new `codspeed.yml`
+  workflow runs them under CodSpeed's instruction-counting runner and
+  reports per-PR perf deltas. `continue-on-error` and not a required check;
+  it lands inert until the repo is registered on codspeed.io (free OSS
+  tier), then activates with no further change.
 - **`uv` supply-chain pilots (non-required, observe-first)** — two uv
   preview features run in `test.yml` as second opinions to the
   authoritative `osv-scanner` SBOM gate, both `continue-on-error` so they

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ dev = [
     # tests/fuzz/test_parser_robustness.py rides on the existing
     # `hypothesis` dev dep above and needs no Linux marker.
     "atheris>=2.3.0 ; sys_platform == 'linux'",
+    "pytest-codspeed>=5.0.3",
 ]
 docs = [
     # v0.10.7: in-repo wiki at docs/wiki/ rendered via Material for MkDocs.
@@ -260,7 +261,12 @@ asyncio_mode = "auto"
 # default collection and SHOULD NOT include DAST per the
 # README scope. See `tests/dast/README.md` for the per-suite
 # invocation guidance.
-addopts = "--ignore=tests/dast"
+#
+# tests/benchmarks/ is likewise opt-in: pytest-codspeed micro-benchmarks
+# run under CodSpeed in codspeed.yml (or `pytest tests/benchmarks/` on
+# demand), never in the default gate — they are perf measurements, not
+# pass/fail correctness tests.
+addopts = "--ignore=tests/dast --ignore=tests/benchmarks"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,7 @@
+"""Opt-in pytest-codspeed micro-benchmarks (Horizon-A H-4).
+
+Excluded from the default pytest collection via the root ``addopts
+--ignore=tests/benchmarks``. Run under CodSpeed in
+``.github/workflows/codspeed.yml`` (non-required, observe-first) or on demand
+with ``pytest tests/benchmarks/``.
+"""

--- a/tests/benchmarks/test_perf_benchmarks.py
+++ b/tests/benchmarks/test_perf_benchmarks.py
@@ -1,0 +1,82 @@
+"""pytest-codspeed micro-benchmarks over Evidentia's hot paths (Horizon-A H-4).
+
+Opt-in (excluded from the default collection via the root
+``addopts --ignore=tests/benchmarks``). Run under CodSpeed in
+``.github/workflows/codspeed.yml`` (non-required, observe-first) or on demand
+with ``pytest tests/benchmarks/``.
+
+CodSpeed measures via instruction counting (deterministic, hardware-
+independent), so each scenario keeps setup OUTSIDE the timed callable and
+isolates on-disk stores to throwaway temp dirs. Scenarios mirror
+docs/benchmarks.md: gap analysis (1 + 2 frameworks), catalog load, report
+serialization, and two API request paths (health + gap-reports).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+# Isolate on-disk stores to throwaway temp dirs BEFORE the app is imported, so a
+# benchmark run never reads or writes the developer's real catalog / registry /
+# gap-report stores (mirrors tests/dast). Module-level: the API client and its
+# app are constructed at import time, and the stores read these env vars per call.
+for _env in (
+    "EVIDENTIA_GAP_STORE_DIR",
+    "EVIDENTIA_CATALOG_DIR",
+    "EVIDENTIA_AI_REGISTRY_DIR",
+):
+    os.environ[_env] = tempfile.mkdtemp(prefix="evidentia-bench-")
+
+from evidentia_core.catalogs.loader import load_catalog  # noqa: E402
+from evidentia_core.gap_analyzer import GapAnalyzer, load_inventory  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[2]
+_INVENTORY = _REPO / "examples" / "meridian-fintech" / "my-controls.yaml"
+_ONE_FRAMEWORK = ["nist-800-53-mod"]
+_TWO_FRAMEWORKS = ["nist-800-53-mod", "soc2-tsc"]
+
+
+def test_bench_gap_analysis_single_framework(benchmark) -> None:
+    """End-to-end gap analysis against one framework (the common UX path)."""
+    inventory = load_inventory(_INVENTORY)
+    analyzer = GapAnalyzer()
+    benchmark(lambda: analyzer.analyze(inventory=inventory, frameworks=_ONE_FRAMEWORK))
+
+
+def test_bench_gap_analysis_two_frameworks(benchmark) -> None:
+    """Gap analysis across two frameworks (crosswalk-heavier path)."""
+    inventory = load_inventory(_INVENTORY)
+    analyzer = GapAnalyzer()
+    benchmark(lambda: analyzer.analyze(inventory=inventory, frameworks=_TWO_FRAMEWORKS))
+
+
+def test_bench_catalog_load(benchmark) -> None:
+    """Cold catalog hydration: JSON parse + normalization + family indexing."""
+    benchmark(lambda: load_catalog("nist-800-53-rev5"))
+
+
+def test_bench_report_serialization(benchmark) -> None:
+    """Pure serialization of a gap report to JSON (no disk I/O)."""
+    inventory = load_inventory(_INVENTORY)
+    report = GapAnalyzer().analyze(inventory=inventory, frameworks=_ONE_FRAMEWORK)
+    benchmark(lambda: report.model_dump_json())
+
+
+def test_bench_api_health(benchmark) -> None:
+    """FastAPI request overhead on the trivial health endpoint."""
+    from evidentia_api.app import create_app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(create_app(offline=True))
+    benchmark(lambda: client.get("/api/health"))
+
+
+def test_bench_api_gap_reports(benchmark) -> None:
+    """Gap-report listing endpoint (isolated empty store -> handler path only)."""
+    from evidentia_api.app import create_app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(create_app(offline=True))
+    benchmark(lambda: client.get("/api/gap/reports"))

--- a/uv.lock
+++ b/uv.lock
@@ -1097,6 +1097,7 @@ dev = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
     { name = "ruff" },
@@ -1130,6 +1131,7 @@ dev = [
     { name = "pydantic", specifier = ">=2.9,<3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-codspeed", specifier = ">=5.0.3" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "pytest-randomly", specifier = ">=3.16" },
     { name = "ruff", specifier = ">=0.15.20" },
@@ -3315,6 +3317,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/cf932fcd1960a2fd6d9b09eb403253a8709aeee975961afa6299239a830e/pytest_codspeed-5.0.3.tar.gz", hash = "sha256:91afef90e6a96b013495e4702ef5d6358614a449e71008cdc194ef668778b92f", size = 324571, upload-time = "2026-05-22T16:20:49.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/22/456c48160b761d5028c8afa119f085a9fc42855a783a13d73918078969f0/pytest_codspeed-5.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2eeb25fb1ac3f73c4de50e739e78fea396b89782bdb740bf2a7cd2df21f8d4ee", size = 366255, upload-time = "2026-05-22T16:20:56.214Z" },
+    { url = "https://files.pythonhosted.org/packages/74/33/ac7441fa937c9d9f158083a8c46920a5a5c81ed3c5f96240fc8d650db5c2/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73c5c9d98a3372a42611989ccfa437cce3842431ac6d6b9ab42c4f0e59c070f7", size = 932325, upload-time = "2026-05-22T16:21:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bc/8b994adcb9e9016e7d9a808056a3dd9cca21441e432ef456eae2b697d7fe/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2e0ab65df73e837666d12357280ca50ff6d6ac03ea5266703be518b68170edf", size = 934885, upload-time = "2026-05-22T16:21:01.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6524c57fec279a22ffef6112af404036afc71b4704758ae9f0abda429b8478d4", size = 366253, upload-time = "2026-05-22T16:20:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7b/ae76fd8ac656b9695806a6aafd5f22ec32e6ce20e266a58f9112e01d3cd8/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c383c9121deb58a69f174188e9e4488ffc0daced0ed276abf87747182511901", size = 932360, upload-time = "2026-05-22T16:20:30.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4bcdb4b6522738152885ef067e0c8524d5699828d780fb6f464cdb3db44369c", size = 934928, upload-time = "2026-05-22T16:20:38.62Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b2/1d2a993c532146dce9eca5b5942d51898021c3579ce18b2454f932a915f8/pytest_codspeed-5.0.3-py3-none-any.whl", hash = "sha256:fe2ea83c924c2250675b75686c3ee456b8cf0208d83d552e182a195fdf467378", size = 74033, upload-time = "2026-05-22T16:20:26.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Horizon-A **H-4**: a `pytest-codspeed` micro-benchmark suite over the hot paths from `docs/benchmarks.md`, plus a **non-required, observe-first** `codspeed.yml` gate.

- **`tests/benchmarks/`** (excluded from the default collection via `addopts --ignore`): 6 scenarios — gap analysis (1 + 2 frameworks), catalog load (`nist-800-53-rev5`), report serialization (`model_dump_json`), and two API request paths (`/api/health` + `/api/gap/reports`). On-disk stores (gap / catalog / registry) are isolated to temp dirs at module import so a run never touches the developer's real stores; setup is kept outside the timed callable for a clean instruction-count signal.
- **`.github/workflows/codspeed.yml`**: runs the suite under CodSpeed's runner on push / PR / dispatch, `continue-on-error` and **NOT a required check**. Public repo → tokenless (`id-token: write` for OIDC). SHA-pinned actions.

## Inert until registration

The benchmarks + action run, but results publish only once the repo is registered on **codspeed.io** (the CodSpeed GitHub App, free OSS tier). Until then the upload no-ops and `continue-on-error` keeps the job green; registration activates reporting with **no further code change**.

## Validation

6/6 benchmarks pass locally; full tree **4798 pass** (the dev dep is inert for the default suite); all workflow gates (zizmor / permissions / tools / liveness) + consistency 7/7 green. This PR self-validates — `codspeed.yml` runs here (inert-green) and `test.yml` confirms the dep doesn't regress the required suite.