### PR TITLE
Feat(release): Add a publish-safe preflight dry-run + tag-only deploy environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "v*"
+  # Preflight dry-run. A manual dispatch runs the FULL gate + build/validate path
+  # (wheels + per-package SBOMs + reproducible-build check + container-from-local-
+  # wheels + smoke tests) WITHOUT publishing, so the classes that only ever ran at
+  # tag time (a base/dep regression, a uvx exit-127, a pip-compile hash mismatch)
+  # surface on-demand BEFORE a tag is cut. publish-pypi/publish-container require
+  # github.event_name == 'push' (see tag-guard + their `if:`), so a dispatch — even
+  # one selected on a v* tag ref — is STRUCTURALLY incapable of publishing. The
+  # pypi/ghcr deployment environments are independently restricted to v* tag refs
+  # as a second, platform-level belt (see docs/release-checklist.md).
+  workflow_dispatch: {}
 
 # Workflow-level least-privilege default. Each publish job elevates locally.
 # Closes OpenSSF Scorecard alert #30 (no top-level permission defined).
@@ -51,10 +61,14 @@ concurrency:
 # ---------------------------------------------------------------------------
 
 jobs:
-  # Accidental-publish hardening (v0.10.12 Wave 0b). The trigger is tags:['v*'],
-  # so any v-prefixed tag — a typo, an rcN, a fork mirror — would otherwise reach
-  # the publish jobs. This guard makes publishing structurally conditional on
-  # (a) the canonical repo AND (b) a strict vX.Y.Z semver tag.
+  # Accidental-publish hardening (v0.10.12 Wave 0b; v0.10.17 preflight). The trigger
+  # set is tags:['v*'] + workflow_dispatch, so a v-prefixed tag — a typo, an rcN, a
+  # fork mirror — OR a manual preflight dispatch would otherwise reach the publish
+  # jobs. This guard makes publishing structurally conditional on (a) a real tag
+  # PUSH (github.event_name == 'push', NOT a workflow_dispatch — including a dispatch
+  # selected on a v* tag ref), (b) the canonical repo, AND (c) a strict vX.Y.Z semver
+  # tag. The publish jobs re-assert event_name == 'push' in their own `if:` so no
+  # single edit to this guard can re-open a dispatch publish path.
   tag-guard:
     name: Validate publish trigger (canonical repo + semver tag)
     runs-on: ubuntu-latest
@@ -65,12 +79,13 @@ jobs:
         id: check
         run: |
           publishable=false
-          if [ "${{ github.repository }}" = "Polycentric-Labs/evidentia" ] \
+          if [ "${{ github.event_name }}" = "push" ] \
+             && [ "${{ github.repository }}" = "Polycentric-Labs/evidentia" ] \
              && printf '%s' "$GITHUB_REF" | grep -Eq '^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'; then
             publishable=true
           fi
           echo "publishable=$publishable" >> "$GITHUB_OUTPUT"
-          echo "repository=${{ github.repository }} ref=$GITHUB_REF -> publishable=$publishable"
+          echo "event=${{ github.event_name }} repository=${{ github.repository }} ref=$GITHUB_REF -> publishable=$publishable"
 
   # Tag-time pre-publish gate (v0.10.8 A1). Runs the full SSOT gate suite
   # (scripts/run_gate_suite.py --scope full) on the exact tagged commit. `build`
@@ -122,7 +137,13 @@ jobs:
   build:
     name: Build + validate all artifacts (wheels + container)
     needs: [gate, tag-guard]
-    if: ${{ needs.tag-guard.outputs.publishable == 'true' }}
+    # Runs on a real release (publishable) AND on a preflight dispatch (dry-run):
+    # the whole point of the preflight is to exercise THIS exact build/validate job
+    # on-demand. It stays credential-free — permissions: contents:read only, no
+    # environment:, push:false — so producing artifacts on a dispatch grants no
+    # publish capability (publish-pypi/publish-container require event_name=='push').
+    # NOTE: never hoist packages:/id-token: write into this job (load-bearing).
+    if: ${{ needs.tag-guard.outputs.publishable == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -155,12 +176,25 @@ jobs:
       - name: Sync workspace
         run: uv sync --all-packages
 
-      - name: Extract version from tag
+      - name: Extract version
         id: version
         run: |
-          REF="${GITHUB_REF_NAME}"
-          echo "tag=${REF}" >> "$GITHUB_OUTPUT"
-          echo "semver=${REF#v}" >> "$GITHUB_OUTPUT"
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            # Real release: the pushed tag name IS the version (bump_version set it).
+            tag="${GITHUB_REF_NAME}"
+            semver="${tag#v}"
+          else
+            # Preflight dispatch (any ref): GITHUB_REF_NAME on a branch dispatch is
+            # e.g. 'main', not a version, which would fail the container version
+            # smoke-test below. Derive the version from the workspace manifest (the
+            # version-consistency SSOT) — the built wheels carry exactly this, so the
+            # smoke-test matches and a preflight on `main` runs green.
+            semver="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')"
+            tag="v${semver}"
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "semver=${semver}" >> "$GITHUB_OUTPUT"
+          echo "event=${GITHUB_EVENT_NAME} -> tag=${tag} semver=${semver}"
 
       # SOURCE_DATE_EPOCH-driven reproducible builds (v0.8.3 G4): byte-identical
       # wheels across hosts, which also makes the local-wheel hashes pip-compile
@@ -390,7 +424,11 @@ jobs:
       - name: Upload release-dist (wheels + sdists + SBOM)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: release-dist
+          # On a preflight dispatch, suffix the name so the artifact can't be mistaken
+          # for a real-release artifact (publish-* skip on dispatch, so the plain name
+          # is never needed there). On a real push the name stays `release-dist` so the
+          # publish jobs download it unchanged.
+          name: release-dist${{ github.event_name == 'workflow_dispatch' && format('-preflight-{0}', github.run_id) || '' }}
           path: |
             dist/
             evidentia-sbom.cdx.json
@@ -400,7 +438,9 @@ jobs:
       - name: Upload release-image (validated container tarball)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: release-image
+          # Preflight dispatch -> suffixed name (see release-dist above); real push
+          # -> plain `release-image` so publish-container downloads it unchanged.
+          name: release-image${{ github.event_name == 'workflow_dispatch' && format('-preflight-{0}', github.run_id) || '' }}
           path: evidentia-image.tar.gz
           if-no-files-found: error
           retention-days: 7
@@ -413,7 +453,10 @@ jobs:
   publish-pypi:
     name: Publish wheels to PyPI
     needs: [build, tag-guard]
-    if: ${{ success() && needs.tag-guard.outputs.publishable == 'true' }}
+    # Redundant, INDEPENDENT event gate (defense-in-depth): publishing requires a
+    # real tag PUSH at TWO orthogonal points (here + tag-guard's publishable), so no
+    # single future edit to tag-guard can re-open a workflow_dispatch publish path.
+    if: ${{ success() && github.event_name == 'push' && needs.tag-guard.outputs.publishable == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -495,7 +538,10 @@ jobs:
   publish-container:
     name: Publish container image to ghcr.io + create the GitHub Release
     needs: [publish-pypi, tag-guard]
-    if: ${{ success() && needs.tag-guard.outputs.publishable == 'true' }}
+    # Redundant, INDEPENDENT event gate (see publish-pypi): event_name == 'push' AND
+    # publishable, so a workflow_dispatch (even one selected on a v* tag ref) can
+    # never reach the GHCR push / cosign-sign / Release-create steps.
+    if: ${{ success() && github.event_name == 'push' && needs.tag-guard.outputs.publishable == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: ghcr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release-pipeline preflight dry-run** — `release.yml` now accepts a manual
+  `workflow_dispatch` that runs the full pre-publish path (the SSOT gate suite +
+  wheels + per-package SBOMs + the reproducible-build double-build + the
+  container-built-from-local-wheels + the image smoke tests) **without publishing**,
+  so the failure classes that previously surfaced only at tag time (a base/dep
+  regression, a `uvx` exit-127, a `pip-compile` hash mismatch — the v0.10.14 /
+  v0.10.15 ghost-tag failures) can be caught on-demand before a tag is cut
+  (`gh workflow run release.yml --ref main`). The dry-run is structurally incapable
+  of publishing: `tag-guard` and both publish jobs require `github.event_name ==
+  'push'`, so a dispatch — even one selected on a `v*` tag ref — yields
+  `publishable=false` and `publish-pypi` / `publish-container` skip. As a second,
+  platform-level belt the `pypi` and `ghcr` deployment environments are restricted
+  to `v*` **tag** refs with required reviewers, so a real release now also pauses
+  for an explicit deployment approval. See `docs/release-checklist.md` Step 5.6.
+
 ### Changed
 
 - **Refreshed the DHI runtime base image digest** — the pinned

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -302,6 +302,41 @@ Apply via Grep/Edit; commit as a single
 
 ---
 
+## Step 5.6 — Release preflight dry-run (optional pre-tag validation, v0.10.17+)
+
+For a higher-fidelity pre-tag check than the local Step-5 gate — especially
+when `release.yml`, the `Dockerfile`, or the dependency closure changed — run
+the **release preflight**: a `workflow_dispatch` on `release.yml` that executes
+the FULL pre-publish path on a runner (the SSOT gate suite + wheels + per-package
+SBOMs + the reproducible-build double-build + the container-built-FROM-LOCAL-WHEELS
++ all the image smoke tests) **without publishing anything**. It catches the
+classes that historically surfaced only at tag time — a base/dep regression, a
+`uvx` exit-127, a `pip-compile` hash mismatch (the v0.10.14 / v0.10.15 ghost-tag
+failures).
+
+```bash
+# Run the preflight on the branch you're about to tag from (usually main):
+gh workflow run release.yml --ref main
+# then watch it:
+gh run watch "$(gh run list --workflow release.yml --event workflow_dispatch \
+  --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+Publish-safe by construction: `tag-guard` and both publish jobs require
+`github.event_name == 'push'`, so a dispatch — even one selected on a `v*` tag
+ref — yields `publishable=false` and `publish-pypi` / `publish-container` SKIP.
+The `pypi` / `ghcr` deployment environments are independently restricted to `v*`
+**tag** refs (with required reviewers), a second, platform-level belt.
+
+Acceptance:
+
+- [ ] The preflight dispatch run is GREEN through `build` (gate + build +
+      reproducible-build check + container smoke all pass)
+- [ ] `publish-pypi` and `publish-container` show **skipped** — confirm nothing
+      published on the dispatch
+
+---
+
 ## Step 6 — Inconsistency scour
 
 Per the testing-playbook 3-pass scour pattern:
@@ -440,6 +475,17 @@ git push origin main          # if main has unpushed commits
 git push origin vX.Y.Z         # the tag triggers release.yml
 gh run watch                   # monitor the release workflow
 ```
+
+> **v0.10.17+ — deployment approval gate.** The `pypi` and `ghcr` deployment
+> environments carry **required reviewers** (Allen; self-review allowed), so
+> after the tag push the `release.yml` run PAUSES at `publish-pypi` (and again at
+> `publish-container`) awaiting an "Approve deployment" click in the Actions run
+> UI — the Tier-4 per-publish approval enforced by the platform, not just by
+> discipline. Approve each once the preceding jobs are green. These environments
+> are also restricted to `v*` **tag** refs and are consumed ONLY by `release.yml`;
+> do not re-add a branch policy or point another workflow at them without
+> re-checking this guard (a `custom_branch_policies:true` environment with zero
+> matching policies blocks ALL deployments → a wheels-only half-release).
 
 If the release.yml workflow fails:
 

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release-pipeline preflight dry-run** — `release.yml` now accepts a manual
+  `workflow_dispatch` that runs the full pre-publish path (the SSOT gate suite +
+  wheels + per-package SBOMs + the reproducible-build double-build + the
+  container-built-from-local-wheels + the image smoke tests) **without publishing**,
+  so the failure classes that previously surfaced only at tag time (a base/dep
+  regression, a `uvx` exit-127, a `pip-compile` hash mismatch — the v0.10.14 /
+  v0.10.15 ghost-tag failures) can be caught on-demand before a tag is cut
+  (`gh workflow run release.yml --ref main`). The dry-run is structurally incapable
+  of publishing: `tag-guard` and both publish jobs require `github.event_name ==
+  'push'`, so a dispatch — even one selected on a `v*` tag ref — yields
+  `publishable=false` and `publish-pypi` / `publish-container` skip. As a second,
+  platform-level belt the `pypi` and `ghcr` deployment environments are restricted
+  to `v*` **tag** refs with required reviewers, so a real release now also pauses
+  for an explicit deployment approval. See `docs/release-checklist.md` Step 5.6.
+
 ### Changed
 
 - **Refreshed the DHI runtime base image digest** — the pinned


### PR DESCRIPTION
## What

Adds a manual `workflow_dispatch` to `release.yml` — a **preflight dry-run** that runs the FULL pre-publish path (SSOT gate suite + wheels + per-package SBOMs + reproducible-build double-build + container-built-from-local-wheels + image smoke tests) **without publishing**, so the failure classes that previously surfaced only at tag time (a base/dep regression, a `uvx` exit-127, a `pip-compile` hash mismatch — the v0.10.14 / v0.10.15 ghost-tag failures) can be caught on-demand before a tag is cut.

Closes the 2026-07-02 release-guardrails labcoat's "preflight = lead candidate" conditional (now fired: ≥2 structural `release.yml` changes/qtr).

## Publish-safe by construction — two independent belts

1. **Workflow-level:** `tag-guard` now gates `publishable` on `github.event_name == 'push'` (plus canonical-repo + strict semver tag), so a dispatch — even one selected on a `v*` tag ref — yields `publishable=false`. Both `publish-pypi` and `publish-container` **re-assert** `event_name == 'push'` in their own `if:`, so no single edit to `tag-guard` can re-open a dispatch publish path (defense-in-depth per the adversarial review).
2. **Platform-level:** the `pypi` and `ghcr` deployment environments are restricted to `v*` **tag** refs with required reviewers (applied via the GitHub API this session; API-verified). This also makes the Tier-4 per-publish approval platform-enforced — a real release now pauses for an explicit deployment approval.

`build` runs on both a real release and a preflight dispatch (it exercises the *exact* release build job) and stays credential-free (`contents:read` only, no `environment:`, `push:false`). On a dispatch it derives the version from the workspace manifest (not `GITHUB_REF_NAME`) so a preflight on `main` passes the container version smoke-test, and it suffixes artifact names so preflight artifacts can't be mistaken for real-release artifacts. **The real tag-push release path is unchanged.**

## Verification

- Design: adversarial workflow (4 skeptic lenses + adjudicator) → no dispatch path publishes; the must-fix defense-in-depth items are folded in.
- Diff: independent whole-branch review → **SHIP** (fidelity C1–C6′ exact, safety invariant holds, real-release path unbroken, YAML/expressions/version-extraction correct).
- Gates: zizmor 1.26.1 (release.yml) clean · perms strict PASS · tools 0 · liveness 0 · consistency 7/7 · docs-health 0-FAIL · version PASS · mkdocs `--strict` OK · release-adjacent tests 53 passed. No `.py` changed.

Design doc: `.local/labcoat/preflight-design-2026-07/` (gitignored). See `docs/release-checklist.md` Step 5.6 for usage.