### PR TITLE
Chore(release): Prepare v0.10.17 — bump + CHANGELOG + doc-accuracy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.17] - 2026-07-09
+
+**Theme**: *v0.10.x hardening close-out.* The final v0.10.x release, completing the Horizon-A elite-engineering-practice arc. Lands a publish-safe release-pipeline **preflight dry-run** — a `workflow_dispatch` that runs the full build/validate path (gate + wheels + per-package SBOMs + reproducible double-build + container-from-local-wheels + smoke tests) but is *structurally unable to publish* (the publish jobs require `github.event_name == 'push'`) — backed by `v*`-tag-only PyPI/GHCR deployment environments with required-reviewer approval, so a real release now pauses for an explicit deployment sign-off. Also: **two real audit-logger security fixes** surfaced by an adversarial review of the CodeQL 2.26.0 findings (CWE-117 log CR/LF injection + CWE-312 cleartext credential in an exception field); the dead CodeQL `.qll` path-injection sanitizer pack replaced with a Models-as-Data `barrierModel` extension (honestly dismissal-managed until the stock query consumes it); the Tier-1 demo image reworked to a **shell-free distroless multi-stage build**; CodSpeed perf reporting activated; CI job timeout caps; and a refreshed distroless base digest. No package API changes.
+
 ### Added
 
 - **Release-pipeline preflight dry-run** — `release.yml` now accepts a manual

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,5 +47,5 @@ keywords:
   - slsa
   - python
 license: Apache-2.0
-version: 0.10.16
-date-released: '2026-07-02'
+version: 0.10.17
+date-released: '2026-07-09'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For the full workspace (AI risk-statements, REST API, all collectors, MCP server
 pip install 'evidentia[ai,api,collectors,mcp]'
 ```
 
-Container: `docker pull ghcr.io/polycentric-labs/evidentia:v0.10.16` (cosign keyless OIDC + SLSA Provenance v1 verified).
+Container: `docker pull ghcr.io/polycentric-labs/evidentia:v0.10.17` (cosign keyless OIDC + SLSA Provenance v1 verified).
 
 See the [Getting Started wiki section](https://github.com/Polycentric-Labs/evidentia/wiki/Getting-Started) for air-gapped install, virtualenv setup, and full extras matrix.
 
@@ -120,11 +120,11 @@ See it first, no install — a self-hosted [asciinema](https://asciinema.org/) r
 
 ## Recent Releases
 
+**v0.10.17 (2026-07-09)** — *v0.10.x hardening close-out*. **Release-pipeline preflight dry-run**, `release.yml` now accepts a manual `workflow_dispatch` that runs the full pre-publish path (the SSOT gate suite + wheels + per-package SBOMs + the reproducible-build double-build + the container-built-from-local-wheels + the image smoke tests) **without publishing**, so the failure classes that previously surfaced only at tag time (a base/dep regression, a `uvx` exit-127, a `pip-compile` hash mismatch, the v0.10.14 / v0.10.15 ghost-tag failures) can be caught on-demand before a tag is cut.
+
 **v0.10.16 (2026-07-02)** — *Engineering hardening + distroless container base — never ship a failed test again*. **Cryptography-native air-gap signing via DSSE/in-toto**, a binary-free, network-free signing path that works inside distroless and minimal-base containers.
 
 **v0.10.13 (2026-06-23)** — *Patch — restore the container base to Python 3.13*. **Container base reverted to `python:3.13-slim`** after a Dependabot bump (#83) to `python:3.14-slim` broke `release.yml`'s container build.
-
-**v0.10.12 (2026-06-23)** — *full CLI↔GUI parity build-out + the OMB M-25-21 AI-governance migration*. **OMB M-25-21 "high-impact AI" model**, the AI-governance module now reflects current federal guidance; **Full CLI↔GUI parity build-out**, the local web console grows to **22 consoles at ~98% CLI↔GUI parity** (up from ~13% in v0.10.11), with matched REST endpoints for every new console.
 
 Full release history: [`CHANGELOG.md`](CHANGELOG.md) | [GitHub Releases](https://github.com/Polycentric-Labs/evidentia/releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ a vulnerability in Evidentia's own code.
 
 | Version | Status | Reason |
 |---------|--------|--------|
-| **`0.10.16`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
+| **`0.10.17`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
 | Earlier patches | ❌ Deprecated | Pre-v1.0 single-supported-patch policy; upgrade to the latest patch. |
 | Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](docs/archive/RENAMED.md). |
 
@@ -172,7 +172,7 @@ Verify a release wheel:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.16-py3-none-any.whl"
+  "pypi:evidentia-0.10.17-py3-none-any.whl"
 ```
 
 If verification fails, **stop and report immediately** via the

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -58,7 +58,7 @@
 # from cosign verification, NOT `:latest`):
 #   docker build -f docker/Dockerfile.demo \
 #       --build-arg BASE=ghcr.io/polycentric-labs/evidentia@sha256:<digest> \
-#       -t evidentia-demo:v0.10.16 .
+#       -t evidentia-demo:v0.10.17 .
 #
 # Smoke test (before the signed digest exists — BASE is overridable so the
 # multi-stage build + the allowlist/refusal logic are testable against a bare
@@ -74,7 +74,7 @@
 #   docker run --rm --network none --read-only --tmpfs /tmp \
 #       --memory 512m --cpus 1 --pids-limit 256 \
 #       --security-opt no-new-privileges --cap-drop ALL \
-#       evidentia-demo:v0.10.16 doctor
+#       evidentia-demo:v0.10.17 doctor
 
 # The signed release digest is the default BASE at deploy time. Declared here as a
 # GLOBAL ARG (before the first FROM) so the final stage's `FROM ${BASE}` can

--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -1,2 +1,2 @@
-evidentia[gui]==0.10.16
+evidentia[gui]==0.10.17
 urllib3>=2.7.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Evidentia roadmap
 
-**Last updated: v0.10.16 (planning, July 2026).**
+**Last updated: v0.10.17 (planning, July 2026).**
 
 > **Engineering practices** — how Evidentia is built, tested, and shipped (the
 > PR-flow + merge-queue gate, atomic releases, supply-chain integrity, and the
@@ -8,10 +8,15 @@
 
 This roadmap synthesizes community feedback with the architecture plan
 at the project root. Versions v0.3.0 through v0.7.16 + v0.8.0-v0.8.7
-+ v0.9.0-v0.9.9 + v0.10.0-v0.10.13 have shipped; v0.10.16 is the current
-release (cryptography-native DSSE air-gap signing + the distroless DHI
-container base hardening, following v0.10.12's CLI↔GUI parity build-out + the
-OMB M-25-21 AI-governance migration), before the v0.11 federal-compliance theme. **v0.9.0 opened the
++ v0.9.0-v0.9.9 + v0.10.0-v0.10.16 have shipped; v0.10.17 is the current
+release — the **v0.10.x hardening close-out**: a publish-safe release-pipeline
+preflight dry-run + `v*`-tag-only PyPI/GHCR deployment environments with
+required-reviewer approval, two real audit-logger security fixes (CWE-117 log
+injection + CWE-312 cleartext credential), the Tier-1 demo image reworked to a
+shell-free distroless build, and CodSpeed perf reporting — following v0.10.16's
+cryptography-native DSSE air-gap signing + distroless DHI container base and
+v0.10.12's CLI↔GUI parity build-out + OMB M-25-21 AI-governance migration,
+before the v0.11 federal-compliance theme. **v0.9.0 opened the
 v0.9.x "federal compliance" line** with POA&M + CONMON read-only
 library; v0.9.1 landed the Polycentric Labs org migration; v0.9.2
 added the CONMON REST router + federal corpus + LLM rater + federal

--- a/docs/SECURE-BY-DESIGN-PLEDGE.md
+++ b/docs/SECURE-BY-DESIGN-PLEDGE.md
@@ -108,16 +108,26 @@ enable a significant, measurable reduction in the prevalence of one or more
 entire classes of vulnerability across the manufacturer's products.
 
 **How Evidentia aligns.** This is the goal where the project invests most
-heavily, with multiple *class-eliminating* controls (not per-instance fixes):
+heavily, favoring *class-eliminating* controls over per-instance fixes wherever
+the tooling allows (and saying so honestly where it does not yet):
 
-- **Static analysis — CodeQL `security-extended` + a custom sanitizer pack.**
-  The advanced CodeQL setup runs the `security-extended` query suite across
-  Python, JavaScript/TypeScript, and GitHub Actions, *plus* a project-authored
-  QL pack that declares `evidentia_core.security.paths.validate_within` as a
-  sanitizer for the `py/path-injection` query — closing path-traversal
-  (CWE-22) false-positives at the analysis layer rather than dismissing alerts
-  one by one. Evidence: `.github/workflows/codeql.yml`,
-  `.github/codeql/codeql-config.yml`, `.github/codeql/python-sanitizers/`.
+- **Static analysis — CodeQL `security-extended` + a Models-as-Data barrier
+  extension.** The advanced CodeQL setup runs the `security-extended` query
+  suite across Python, JavaScript/TypeScript, and GitHub Actions. It ships a
+  Models-as-Data `barrierModel` extension
+  (`.github/codeql/path-injection-barriers.model.yml`, loaded via the config's
+  `dataExtensions:` key) declaring `evidentia_core.security.paths.validate_within`
+  and `resolve_catalog_path` as `py/path-injection` barriers. **Honest scope:**
+  the stock `py/path-injection` query does not yet consume Models-as-Data
+  `barrierModel` (it uses the QL `PathInjection::Sanitizer` classes), so the
+  extension is a forward-looking hook and this specific CWE-22 false-positive
+  class is currently **dismissal-managed** (per-instance dismissals with written
+  reasons, e.g. `#170`/`#171`) rather than eliminated at the analysis layer. The
+  earlier project-authored `.qll` sanitizer pack was removed in v0.10.17 — it
+  never loaded (the `packs:` config key takes only published registry specs, and
+  an external library pack cannot inject a barrier into a stock query). Evidence:
+  `.github/workflows/codeql.yml`, `.github/codeql/codeql-config.yml`,
+  `.github/codeql/path-injection-barriers.model.yml`.
 - **SSRF guard (CWE-918), secure-by-default + anti-DNS-rebinding.** A single
   reusable outbound-request chokepoint (`enforce_public_host`) refuses any host
   that resolves to a private / loopback / link-local / reserved address,

--- a/docs/slsa-source-track.md
+++ b/docs/slsa-source-track.md
@@ -75,7 +75,7 @@ All facts below were read from the live GitHub configuration of
    *"main — PR flow (required checks + merge queue)"*, Repository-level,
    **active**) — targets the default branch. Rules: `pull_request`
    (allowed merge methods: `squash`), `required_status_checks`
-   (**19** required checks), `merge_queue` (SQUASH), `required_linear_history`,
+   (**21** required checks), `merge_queue` (SQUASH), `required_linear_history`,
    `required_signatures`, `non_fast_forward`. `bypass_actors: []`,
    `current_user_can_bypass: never`.
 
@@ -144,14 +144,14 @@ flag the formal-VSA gap honestly in
 
 | Requirement | Evidence | Status |
 |-------------|----------|--------|
-| Org enforces customized technical controls on specific named refs | Repo ruleset `18097115` on `main`: PR-required, 19 required status checks, merge queue, signed commits, linear history; tag ruleset `18175057` on `v*` | ✅ |
+| Org enforces customized technical controls on specific named refs | Repo ruleset `18097115` on `main`: PR-required, 21 required status checks, merge queue, signed commits, linear history; tag ruleset `18175057` on `v*` | ✅ |
 | Controls enforced **continuously** (no lapse) | Rulesets are `enforcement: active`; org baseline active since 2026-05-25; bypass lists empty — there is no actor who can silently disable enforcement for a single change | ✅ |
 | Controls documented (their meaning) | This document + [`docs/scorecard-posture.md`](scorecard-posture.md) + `SECURITY.md` define the enforced controls and their intent | ✅ |
 | Continuity tracked from a start revision | Org baseline ruleset `created_at` 2026-05-25; repo PR-flow ruleset `created_at` 2026-06-24; tag ruleset `created_at` 2026-06-26 — each establishes a continuity start point | ✅ |
 
 **L3 is met.** Evidentia enforces a customized, documented set of technical
 controls on its protected `main` and `v*` references, continuously and without
-bypass. The required-status-checks gate (19 contexts including CodeQL SAST,
+bypass. The required-status-checks gate (21 contexts including CodeQL SAST,
 cross-platform pytest, ruff, mypy, OSV/SBOM scan, gitleaks secret-scan, OpenAPI
 + CLI↔GUI drift gates, and workflow-permission audit) is itself part of the
 enforced control surface.
@@ -170,13 +170,13 @@ enforced control surface.
 |-------------|---------|--------|
 | Changes to protected branches agreed to by **two or more trusted persons** | **Single maintainer.** The `main` ruleset requires a PR (`pull_request` rule), but `required_approving_review_count` is **0** — because GitHub does not permit an author to approve their own PR, a non-zero requirement on a solo project would deadlock every merge. There is no second trusted person to review. | ❌ |
 | Uploader and reviewer are different trusted persons (or two reviewers) | Not satisfiable with one maintainer | ❌ |
-| Informed review covering security-relevant properties | Partially substituted by automated gates (19 required checks incl. CodeQL SAST) + a mandatory `/pre-release-review` before every tag, but these are **automated controls, not a second human reviewer** | ⚠️ substitute only |
+| Informed review covering security-relevant properties | Partially substituted by automated gates (21 required checks incl. CodeQL SAST) + a mandatory `/pre-release-review` before every tag, but these are **automated controls, not a second human reviewer** | ⚠️ substitute only |
 
 **L4 is not met, and we do not claim it.** The honest gap is **two-person
 review**. Evidentia is a single-maintainer project; GitHub structurally blocks
 self-approval, so the "two trusted persons" requirement cannot be satisfied no
 matter how the ruleset is configured. The PR-flow ruleset enforces the *process*
-(every change is a PR through the merge queue, with 19 required checks and an
+(every change is a PR through the merge queue, with 21 required checks and an
 empty bypass list), but the *human* two-party-review control at the heart of L4
 is absent. We surface this rather than papering over it with automated-gate
 substitutes.
@@ -240,11 +240,11 @@ special permissions needed for public ruleset metadata):
 # 1. Org default-branch baseline (signed commits + no force-push/delete, org-wide)
 gh api orgs/Polycentric-Labs/rulesets/16831409
 
-# 2. main PR-flow ruleset: PR required, 19 status checks, merge queue,
+# 2. main PR-flow ruleset: PR required, 21 status checks, merge queue,
 #    signed commits, linear history, EMPTY bypass_actors, can_bypass=never
 gh api repos/Polycentric-Labs/evidentia/rulesets/18097115
 
-#    Count the required status checks (expect 19):
+#    Count the required status checks (expect 21):
 gh api repos/Polycentric-Labs/evidentia/rulesets/18097115 \
   --jq '.rules[] | select(.type=="required_status_checks")
         | .parameters.required_status_checks | length'
@@ -264,7 +264,7 @@ git config --get gpg.format       # -> ssh
 
 Expected results (as of this writing): ruleset 16831409 has rules
 `deletion` + `non_fast_forward` + `required_signatures` with empty
-`bypass_actors`; ruleset 18097115 reports 19 required status checks, an empty
+`bypass_actors`; ruleset 18097115 reports 21 required status checks, an empty
 `bypass_actors`, and `current_user_can_bypass: "never"`; ruleset 18175057
 protects `refs/tags/v*` with `deletion` + `non_fast_forward` +
 `required_signatures`; and `main`'s HEAD verifies (`verified: true`,

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -423,10 +423,16 @@ suppress duplicates via `--no-security-headers`.
 
 ### v0.7.7 (shipped)
 
-- **CF3** — CodeQL custom sanitizer pack: contribute a `.qll`
-  declaring `validate_within` as a `BarrierGuard` to close the
-  3 path-injection false positives (#71/#72/#73) at the analysis
-  layer rather than dismissing each instance.
+- **CF3** — CodeQL path-injection barrier (superseded outcome).
+  The original `.qll` `BarrierGuard` sanitizer pack was built but
+  **never loaded** (the `packs:` config key takes only published
+  registry specs, and an external library pack cannot inject a
+  barrier into a stock query); it was removed in v0.10.17 and
+  replaced with a Models-as-Data `barrierModel` extension
+  (`.github/codeql/path-injection-barriers.model.yml`). NOTE: the
+  stock `py/path-injection` query does not yet consume MaD
+  `barrierModel`, so this FP class remains **dismissal-managed**
+  for now; the model is a forward-looking hook.
 - **CF4** (this doc) — public threat model elevation. ✅
 - **C1 partial** — character-set regex allowlist for `COLLECTOR_*`
   env vars (optional; depends on cycle headroom alongside the

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -21,10 +21,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  pypi:evidentia_core-0.10.16-py3-none-any.whl
+  pypi:evidentia_core-0.10.17-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.16-py3-none-any.whl
+#   OK: evidentia_core-0.10.17-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -36,10 +36,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  pypi:evidentia_core-0.10.16-py3-none-any.whl
+  pypi:evidentia_core-0.10.17-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.16-py3-none-any.whl
+#   OK: evidentia_core-0.10.17-py3-none-any.whl
 ```
 
 Per-release sweep across all 8 packages:
@@ -51,7 +51,7 @@ for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
            evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
   pypi-attestations verify pypi \
     --repository https://github.com/Polycentric-Labs/evidentia \
-    "pypi:${pkg}-0.10.16-py3-none-any.whl"
+    "pypi:${pkg}-0.10.17-py3-none-any.whl"
 done
 ```
 
@@ -62,7 +62,7 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
                  'evidentia_core','evidentia_eval','evidentia_integrations','evidentia_mcp') {
   pypi-attestations verify pypi `
     --repository https://github.com/Polycentric-Labs/evidentia `
-    "pypi:${pkg}-0.10.16-py3-none-any.whl"
+    "pypi:${pkg}-0.10.17-py3-none-any.whl"
 }
 ```
 
@@ -75,8 +75,8 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -89,8 +89,8 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -102,7 +102,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
 
 ```bash
 # Download the SBOM
-gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' \
+gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' \
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -115,7 +115,7 @@ osv-scanner scan --sbom evidentia-sbom.cdx.json
 
 ```powershell
 # Download the SBOM
-gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' `
+gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' `
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -132,8 +132,8 @@ attestation inline. To extract it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --type slsaprovenance1
 ```
@@ -141,8 +141,8 @@ cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com `
   --type slsaprovenance1
 ```

--- a/docs/wiki/1-getting-started/installation.md
+++ b/docs/wiki/1-getting-started/installation.md
@@ -28,7 +28,7 @@ Verify the install:
 
 ```bash
 evidentia version
-# → Evidentia v0.10.16
+# → Evidentia v0.10.17
 # → Python 3.12.x
 ```
 
@@ -83,9 +83,9 @@ Every release publishes a cosign-signed multi-arch image to GitHub Container
 Registry:
 
 ```bash
-docker pull ghcr.io/polycentric-labs/evidentia:v0.10.16
-docker run --rm ghcr.io/polycentric-labs/evidentia:v0.10.16 version
-# → Evidentia v0.10.16
+docker pull ghcr.io/polycentric-labs/evidentia:v0.10.17
+docker run --rm ghcr.io/polycentric-labs/evidentia:v0.10.17 version
+# → Evidentia v0.10.17
 # → Python 3.13.x
 ```
 
@@ -93,7 +93,7 @@ To run a gap analysis against a local inventory, mount your working directory:
 
 ```bash
 docker run --rm -v "$PWD:/work" -w /work \
-  ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+  ghcr.io/polycentric-labs/evidentia:v0.10.17 \
   gap analyze --inventory my-controls.yaml \
   --frameworks nist-800-53-rev5-moderate --output gap-report.json
 ```
@@ -102,7 +102,7 @@ On **Windows PowerShell**, use PowerShell's backtick line-continuation instead o
 
 ```powershell
 docker run --rm -v "${PWD}:/work" -w /work `
-  ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+  ghcr.io/polycentric-labs/evidentia:v0.10.17 `
   gap analyze --inventory my-controls.yaml `
   --frameworks nist-800-53-rev5-moderate --output gap-report.json
 ```
@@ -112,7 +112,7 @@ The image is keyless-signed via Fulcio + Rekor. Verify it before you trust it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"
@@ -121,7 +121,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"

--- a/docs/wiki/1-getting-started/quickstart.md
+++ b/docs/wiki/1-getting-started/quickstart.md
@@ -17,7 +17,7 @@ Verify:
 
 ```bash
 evidentia version
-# → Evidentia v0.10.16 / Python 3.12.x
+# → Evidentia v0.10.17 / Python 3.12.x
 ```
 
 ## Step 2 — Pick a framework (10 seconds)
@@ -122,8 +122,8 @@ The wheel you installed has a PEP 740 attestation:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.16-py3-none-any.whl"
-# → OK: evidentia-0.10.16-py3-none-any.whl
+  "pypi:evidentia-0.10.17-py3-none-any.whl"
+# → OK: evidentia-0.10.17-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -132,8 +132,8 @@ pypi-attestations verify pypi \
 pip install pypi-attestations
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  "pypi:evidentia-0.10.16-py3-none-any.whl"
-# → OK: evidentia-0.10.16-py3-none-any.whl
+  "pypi:evidentia-0.10.17-py3-none-any.whl"
+# → OK: evidentia-0.10.17-py3-none-any.whl
 ```
 
 The container image is cosign-signed (if you used the Docker install path):
@@ -141,7 +141,7 @@ The container image is cosign-signed (if you used the Docker install path):
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"
@@ -150,7 +150,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"

--- a/docs/wiki/2-guides/air-gapped-install.md
+++ b/docs/wiki/2-guides/air-gapped-install.md
@@ -38,8 +38,8 @@ Pull the cosign-signed image on the connected host, save it to a tarball, and
 carry the tarball across the air gap:
 
 ```bash
-docker pull ghcr.io/polycentric-labs/evidentia:v0.10.16
-docker save ghcr.io/polycentric-labs/evidentia:v0.10.16 -o evidentia.tar
+docker pull ghcr.io/polycentric-labs/evidentia:v0.10.17
+docker save ghcr.io/polycentric-labs/evidentia:v0.10.17 -o evidentia.tar
 ```
 
 On the air-gapped host: `docker load -i evidentia.tar`.
@@ -56,7 +56,7 @@ index disabled so pip never reaches for the network:
 python -m venv .venv && source .venv/bin/activate
 pip install --no-index --find-links ./evidentia-wheelhouse evidentia
 evidentia version
-# → Evidentia v0.10.16 / Python 3.12.x
+# → Evidentia v0.10.17 / Python 3.12.x
 ```
 
 **PowerShell (Windows)**
@@ -65,7 +65,7 @@ evidentia version
 python -m venv .venv ; .\.venv\Scripts\Activate.ps1
 pip install --no-index --find-links ./evidentia-wheelhouse evidentia
 evidentia version
-# → Evidentia v0.10.16 / Python 3.12.x
+# → Evidentia v0.10.17 / Python 3.12.x
 ```
 
 ## Step 3 — Validate the air-gap posture

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.17] - 2026-07-09
+
+**Theme**: *v0.10.x hardening close-out.* The final v0.10.x release, completing the Horizon-A elite-engineering-practice arc. Lands a publish-safe release-pipeline **preflight dry-run** — a `workflow_dispatch` that runs the full build/validate path (gate + wheels + per-package SBOMs + reproducible double-build + container-from-local-wheels + smoke tests) but is *structurally unable to publish* (the publish jobs require `github.event_name == 'push'`) — backed by `v*`-tag-only PyPI/GHCR deployment environments with required-reviewer approval, so a real release now pauses for an explicit deployment sign-off. Also: **two real audit-logger security fixes** surfaced by an adversarial review of the CodeQL 2.26.0 findings (CWE-117 log CR/LF injection + CWE-312 cleartext credential in an exception field); the dead CodeQL `.qll` path-injection sanitizer pack replaced with a Models-as-Data `barrierModel` extension (honestly dismissal-managed until the stock query consumes it); the Tier-1 demo image reworked to a **shell-free distroless multi-stage build**; CodSpeed perf reporting activated; CI job timeout caps; and a refreshed distroless base digest. No package API changes.
+
 ### Added
 
 - **Release-pipeline preflight dry-run** — `release.yml` now accepts a manual

--- a/docs/wiki/6-project/roadmap.md
+++ b/docs/wiki/6-project/roadmap.md
@@ -3,7 +3,7 @@
 
 # Evidentia roadmap
 
-**Last updated: v0.10.16 (planning, July 2026).**
+**Last updated: v0.10.17 (planning, July 2026).**
 
 > **Engineering practices** — how Evidentia is built, tested, and shipped (the
 > PR-flow + merge-queue gate, atomic releases, supply-chain integrity, and the
@@ -11,10 +11,15 @@
 
 This roadmap synthesizes community feedback with the architecture plan
 at the project root. Versions v0.3.0 through v0.7.16 + v0.8.0-v0.8.7
-+ v0.9.0-v0.9.9 + v0.10.0-v0.10.13 have shipped; v0.10.16 is the current
-release (cryptography-native DSSE air-gap signing + the distroless DHI
-container base hardening, following v0.10.12's CLI↔GUI parity build-out + the
-OMB M-25-21 AI-governance migration), before the v0.11 federal-compliance theme. **v0.9.0 opened the
++ v0.9.0-v0.9.9 + v0.10.0-v0.10.16 have shipped; v0.10.17 is the current
+release — the **v0.10.x hardening close-out**: a publish-safe release-pipeline
+preflight dry-run + `v*`-tag-only PyPI/GHCR deployment environments with
+required-reviewer approval, two real audit-logger security fixes (CWE-117 log
+injection + CWE-312 cleartext credential), the Tier-1 demo image reworked to a
+shell-free distroless build, and CodSpeed perf reporting — following v0.10.16's
+cryptography-native DSSE air-gap signing + distroless DHI container base and
+v0.10.12's CLI↔GUI parity build-out + OMB M-25-21 AI-governance migration,
+before the v0.11 federal-compliance theme. **v0.9.0 opened the
 v0.9.x "federal compliance" line** with POA&M + CONMON read-only
 library; v0.9.1 landed the Polycentric Labs org migration; v0.9.2
 added the CONMON REST router + federal corpus + LLM rater + federal

--- a/docs/wiki/6-project/security.md
+++ b/docs/wiki/6-project/security.md
@@ -73,7 +73,7 @@ a vulnerability in Evidentia's own code.
 
 | Version | Status | Reason |
 |---------|--------|--------|
-| **`0.10.16`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](https://github.com/Polycentric-Labs/evidentia/blob/main/CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
+| **`0.10.17`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](https://github.com/Polycentric-Labs/evidentia/blob/main/CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
 | Earlier patches | ❌ Deprecated | Pre-v1.0 single-supported-patch policy; upgrade to the latest patch. |
 | Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/archive/RENAMED.md). |
 
@@ -175,7 +175,7 @@ Verify a release wheel:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.16-py3-none-any.whl"
+  "pypi:evidentia-0.10.17-py3-none-any.whl"
 ```
 
 If verification fails, **stop and report immediately** via the

--- a/docs/wiki/6-project/verification.md
+++ b/docs/wiki/6-project/verification.md
@@ -24,10 +24,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  pypi:evidentia_core-0.10.16-py3-none-any.whl
+  pypi:evidentia_core-0.10.17-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.16-py3-none-any.whl
+#   OK: evidentia_core-0.10.17-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -39,10 +39,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  pypi:evidentia_core-0.10.16-py3-none-any.whl
+  pypi:evidentia_core-0.10.17-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.16-py3-none-any.whl
+#   OK: evidentia_core-0.10.17-py3-none-any.whl
 ```
 
 Per-release sweep across all 8 packages:
@@ -54,7 +54,7 @@ for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
            evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
   pypi-attestations verify pypi \
     --repository https://github.com/Polycentric-Labs/evidentia \
-    "pypi:${pkg}-0.10.16-py3-none-any.whl"
+    "pypi:${pkg}-0.10.17-py3-none-any.whl"
 done
 ```
 
@@ -65,7 +65,7 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
                  'evidentia_core','evidentia_eval','evidentia_integrations','evidentia_mcp') {
   pypi-attestations verify pypi `
     --repository https://github.com/Polycentric-Labs/evidentia `
-    "pypi:${pkg}-0.10.16-py3-none-any.whl"
+    "pypi:${pkg}-0.10.17-py3-none-any.whl"
 }
 ```
 
@@ -78,8 +78,8 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -92,8 +92,8 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 \
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -105,7 +105,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.16 `
 
 ```bash
 # Download the SBOM
-gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' \
+gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' \
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -118,7 +118,7 @@ osv-scanner scan --sbom evidentia-sbom.cdx.json
 
 ```powershell
 # Download the SBOM
-gh release download v0.10.16 --pattern 'evidentia-sbom.cdx.json' `
+gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' `
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -135,8 +135,8 @@ attestation inline. To extract it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" \
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --type slsaprovenance1
 ```
@@ -144,8 +144,8 @@ cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.16 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.16" `
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com `
   --type slsaprovenance1
 ```

--- a/marketplace/grc-engineering-suite/plugins/evidentia/.claude-plugin/plugin.json
+++ b/marketplace/grc-engineering-suite/plugins/evidentia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "evidentia",
   "description": "Evidentia GRC engine — OSCAL-first gap analysis, SARIF CI-gate output, OCSF ingestion. Open-source Apache-2.0 (Polycentric Labs). Wraps the evidentia-mcp server so AI clients drive the full product through one tool surface.",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "author": {
     "name": "Polycentric Labs",
     "url": "https://github.com/Polycentric-Labs"

--- a/packages/evidentia-ai/pyproject.toml
+++ b/packages/evidentia-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-ai"
-version = "0.10.16"
+version = "0.10.17"
 description = "LLM-powered risk statement generator and evidence validator for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
     # v0.10.5 P9: the DFAH eval harness was extracted to the
     # ``evidentia-eval`` workspace package so air-gap installs of
     # the production risk-statement runtime no longer pull the
@@ -26,7 +26,7 @@ dependencies = [
     # dependency here so the v0.10.5 deprecation shims (``from
     # evidentia_ai.eval import …``) continue to work through
     # v0.11.x; v0.12.0 removes both the shims and this pin.
-    "evidentia-eval>=0.10.16,<0.11.0",
+    "evidentia-eval>=0.10.17,<0.11.0",
     # v0.7.0 Step-3 review: pin LiteLLM above the compromised
     # 1.82.7 / 1.82.8 versions from the March 24, 2026 PyPI supply
     # chain incident (~40-min compromise window before quarantine).

--- a/packages/evidentia-api/pyproject.toml
+++ b/packages/evidentia-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-api"
-version = "0.10.16"
+version = "0.10.17"
 description = "FastAPI REST server + bundled React web UI for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -20,8 +20,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
-    "evidentia-ai>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-ai>=0.10.17,<0.11.0",
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.50.1",
     # v0.7.2 supply-chain follow-up: floor bumped from >=0.0.9 to

--- a/packages/evidentia-collectors/pyproject.toml
+++ b/packages/evidentia-collectors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-collectors"
-version = "0.10.16"
+version = "0.10.17"
 description = "Evidence collection agents for AWS, Databricks, GitHub, Okta, Snowflake, SQL databases, and vendor-risk APIs (Vanta, Drata, BitSight, SecurityScorecard)"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
     "httpx>=0.27",
 ]
 

--- a/packages/evidentia-core/pyproject.toml
+++ b/packages/evidentia-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-core"
-version = "0.10.16"
+version = "0.10.17"
 description = "Core data models, catalog loading, and gap analysis engine for Evidentia GRC tool"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]

--- a/packages/evidentia-eval/pyproject.toml
+++ b/packages/evidentia-eval/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-eval"
-version = "0.10.16"
+version = "0.10.17"
 description = "DFAH (Decision-Faithfulness Assessment Harness) determinism + faithfulness eval harness for Evidentia — dev-time AI-output quality gates"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/evidentia-integrations/pyproject.toml
+++ b/packages/evidentia-integrations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-integrations"
-version = "0.10.16"
+version = "0.10.17"
 description = "Output integrations for Jira and ServiceNow"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
     "httpx>=0.27",
 ]
 

--- a/packages/evidentia-mcp/pyproject.toml
+++ b/packages/evidentia-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-mcp"
-version = "0.10.16"
+version = "0.10.17"
 description = "Model Context Protocol (MCP) server for Evidentia — exposes gap analysis, risk generation, explanation, and OSCAL emit to MCP-aware AI clients (Claude Desktop, Claude Code, ChatGPT, etc.)"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,9 +18,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
-    "evidentia-ai>=0.10.16,<0.11.0",
-    "evidentia-collectors>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-ai>=0.10.17,<0.11.0",
+    "evidentia-collectors>=0.10.17,<0.11.0",
     # MCP Python SDK. Includes FastMCP server scaffolding +
     # protocol types. Floor pinned to 1.27 (the version Evidentia
     # was tested against during v0.8.0 P0.3 development);

--- a/packages/evidentia-ui/openapi.json
+++ b/packages/evidentia-ui/openapi.json
@@ -6071,7 +6071,7 @@
   "info": {
     "description": "REST API for the Evidentia GRC tool. All endpoints mirror CLI capabilities. Binds to 127.0.0.1 by default for localhost web-UI use.",
     "title": "Evidentia API",
-    "version": "0.10.16"
+    "version": "0.10.17"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/packages/evidentia-ui/package.json
+++ b/packages/evidentia-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evidentia/ui",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "Evidentia web UI — React + Vite + shadcn/ui frontend served by evidentia-api.",
   "private": true,
   "type": "module",

--- a/packages/evidentia/pyproject.toml
+++ b/packages/evidentia/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia"
-version = "0.10.16"
+version = "0.10.17"
 description = "Open-source GRC tool: gap analysis, risk statements, evidence collection, web UI, and compliance automation"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,16 +18,16 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.16,<0.11.0",
-    "evidentia-ai>=0.10.16,<0.11.0",
+    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-ai>=0.10.17,<0.11.0",
     # v0.10.5 P9: DFAH eval harness extracted from evidentia-ai.
     # ``evidentia eval`` CLI verbs live here, so the meta-package
     # depends on evidentia-eval directly (not via the evidentia-ai
     # transitive pin) so the verbs work even when the v0.12.0
     # shim removal eventually trims evidentia-ai's runtime dep.
-    "evidentia-eval>=0.10.16,<0.11.0",
-    "evidentia-collectors>=0.10.16,<0.11.0",
-    "evidentia-integrations>=0.10.16,<0.11.0",
+    "evidentia-eval>=0.10.17,<0.11.0",
+    "evidentia-collectors>=0.10.17,<0.11.0",
+    "evidentia-integrations>=0.10.17,<0.11.0",
     # click 8.2 removed CliRunner's mix_stderr (stderr is now always a separate
     # stream) and typer 0.26 vendors its own click. The test suite and the wiki
     # reference generator (scripts/wiki/sync_reference.py) were updated to match
@@ -43,7 +43,7 @@ dependencies = [
 # Web UI — installs the FastAPI server + bundled React SPA.
 # Usage: `pip install "evidentia[gui]"` or `uv tool install "evidentia[gui]"`,
 # then `evidentia serve` to open the local web UI.
-gui = ["evidentia-api>=0.10.16,<0.11.0"]
+gui = ["evidentia-api>=0.10.17,<0.11.0"]
 # v0.7.12 P0: cloud-backed WORM storage adapters. Each extra
 # pulls in the cloud SDK + maps to the matching evidentia-core
 # extra so the WORM impl module imports cleanly. Operators
@@ -57,7 +57,7 @@ worm-gcs = ["evidentia-core[worm-gcs]>=0.10.0,<0.11.0"]
 # Code, ChatGPT Desktop, custom clients) over stdio.
 # Usage: `pip install "evidentia[mcp]"`, then `evidentia mcp
 # serve`.
-mcp = ["evidentia-mcp>=0.10.16,<0.11.0"]
+mcp = ["evidentia-mcp>=0.10.17,<0.11.0"]
 
 [project.scripts]
 evidentia = "evidentia.cli.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-workspace"
-version = "0.10.16"
+version = "0.10.17"
 # Upper bound tracks the TRUE runnable ceiling of the workspace, which is set by the
 # tightest transitive Python cap: litellm (a hard dep of evidentia-ai, pinned
 # >=1.83.7,<2.0) declares requires_python "<3.14,>=3.10", so the stack cannot run on

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "evidentia"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia" }
 dependencies = [
     { name = "click" },
@@ -791,7 +791,7 @@ provides-extras = ["gui", "worm-s3", "worm-azure", "worm-gcs", "mcp"]
 
 [[package]]
 name = "evidentia-ai"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-ai" }
 dependencies = [
     { name = "evidentia-core" },
@@ -819,7 +819,7 @@ provides-extras = ["eval-faithfulness"]
 
 [[package]]
 name = "evidentia-api"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-api" }
 dependencies = [
     { name = "evidentia-ai" },
@@ -842,7 +842,7 @@ requires-dist = [
 
 [[package]]
 name = "evidentia-collectors"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-collectors" }
 dependencies = [
     { name = "evidentia-core" },
@@ -932,7 +932,7 @@ provides-extras = ["aws", "github", "okta", "sql-postgres", "sql-mysql", "sql-sq
 
 [[package]]
 name = "evidentia-core"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-core" }
 dependencies = [
     { name = "cryptography" },
@@ -990,7 +990,7 @@ provides-extras = ["sigstore", "xlsx", "worm-s3", "worm-azure", "worm-gcs", "ocs
 
 [[package]]
 name = "evidentia-eval"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-eval" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1012,7 +1012,7 @@ provides-extras = ["faithfulness-semantic"]
 
 [[package]]
 name = "evidentia-integrations"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-integrations" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1056,7 +1056,7 @@ provides-extras = ["jira", "servicenow", "tableau", "powerbi", "all"]
 
 [[package]]
 name = "evidentia-mcp"
-version = "0.10.16"
+version = "0.10.17"
 source = { editable = "packages/evidentia-mcp" }
 dependencies = [
     { name = "evidentia-ai" },
@@ -1075,7 +1075,7 @@ requires-dist = [
 
 [[package]]
 name = "evidentia-workspace"
-version = "0.10.16"
+version = "0.10.17"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
The v0.10.x **hardening close-out** release-prep. Bumps 0.10.16 → 0.10.17 and corrects three stale public-doc claims the CodeQL-saga sweep (#163/#164) didn't reach. The signed `v0.10.17` tag follows once this merges.

## Version + release finalization
- `bump_version.py --to 0.10.17` across all 8 package `pyproject.toml` + root + `package.json` + `openapi.json` + anchored version refs; `uv.lock` regenerated.
- CHANGELOG `[Unreleased]` → `[0.10.17] - 2026-07-09` (+ Theme summary + fresh `[Unreleased]`).
- ROADMAP intro + README Recent-Releases regenerated for v0.10.17.

## Doc-accuracy fixes (surfaced by the final pre-tag validation)
- **`docs/SECURE-BY-DESIGN-PLEDGE.md` Goal 3** claimed CodeQL runs a project-authored `.qll` sanitizer pack "closing CWE-22 false-positives at the analysis layer" and cited `.github/codeql/python-sanitizers/` — **which does not exist** (removed in #163). Rewritten to the truth: a Models-as-Data `barrierModel` extension, with the honest caveat that the stock `py/path-injection` query doesn't yet consume MaD barriers, so that FP class is currently dismissal-managed.
- `docs/threat-model.md` CF3 → same superseded outcome.
- `docs/slsa-source-track.md`: required-check count corrected **19 → 21** (8 sites incl. the verify command), matching ruleset 18097115.

## Validation
version-consistency PASS (0.10.17) · consistency 7/7 · docs-health 0-FAIL · ruff · mypy strict-optional 287 files · check_parity · mkdocs `--strict` · frontend typecheck + **no type drift** + vitest 142 + build. pytest **4791 passed**, 7 env-only failures (known SSRF-guard + `--all-extras` lazy-import artifacts — CI's proper env is authoritative).

Validated by the final exhaustive labcoat (5-dim hard-skeptic + Gemini cross-vendor + GitHub-docs primary-source): release-safety / supply-chain / security all GO; env gate config API-verified correct.