### PR TITLE
Ci(reliability): Cap dast + codspeed job runtimes with timeout-minutes

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,6 +34,11 @@ jobs:
   benchmarks:
     name: codspeed benchmarks (pilot, non-blocking)
     runs-on: ubuntu-latest
+    # Bound the run: the CodSpeed Valgrind instrumentation of tests/benchmarks/
+    # plus the workspace sync is open-ended; cap it so a stuck benchmark or a
+    # hung upload can't tie up a runner (this observe-first pilot is non-blocking,
+    # but a hang would still consume minutes).
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write  # OpenID Connect auth for the tokenless CodSpeed upload

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -41,6 +41,11 @@ jobs:
   dast:
     name: schemathesis (stateless + stateful)
     runs-on: ubuntu-latest
+    # Bound the fuzz workload: the stateful schemathesis suite (max_examples=200 +
+    # derandomize) and the stateless sweep are open-ended and could hang on a
+    # pathological state-machine path; cap the run so a stuck job can't tie up a
+    # runner indefinitely (mirrors mutmut.yml's cap on the other heavy suite).
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`timeout-minutes` caps added to the `dast` and `codspeed` jobs** — the two
+  observe-first suites added this cycle ran open-ended (schemathesis stateful
+  fuzzing and CodSpeed Valgrind instrumentation), so a pathological path or a hung
+  upload could tie up a runner indefinitely. Both now carry an explicit cap (dast
+  30 min, codspeed 20 min), mirroring `mutmut.yml`'s existing cap on the other
+  heavy suite.
 - **`docker/Dockerfile.demo` reworked to a shell-free multi-stage build** — the
   Tier-1 hosted-demo image (the real CLI behind an argv allowlist) now builds its
   final stage FROM the distroless signed release base with `COPY` + `ENV` + `USER`

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`timeout-minutes` caps added to the `dast` and `codspeed` jobs** — the two
+  observe-first suites added this cycle ran open-ended (schemathesis stateful
+  fuzzing and CodSpeed Valgrind instrumentation), so a pathological path or a hung
+  upload could tie up a runner indefinitely. Both now carry an explicit cap (dast
+  30 min, codspeed 20 min), mirroring `mutmut.yml`'s existing cap on the other
+  heavy suite.
 - **`docker/Dockerfile.demo` reworked to a shell-free multi-stage build** — the
   Tier-1 hosted-demo image (the real CLI behind an argv allowlist) now builds its
   final stage FROM the distroless signed release base with `COPY` + `ENV` + `USER`


### PR DESCRIPTION
## What

The two observe-first suites added in the v0.10.x hardening cycle — `dast` (schemathesis stateless + stateful, `max_examples=200` + derandomize) and `codspeed` (CodSpeed Valgrind instrumentation of `tests/benchmarks/`) — ran with **no job `timeout-minutes`**, unlike the comparable heavy `mutmut` suite (90-min cap). Both are open-ended and could hang on a pathological state-machine path or a stuck upload and tie up a runner indefinitely.

Adds explicit caps: **dast 30 min, codspeed 20 min**. No behavior change on a healthy run; a hang now fails fast instead of consuming the full runner budget.

Surfaced by the v0.10.17-closeout internal delta sweep vs the 2026-06-26 elite-practice baseline.

## Validation

zizmor 1.26.1 (both files) clean · perms strict PASS · tools 0 · liveness 0 · consistency 7/7 · docs-health 0-FAIL.