### PR TITLE
Ci(perf): Set CodSpeed v4 mode:simulation so the pilot actually reports

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -6,11 +6,13 @@
 # gate (this job name is not in the branch ruleset's required checks, and it is
 # continue-on-error).
 #
-# INERT UNTIL REGISTERED: the benchmarks run + the action executes, but results
-# publish only once the repo is registered on codspeed.io (the CodSpeed GitHub
-# App, free OSS tier). Until then the upload no-ops and continue-on-error keeps
-# the job green. Public repo -> the upload token is omitted (tokenless);
-# id-token: write enables CodSpeed's OpenID Connect authentication.
+# REPORTING: the repo is registered on codspeed.io (the CodSpeed GitHub App,
+# free OSS tier), so the action uploads instruction-count results and reports
+# per-PR perf deltas via the CodSpeed dashboard + PR comment. Public repo ->
+# the upload token is omitted (tokenless); id-token: write enables CodSpeed's
+# OpenID Connect authentication. continue-on-error keeps a transient upload
+# failure non-blocking (observe-first); perf-regression signal comes from the
+# PR comment, not from failing this step.
 name: codspeed
 
 on:
@@ -55,12 +57,16 @@ jobs:
         run: uv sync --all-packages
 
       - name: Run CodSpeed benchmarks
-        # step-level continue-on-error: keep the JOB green (not red-non-blocking)
-        # while the repo is unregistered on codspeed.io — the upload step fails
-        # until registration, but that must not surface as a red PR check. Once
-        # registered the upload succeeds; CodSpeed reports perf deltas via its
-        # dashboard + PR comment, not by failing this step.
+        # step-level continue-on-error: this is an observe-first, non-required
+        # pilot — a transient CodSpeed upload/outage must not surface as a red PR
+        # check. CodSpeed reports perf deltas via its dashboard + PR comment, not
+        # by failing this step, so keeping it non-blocking loses no regression signal.
         continue-on-error: true
         uses: CodSpeedHQ/action@9f3a37ece7abc84992501a7fcd54d1704f3458fa  # v4.18.4
         with:
+          # v4 requires an explicit instrument mode. `simulation` is the Valgrind
+          # instruction-counting instrument (deterministic, hardware-independent)
+          # that runs on standard ubuntu-latest runners; `walltime` would require
+          # dedicated CodSpeed macro runners. (v4 renamed the old `instrumentation`.)
+          mode: simulation
           run: uv run --no-sync python -m pytest tests/benchmarks/ --codspeed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CodSpeed pilot job now lands inert-green, not inert-red** — moved
-  `continue-on-error` to the CodSpeed step so the job stays green while the
-  repo is unregistered on codspeed.io (the upload step fails until
-  registration); it was previously a red-but-non-blocking check.
+- **CodSpeed perf-regression pilot now reports** — added the `mode: simulation`
+  input that CodSpeed Action v4 now requires (the Valgrind instruction-counting
+  instrument for standard GitHub-hosted runners; without it the step errored out
+  before ever benchmarking, and step-level `continue-on-error` silently masked
+  it as green). With the repo now registered on codspeed.io, the job benchmarks
+  `tests/benchmarks/` and reports per-PR perf deltas via the CodSpeed dashboard
+  and PR comment. `continue-on-error` stays at the step level so a transient
+  CodSpeed upload/outage remains non-blocking (observe-first); the
+  perf-regression signal comes from the PR comment, not from failing the check.
 
 ### Security
 

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -26,10 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **CodSpeed pilot job now lands inert-green, not inert-red** — moved
-  `continue-on-error` to the CodSpeed step so the job stays green while the
-  repo is unregistered on codspeed.io (the upload step fails until
-  registration); it was previously a red-but-non-blocking check.
+- **CodSpeed perf-regression pilot now reports** — added the `mode: simulation`
+  input that CodSpeed Action v4 now requires (the Valgrind instruction-counting
+  instrument for standard GitHub-hosted runners; without it the step errored out
+  before ever benchmarking, and step-level `continue-on-error` silently masked
+  it as green). With the repo now registered on codspeed.io, the job benchmarks
+  `tests/benchmarks/` and reports per-PR perf deltas via the CodSpeed dashboard
+  and PR comment. `continue-on-error` stays at the step level so a transient
+  CodSpeed upload/outage remains non-blocking (observe-first); the
+  perf-regression signal comes from the PR comment, not from failing the check.
 
 ### Security
 


### PR DESCRIPTION
## What

CodSpeed Action v4 made the `mode` input **required**. The `codspeed` job omitted it, so the step errored (exit 1) *before ever benchmarking*, and step-level `continue-on-error` silently masked it as a green check. The perf pilot has therefore **never uploaded** — independent of the codspeed.io GitHub App registration.

This adds `mode: simulation` — the Valgrind instruction-counting instrument that runs on standard GitHub-hosted runners (v4 renamed the old `instrumentation`; `walltime` would require dedicated CodSpeed macro runners).

## Why now

Last loose end of the H-4 CodSpeed pilot from the v0.10.x hardening cycle — the repo is now registered on codspeed.io, so with `mode` set the job benchmarks `tests/benchmarks/` and reports per-PR perf deltas via the CodSpeed dashboard + PR comment. Belongs in v0.10.17.

`continue-on-error` is retained at the step level so a transient CodSpeed upload/outage stays non-blocking (observe-first); the perf-regression signal comes from the PR comment, not from failing the check.

## Changes

- `.github/workflows/codspeed.yml` — add `mode: simulation`; refresh the stale "inert until registered" comments
- `CHANGELOG.md` — rewrite the stale `[Unreleased]` CodSpeed entry to the accurate shipped state
- `docs/wiki/6-project/changelog.md` — wiki mirror regen

## Validation

- Workflow gates: zizmor 1.26.1 clean · `audit_workflow_permissions --strict` PASS · `check_workflow_tools --strict` 0 · `check_workflow_liveness` 0
- `run_gate_suite --scope consistency` 7/7 · docs-health `--strict` 0 FAIL · version-consistency PASS
- **Empirical proof** = this PR's own `codspeed` run must actually upload results (not merely show green). Non-required, observe-first.