### PR TITLE
Docs(release): Refresh enterprise-grade + deprecation-calendar for v0.10.17

### DIFF
--- a/docs/deprecation-calendar.md
+++ b/docs/deprecation-calendar.md
@@ -23,7 +23,7 @@
 | `evidentia_core.models.finding.SecurityFinding` (library class name) | `evidentia_core.models.finding.Finding` (same class, new canonical name) | v0.10.1 (2026-05-23) | **v1.0.0** (earliest major bump) | The `SecurityFinding` name is kept as a backward-compatible alias for ≥ 1 minor cycle per the deprecation policy. Both names refer to the same class — no runtime difference, no behavior change, `isinstance(obj, SecurityFinding)` and `isinstance(obj, Finding)` both succeed. The rename aligns with OCSF's "Finding" terminology (Compliance Finding, Detection Finding). No `DeprecationWarning` is emitted in v0.10.1 to avoid spamming the ~50+ existing call sites — the alias is silent. Operators / integrators are encouraged to switch to `Finding` in new code; existing code keeps working unchanged. |
 | `evidentia ai-gov set-omb-impact` (CLI) + `OMBImpactRequest` / `POST …/omb-impact` (API) — OMB **M-24-10** impact leveling | `evidentia ai-gov set-high-impact` + `HighImpactRequest` — OMB **M-25-21** high-impact determination | v0.10.12 (2026-06-23) | **v1.0.0** | OMB M-24-10 was rescinded 2025-04-03 and superseded by M-25-21. The legacy M-24-10 surface is retained as a backward-compatible alias per the deprecation policy; new code should record the M-25-21 high-impact determination instead. |
 
-No other surfaces are currently deprecated as of v0.10.16.
+No other surfaces are currently deprecated as of v0.10.17.
 
 ---
 

--- a/docs/enterprise-grade.md
+++ b/docs/enterprise-grade.md
@@ -1,11 +1,11 @@
-# Enterprise-grade credibility checklist (v0.7.0 baseline · maintenance summary last refreshed v0.10.16, current release v0.10.16)
+# Enterprise-grade credibility checklist (v0.7.0 baseline · maintenance summary last refreshed v0.10.17, current release v0.10.17)
 
 Evidentia's v0.7.0 release established the quality bar that Big-4 audit
 firms (Deloitte, PwC, KPMG, EY), FedRAMP Third-Party Assessor
 Organizations (3PAOs), and senior GRC officers at regulated companies
 would consider production-grade for evidence collection. That baseline
 has stayed closed and been extended every cycle since; the
-**[Status through v0.10.16](#status-through-v01016-maintenance-summary)**
+**[Status through v0.10.17](#status-through-v01017-maintenance-summary)**
 summary below captures what has advanced, while the per-tier tables remain
 the original v0.7.0 baseline snapshot (later status changes noted there
 or in the summary).
@@ -29,7 +29,7 @@ Priority tiers:
 - **MEDIUM** — desirable, often documented as "on the roadmap"
 - **LOW** — nice-to-have
 
-## Status through v0.10.16 (maintenance summary)
+## Status through v0.10.17 (maintenance summary)
 
 The BLOCKER baseline has remained closed since v0.7.0. The enterprise
 posture has advanced materially across the v0.8.x–v0.10.x line:
@@ -63,13 +63,22 @@ posture has advanced materially across the v0.8.x–v0.10.x line:
   integrations, and the Tableau publish path.
 - **95 bundled framework catalogs** across four redistribution tiers
   (updates **L4**'s "82 frameworks" count).
-- **Release + CI hardening (v0.10.13–v0.10.16)** — a distroless
+- **Release + CI hardening (v0.10.13–v0.10.17)** — a distroless
   **Docker Hardened Images** runtime base (v0.10.16), **air-gapped DSSE /
   in-toto signing** (cryptography-native Ed25519 / RSA-PSS, v0.10.16),
-  **PEP 770 per-wheel SBOMs**, a merge-queue PR flow with 19+ required
+  **PEP 770 per-wheel SBOMs**, a merge-queue PR flow with 21 required
   checks, and self-guarding CI sentinels (post-publish rescan, base-image
   freshness, workflow-liveness, dependency-ceiling watch) further harden
   the build + release path beyond the six shipped release credentials.
+  **v0.10.17** closes the line with a publish-safe release **preflight
+  dry-run** (a `workflow_dispatch` that runs the full build/validate path
+  yet is structurally unable to publish), **`v*`-tag-only PyPI/GHCR
+  deployment environments with required-reviewer approval** (a
+  platform-enforced two-step deploy gate exercised on every release), a
+  **shell-free distroless demo image**, and a **CodSpeed** perf-regression
+  gate; two real audit-logger defects (CWE-117 log injection, CWE-312
+  cleartext credential) were also fixed, advancing **SI-2** flaw
+  remediation.
 
 The v0.7.0 BLOCKER-complete, enterprise-ready classification holds; the
 v0.8.x–v0.10.x line extends it across breadth (collectors, consoles,

--- a/docs/wiki/6-project/deprecation-policy.md
+++ b/docs/wiki/6-project/deprecation-policy.md
@@ -26,7 +26,7 @@
 | `evidentia_core.models.finding.SecurityFinding` (library class name) | `evidentia_core.models.finding.Finding` (same class, new canonical name) | v0.10.1 (2026-05-23) | **v1.0.0** (earliest major bump) | The `SecurityFinding` name is kept as a backward-compatible alias for ≥ 1 minor cycle per the deprecation policy. Both names refer to the same class — no runtime difference, no behavior change, `isinstance(obj, SecurityFinding)` and `isinstance(obj, Finding)` both succeed. The rename aligns with OCSF's "Finding" terminology (Compliance Finding, Detection Finding). No `DeprecationWarning` is emitted in v0.10.1 to avoid spamming the ~50+ existing call sites — the alias is silent. Operators / integrators are encouraged to switch to `Finding` in new code; existing code keeps working unchanged. |
 | `evidentia ai-gov set-omb-impact` (CLI) + `OMBImpactRequest` / `POST …/omb-impact` (API) — OMB **M-24-10** impact leveling | `evidentia ai-gov set-high-impact` + `HighImpactRequest` — OMB **M-25-21** high-impact determination | v0.10.12 (2026-06-23) | **v1.0.0** | OMB M-24-10 was rescinded 2025-04-03 and superseded by M-25-21. The legacy M-24-10 surface is retained as a backward-compatible alias per the deprecation policy; new code should record the M-25-21 high-impact determination instead. |
 
-No other surfaces are currently deprecated as of v0.10.16.
+No other surfaces are currently deprecated as of v0.10.17.
 
 ---
 


### PR DESCRIPTION
Post-release **Step-4 doc-refresh** — the two docs carrying a point-in-time "current release" marker that lagged one release behind the shipped `v0.10.17` tag (caught by a post-release doc-staleness audit; `enterprise-grade.md` was flagged by the final labcoat's claim-accuracy dimension).

- **`docs/enterprise-grade.md`** — header + TOC anchor + the "Status through" section advanced v0.10.16 → **v0.10.17**; the Release + CI hardening bullet extended with the v0.10.17 work (preflight dry-run, `v*`-tag-only PyPI/GHCR deployment environments with required-reviewer approval, shell-free distroless demo image, CodSpeed perf gate; the two audit-logger CWE fixes noted under SI-2). Also corrected the merge-queue required-check count **19+ → 21** (matching ruleset 18097115 — same correction as `slsa-source-track.md` in #173).
- **`docs/deprecation-calendar.md`** — "as of v0.10.16" → v0.10.17 currency line.

Docs-only; the shipped v0.10.17 wheels/container/Release are unchanged (these are docs-site pages, not in the wheels). Gates: consistency 7/7 (wiki mirror regenerated) · docs-health 0-FAIL · mkdocs `--strict` (the updated TOC anchor resolves).