### PR TITLE
Feat(gates): Open the v0.11 cycle — doc-currency gate + ROADMAP restructure + ratified plan

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -49,6 +49,10 @@
 #  15. check_ruff                 (`ruff check . --no-cache` — fast lint
 #                                  shifted left from CI so a cached-pass lint
 #                                  break is caught pre-push, not in the queue)
+#  16. check_roadmap_currency     (v0.11 cycle-open, lesson 11: ROADMAP status
+#                                  headings must agree with the CHANGELOG's
+#                                  shipped blocks; exactly one open cycle,
+#                                  which must link an on-disk plan doc)
 #
 # All checks run before the hook exits, so the operator sees every
 # failure at once.
@@ -367,6 +371,13 @@ run_check "check_doc_counts" \
 #     causing avoidable merge-queue churn. ruff is fast (~1-2s), so it fits the
 #     "fast checks pre-push, heavyweight (pytest/mypy) in CI" gate design.
 run_check "check_ruff" run_ruff check . --no-cache || true
+
+# 16. ROADMAP currency (v0.11 cycle-open; lesson 11): the ROADMAP's status
+#     headings must agree with the CHANGELOG's shipped blocks (nothing PLANNED/
+#     RESERVED that has shipped), exactly one cycle may be open, and the open
+#     cycle must link an on-disk plan doc. Pure-filesystem; always runs.
+run_check "check_roadmap_currency" \
+    run_py "${REPO_ROOT}/scripts/check_roadmap_currency.py" || true
 
 # ---------------------------------------------------------------------------
 # Verdict.

--- a/.github/workflows/safeguards-resweep.yml
+++ b/.github/workflows/safeguards-resweep.yml
@@ -52,5 +52,5 @@ jobs:
             exit 0
           fi
           gh issue create --repo "$REPO" --title "$title" --body \
-          "Quarterly reminder to re-run the automated-vs-manual safeguards audit (see \`docs/releases/plans/v0.10.8-plan.md\` Phase G). Re-confirm the tag-time release gate, the CLI<->GUI parity debt-ratchet, and the scheduled safeguards (Scorecard / CodeQL / OSPS-conformance / mutmut) are all still enforced, catch any NEW gap that opened since the last sweep, and adopt any Phase-G backlog item that is now ready. Close this issue once the sweep is complete."
+          "Quarterly reminder to re-run the automated-vs-manual safeguards audit (see \`docs/releases/plans/v0.10.8-plan.md\` Phase G). Re-confirm the tag-time release gate, the CLI<->GUI parity debt-ratchet, and the scheduled safeguards (Scorecard / CodeQL / OSPS-conformance / mutmut) are all still enforced, catch any NEW gap that opened since the last sweep, and adopt any Phase-G backlog item that is now ready. Also run the quarterly practice-delta pass (\`docs/engineering-practices.md\` §Research rigor): re-derive ADOPT / RETIRE against the current ecosystem with primary-source verification of every candidate, and fold adopted practice into \`docs/engineering-practices.md\`. Close this issue once the sweep is complete."
           echo "Opened tracking issue: ${title}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ROADMAP-currency gate** (`scripts/check_roadmap_currency.py`) — the
+  roadmap's status headings must agree with the CHANGELOG's shipped
+  `## [X.Y.Z]` blocks: nothing PLANNED/RESERVED that has shipped, no SHIPPED
+  entries inside a PLANNED cycle umbrella, exactly one open cycle, and the
+  open cycle must link an on-disk plan doc (plus an advisory that every
+  release in the latest cycle has its entry). CHANGELOG blocks are the
+  source of truth — deliberately not git tags, which the shallow CI checkout
+  cannot see and which unpublished ghost tags would poison. Runs in the
+  required `consistency` scope and the pre-push hook, and was observed
+  firing on the real v0.10.x roadmap drift (four shipped releases
+  mis-marked PLANNED) before the tree was fixed. Two prose currency anchors
+  registered alongside it (the deprecation-calendar closing line and the
+  enterprise-grade maintenance-summary claim), so those live lines now
+  force-update on every version bump and hard-fail when stale. Recorded as
+  lesson 11 in `docs/engineering-practices.md`: *a doc's currency claim is
+  a gate or it is a lie.*
+
+### Changed
+
+- **ROADMAP restructured at the v0.11 cycle open** — the v0.10.x line is
+  closed SHIPPED (16 published releases), the four mis-marked entries
+  (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12) are corrected to SHIPPED, the
+  four missing entries (v0.10.10 / v0.10.13 / v0.10.16 / v0.10.17) are
+  backfilled, and v0.11 is promoted to the open cycle linking its plan doc
+  (`docs/releases/plans/v0.11-plan.md`, pending ratification).
+  `docs/enterprise-grade.md`'s header is restructured so its live currency
+  claim sits on a single anchorable line. The quarterly safeguards-resweep
+  issue template gains a practice-delta item (method recorded in
+  `docs/engineering-practices.md` §Research rigor).
+
 ## [0.10.17] - 2026-07-09
 
 **Theme**: *v0.10.x hardening close-out.* The final v0.10.x release, completing the Horizon-A elite-engineering-practice arc. Lands a publish-safe release-pipeline **preflight dry-run** — a `workflow_dispatch` that runs the full build/validate path (gate + wheels + per-package SBOMs + reproducible double-build + container-from-local-wheels + smoke tests) but is *structurally unable to publish* (the publish jobs require `github.event_name == 'push'`) — backed by `v*`-tag-only PyPI/GHCR deployment environments with required-reviewer approval, so a real release now pauses for an explicit deployment sign-off. Also: **two real audit-logger security fixes** surfaced by an adversarial review of the CodeQL 2.26.0 findings (CWE-117 log CR/LF injection + CWE-312 cleartext credential in an exception field); the dead CodeQL `.qll` path-injection sanitizer pack replaced with a Models-as-Data `barrierModel` extension (honestly dismissal-managed until the stock query consumes it); the Tier-1 demo image reworked to a **shell-free distroless multi-stage build**; CodSpeed perf reporting activated; CI job timeout caps; and a refreshed distroless base digest. No package API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12) are corrected to SHIPPED, the
   four missing entries (v0.10.10 / v0.10.13 / v0.10.16 / v0.10.17) are
   backfilled, and v0.11 is promoted to the open cycle linking its plan doc
-  (`docs/releases/plans/v0.11-plan.md`, pending ratification).
+  (`docs/releases/plans/v0.11-plan.md`, ratified 2026-07-09).
   `docs/enterprise-grade.md`'s header is restructured so its live currency
   claim sits on a single anchorable line. The quarterly safeguards-resweep
   issue template gains a practice-delta item (method recorded in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1589,12 +1589,16 @@ the operator self-test + demo/pitch phase.
 **3250 tests / 14 skipped / mypy strict 261 of 261 source files /
 ruff clean.**
 
-## v0.10.x — Research-driven integration & AI-governance line — PLANNED
+## v0.10.x — Research-driven integration & AI-governance line — SHIPPED
 
 Opened 2026-05-21 following a competitive/integration research pass
 (see [`docs/integration-survey.md`](integration-survey.md) and
 [`docs/positioning-and-value.md`](positioning-and-value.md) §5.5 /
-§5.6.A). The v0.10.x line is the home for the research-driven feature
+§5.6.A). **Closed 2026-07-09 with v0.10.17** — 16 published releases
+(v0.10.0 – v0.10.13 + v0.10.16 + v0.10.17; the v0.10.14 / v0.10.15
+tags were never published: the atomic-release gate stopped both runs
+with nothing shipped — see the v0.10.16 entry below). The v0.10.x
+line is the home for the research-driven feature
 surface: because it brings meaningful new feature surface, it is a
 minor bump from v0.9.9 rather than a continuation of v0.9.x patches.
 
@@ -1636,7 +1640,7 @@ referenced in the v0.9.9 entry above; it runs before the v1.0
 domain-expert walk-through, and any gaps it surfaces feed back into the
 backlog.
 
-### v0.10.5 — OSS first-mover artifacts — PLANNED (added 2026-05-24)
+### v0.10.5 — OSS first-mover artifacts — SHIPPED (released 2026-05-26)
 
 Sourced from the Phase B audit re-run + 6-stream Evidentia-integration
 research synthesis (`~/.claude/skills/pre-release-review/_audits/evidentia-integration-plan-2026-05-24.md`).
@@ -1893,7 +1897,7 @@ its size limit), and research-resync cadence.
 - Pre-push gate L1 / L3 — defer-or-skip; revisit if a new pattern
   justifies them.
 
-### v0.10.9 — Debt + robustness patch — PLANNED
+### v0.10.9 — Debt + robustness patch — SHIPPED (released 2026-06-10)
 
 Theme: close the v0.10.8 ship findings and skill-iteration debt, and
 harden the release machinery that cycle built. Full plan:
@@ -1934,7 +1938,23 @@ harden the release machinery that cycle built. Full plan:
   last full pass at v0.9.5) runs alongside the cycle; outputs land in
   `docs/positioning-and-value.md`.
 
-### v0.10.11 — Public demo completion + traceability + hygiene — PLANNED
+### v0.10.10 — Supply-chain hardening + the public demo suite + FDA 524B pack — SHIPPED (released 2026-06-15)
+
+Patch (v0.10.9 → v0.10.10). Container base Python 3.14 → 3.13 (removes
+three container CVEs at the root, incl. a litellm HIGH); the collectors
+SSRF guard lifted into a shared, default-on
+`evidentia_core.network_guard.enforce_public_host` across all 13
+outbound collectors, made DNS-rebind-resistant by pinning the validated
+resolution through the actual connection; `tuf` 6 → 7; a container
+osv-gate in `release.yml` + `container-build.yml`; the **FDA Section
+524B medical-device pack** (the `fda-524b-appendix1` Tier-A catalog,
+ISO 14971 / AAMI SW96 license-respecting stubs, two illustrative
+crosswalks, a demo-gated `#/demo/fda` console route, and the wiki
+guide); and the in-repo artifacts for the three-tier **public demo
+suite** (static demo-mode console build, asciinema cast, constrained
+Tier-1 runner + demo-profile Dockerfile).
+
+### v0.10.11 — Public demo completion + traceability + hygiene — SHIPPED (released 2026-06-17)
 
 Patch (0.10.10 → 0.10.11). Per-cycle detail: [`v0.10.11-plan.md`](releases/plans/v0.10.11-plan.md). Three tracks:
 
@@ -1942,16 +1962,70 @@ Patch (0.10.10 → 0.10.11). Per-cycle detail: [`v0.10.11-plan.md`](releases/pla
 - **Control↔Threat Traceability Matrix** — promote the threat→control→evidence view from a rendered demo into a first-class GUI + CLI capability that emits a **Sigstore-signable OSCAL** matrix (builds on `models/threat.py`; the OSCAL slice here sets up the v0.11 TM-BOM). Generalist OSS.
 - **Hygiene** — collector guard-before-driver-import + mock-driver SSRF test (the proper fix behind the v0.10.10 CI extras hotfix); the `MetricCard` `<p>`→`<div>` DOM-nesting fix (carried in the shipped `#/demo/fda`); the `oscal sign`→`gap analyze --sign-with-*` correction in `threat-model.md` + `troubleshooting.md`; `GapExportControl` jsdom `Blob.stream` cleanup; a CI `--no-extras` pytest fidelity smoke (the gate the v0.10.10 push exposed).
 
-### v0.10.12 — Full CLI↔GUI parity build-out — PLANNED (dedicated session)
+### v0.10.12 — Full CLI↔GUI parity build-out — SHIPPED (released 2026-06-23)
 
 A single, heavily-planned, subagent-driven, multi-step-verified push to bring the web console to (near-)full CLI parity in one sitting (the v0.10.7 GUI-rebuild / wiki-population playbook). **Planning deliverable: a comprehensive surface × tier matrix** — for every capability, decide its presence and scope on each surface (**CLI** / self-hosted **GUI** / hosted **web app**), and adopt a standing rule that every *new* feature gets an explicit surface decision. (The detailed breakdown is a private planning artifact, not this public roadmap.) The planning pass reconciles the prior surface/tier research via project-file synthesis + dedicated `polycentric-labcoat` research fleets. (Keeps v0.11 reserved for the federal theme below.) The cycle **closes with a docs/ curation + CHANGELOG trim** once the console is at parity — archive the accumulated per-cycle plan + security-review docs and tighten the CHANGELOG (housekeeping, run last).
 
 Also folded in (additive, backward-compatible): the AI-governance module **migrates from the rescinded OMB M-24-10 to the M-25-21 "high-impact AI" model**. M-24-10 (2024-03-28) was rescinded 2025-04-03 by M-25-21, which collapses the old rights-impacting / safety-impacting split into one **high-impact AI** category across six bases (civil rights/liberties/privacy, access to essential services, critical government resources, health & safety, critical infrastructure, strategic assets). New `evidentia_core.ai_governance.omb_m_25_21` module (`HighImpactDetermination` + `HighImpactBasis` enums + `OMBHighImpactAssessment` model + `triggers_minimum_practices()` + `crosswalk_from_legacy()`), `evidentia ai-gov set-high-impact` CLI verb, `POST /api/ai-gov/systems/{system_id}/set-high-impact` REST route, `AI_SYSTEM_HIGH_IMPACT_CLASSIFIED` audit event, and an additive `omb_high_impact` registry field. The legacy M-24-10 module + `OMBImpactCategory` + `set-omb-impact` CLI/REST verb + `omb_impact` field remain DEPRECATED-but-functional (no behaviour change). The seven M-25-21 minimum risk-management practices are DOCUMENTED this cycle; structured per-practice tracking is deferred to v0.11 (see below).
 
-### v0.11 — Federal-compliance theme + AI governance — PLANNED (post-deep-dive)
+### v0.10.13 — Container-base restore patch — SHIPPED (released 2026-06-23)
 
-Sourced from Phase B audit v3 + integration plan §"Per-release
-detailed integration plan" §v0.11. Substantive minor (~6-8 weeks):
+Patch on v0.10.12, same day. v0.10.12 published to PyPI cleanly but its
+container build failed afterward: a Dependabot bump to
+`python:3.14-slim` meant the resolver could only reach a CVE-carrying
+litellm, so the CVE-clean pin was uninstallable. Reverts the base to the
+digest-pinned `python:3.13-slim` and un-breaks the container smoke test
+that should have caught it (it had silently exited at version-extraction
+since v0.10.11 — the chronically-red-gate failure class; it now reads
+the version from PyPI, self-correcting). The Python packages are
+identical to v0.10.12. This packages-only half-release is the direct
+spur for the v0.10.16 atomic-release reorder.
+
+### v0.10.16 — Engineering hardening + distroless container base — SHIPPED (released 2026-07-02)
+
+*Never ship a failed test again.* Cryptography-native **DSSE/in-toto
+air-gap signing** (`--sign-with-key`, Ed25519 / RSA-PSS, fail-closed
+pinned-key verify — works inside distroless containers with no `gpg`
+binary); the **atomic validate-before-publish release pipeline** (every
+artifact builds and validates before anything publishes); the published
+container migrated to a distroless **Docker Hardened Images** base
+(`dhi.io/python:3.13`, nonroot uid 65532, no shell / `curl` / `gpg`)
+with a scheduled base-freshness sentinel; **PR-flow + merge queue** on
+`main` with an empty bypass list; the fixable-only post-publish
+container-rescan gate; and the public
+[`docs/engineering-practices.md`](engineering-practices.md) + security
+posture docs (SECURE-BY-DESIGN-PLEDGE, slsa-source-track, GHSA/rollback
+runbooks, `security-insights.yml`). **The v0.10.14 and v0.10.15 tags
+were never published**: the atomic gate stopped both runs with nothing
+shipped (a `pip-compile` hash-reuse, then a missing tool in the publish
+job's first-ever live execution) — v0.10.16 is the same release content
+plus both pipeline fixes, so those two versions have no CHANGELOG block
+by design.
+
+### v0.10.17 — v0.10.x hardening close-out — SHIPPED (released 2026-07-09)
+
+The final v0.10.x release. A publish-safe **release preflight dry-run**
+(`workflow_dispatch` runs the full build/validate path but is
+structurally unable to publish) backed by `v*`-tag-only PyPI/GHCR
+deployment environments with **required-reviewer approval** — the gate
+paused for sign-off twice on its first live release, as designed; **two
+real audit-logger security fixes** (CWE-117 log CR/LF injection +
+CWE-312 cleartext credential in an exception field) surfaced by an
+adversarial review of the CodeQL 2.26.0 findings; the Tier-1 demo image
+reworked to a shell-free distroless multi-stage build; CodSpeed
+performance reporting activated (its prior "green" job had never
+uploaded — a lesson-9 catch); CI job timeout caps; and three
+doc-accuracy fixes.
+
+## v0.11 — Federal-compliance theme + AI governance — PLANNED
+
+**The open cycle** (opened 2026-07-09). Full plan:
+[`v0.11-plan.md`](releases/plans/v0.11-plan.md) — wave sequencing, the
+cycle-hygiene track (the 2026-07 practice-delta adoptions + the
+v0.10.17 deferred queue), the medical-device row split, and the
+ratification asks. Sourced from Phase B audit v3 + integration plan
+§"Per-release detailed integration plan" §v0.11. Substantive minor
+(~6-8 weeks):
 
 - **KSI (Key Security Indicators) emission** per FedRAMP's
   machine-readable schemas (FRMR JSON; the `FedRAMP/schemas`

--- a/docs/engineering-practices.md
+++ b/docs/engineering-practices.md
@@ -295,6 +295,16 @@ they drive a change. The atomic-release design in this document, for example,
 was pressure-tested by the multi-model review described above, which caught two
 real defects before any of it reached the release pipeline.
 
+**Quarterly practice delta.** The engineering-practice baseline itself is
+re-validated on a quarterly cadence, carried as an item on the scheduled
+safeguards-resweep tracking issue: independent models propose adopt/retire
+candidates against the current ecosystem, every candidate is verified against
+a primary source before it is actioned, and refuted or unverifiable claims
+are recorded rather than actioned (the model fleet generates ideas; only
+primary sources produce facts — the 2026-07 pass quarantined several
+fabricated tool and PEP names on exactly this rule). Adopted practice extends
+this document; it never starts a parallel one.
+
 ---
 
 ## Documentation discipline
@@ -499,6 +509,34 @@ sufficient when other transitive gates remain. The same audit applies to every
 ignore/ceiling rule in the dependency-update config: state the exact class it
 is meant to catch, and verify that class against the tool's actual
 classification of the change, not an assumption about what "major" means.
+
+**11. Shipped releases sat marked "planned" in the public roadmap.** A
+release cycle closed and its retrospective found the roadmap disagreeing with
+reality in every direction at once: four shipped releases still carried a
+PLANNED heading, the shipped cycle's umbrella heading itself said PLANNED
+while holding SHIPPED entries beneath it, four shipped patches had no entry
+at all, and two other documents' "current as of release X" prose lines had
+quietly drifted stale — none of it caught by machinery, all of it
+hand-discovered after the fact. *Root cause:* a document's **currency
+claims** — a status word on a heading, a "current release" line — carried no
+enforcement; for the prose half, the enforcement mechanism (the
+version-anchor overlay) already existed and had simply never been pointed at
+those lines. *The lesson, stated as a rule:* **a doc's currency claim is a
+gate or it is a lie** — prose that asserts "this reflects release X" or "this
+is planned" rots silently unless some check fails the moment it stops being
+true. *Prevention:* the live prose markers are registered as version anchors
+(force-updated on every bump, hard-failed on drift), and a roadmap-currency
+gate (`scripts/check_roadmap_currency.py`, in the required consistency scope
+and the pre-push hook) cross-checks every roadmap status heading against the
+CHANGELOG's shipped blocks — the source of truth a shallow CI checkout can
+actually see (deliberately not git tags: the CI checkout fetches none, and
+unpublished ghost tags must not demand entries) — requires exactly one open
+cycle, and requires that cycle to link its on-disk plan doc. Per lesson 9's
+rule the gate was run against the still-broken tree first and observed
+firing on the real defects — an observation that immediately tightened the
+gate itself (its plan-doc assertion had to be scoped to the cycle's intro,
+or old per-patch plan links inside the section would satisfy it) — before
+the tree was fixed.
 
 ---
 

--- a/docs/enterprise-grade.md
+++ b/docs/enterprise-grade.md
@@ -1,12 +1,15 @@
-# Enterprise-grade credibility checklist (v0.7.0 baseline · maintenance summary last refreshed v0.10.17, current release v0.10.17)
+# Enterprise-grade credibility checklist
+
+> Baseline established at v0.7.0 (historical).
+> Maintenance summary current as of release v0.10.17.
 
 Evidentia's v0.7.0 release established the quality bar that Big-4 audit
 firms (Deloitte, PwC, KPMG, EY), FedRAMP Third-Party Assessor
 Organizations (3PAOs), and senior GRC officers at regulated companies
 would consider production-grade for evidence collection. That baseline
 has stayed closed and been extended every cycle since; the
-**[Status through v0.10.17](#status-through-v01017-maintenance-summary)**
-summary below captures what has advanced, while the per-tier tables remain
+**[Maintenance summary](#maintenance-summary)**
+below captures what has advanced, while the per-tier tables remain
 the original v0.7.0 baseline snapshot (later status changes noted there
 or in the summary).
 
@@ -29,7 +32,7 @@ Priority tiers:
 - **MEDIUM** — desirable, often documented as "on the roadmap"
 - **LOW** — nice-to-have
 
-## Status through v0.10.17 (maintenance summary)
+## Maintenance summary
 
 The BLOCKER baseline has remained closed since v0.7.0. The enterprise
 posture has advanced materially across the v0.8.x–v0.10.x line:

--- a/docs/releases/plans/v0.11-plan.md
+++ b/docs/releases/plans/v0.11-plan.md
@@ -1,6 +1,9 @@
 # v0.11 plan — Federal-compliance theme + AI governance
 
-**Status: DRAFT — pending ratification (cycle opened 2026-07-09).**
+**Status: RATIFIED 2026-07-09** (cycle opened 2026-07-09; waves and the
+medical-device split as proposed; v0.11.0 = Wave 0 + H + Waves 1–2; H7
+remains a separately-approved Tier-4 settings action; the A4 advisory on
+v0.10.0–v0.10.4 is accepted, backfill optional).
 
 Scope source: [`docs/ROADMAP.md`](../../ROADMAP.md) §v0.11 (the feature list
 locked at the v0.10.x close) plus the v0.11 rows of the medical-device GRC

--- a/docs/releases/plans/v0.11-plan.md
+++ b/docs/releases/plans/v0.11-plan.md
@@ -1,0 +1,209 @@
+# v0.11 plan — Federal-compliance theme + AI governance
+
+**Status: DRAFT — pending ratification (cycle opened 2026-07-09).**
+
+Scope source: [`docs/ROADMAP.md`](../../ROADMAP.md) §v0.11 (the feature list
+locked at the v0.10.x close) plus the v0.11 rows of the medical-device GRC
+feature line, the v0.10.17 deferred queue (folded in as cycle hygiene), and
+the 2026-07 quarterly practice-delta pass (primary-source verified). The
+ROADMAP entry states the cycle must open no later than ~2026-08-15; it opens
+2026-07-09.
+
+A substantive minor (~6–8 weeks): v0.11.0 is the first release of the cycle,
+followed by v0.11.x patches. Precise per-release boundaries are set per
+release plan, per house convention; this document decides the **order**.
+
+---
+
+## Sequencing constraints (why the waves are ordered this way)
+
+1. **The OSCAL 1.2.1 → 1.2.2 evaluation gates every OSCAL emitter.** OSCAL
+   1.2.2 released 2026-04-30; whether the cycle's OSCAL output (AR, POA&M,
+   traceability profile, catalogs) moves to 1.2.2 or stays on 1.2.1 must be
+   decided **before** new OSCAL-emitting features are built, or they get
+   built twice. The evaluation is an assessment with a written verdict, not
+   a committed adoption.
+2. **VEX + Rekor and SLSA VSA ride the same attestation surface** — one
+   signing/attestation wave, not two.
+3. **SP 800-218A pairs with the `docs/ai-coding-policy.md` template** — the
+   catalog and the template ship together (the dogfood narrative depends on
+   both).
+4. **Two standing commitments are carried INTO this cycle and cannot be
+   dropped**: OMB M-25-21 full minimum-practice tracking (+ the M-25-22
+   procurement-lifecycle surface) — v0.10.12 only *documented* the seven
+   practices — and the 4-phase AI-governance crosswalk enrichment.
+5. The hygiene track has no wave dependency — small, independently
+   mergeable PRs, front-loaded early in the cycle.
+
+## Wave 0 — cycle open (this PR)
+
+- **Doc-currency gate** — `scripts/check_roadmap_currency.py` (ROADMAP
+  status headings cross-checked against CHANGELOG shipped blocks; exactly
+  one open cycle; plan doc must exist), wired into the consistency scope +
+  pre-push hook, observed firing RED on the real v0.10.x roadmap drift
+  before the tree was fixed. Two prose currency anchors registered
+  (deprecation-calendar closing line; enterprise-grade maintenance-summary
+  claim). Lesson 11 recorded in `docs/engineering-practices.md`.
+- **ROADMAP restructure** — v0.10.x closed SHIPPED; four mis-marked entries
+  corrected (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12); four missing shipped
+  entries backfilled (v0.10.10 / v0.10.13 / v0.10.16 / v0.10.17); v0.11
+  promoted to the open-cycle h2 linking this plan.
+- **Quarterly practice-delta cadence** recorded in
+  `docs/engineering-practices.md` + the safeguards-resweep issue template
+  (next due 2026-10-01).
+
+## Hygiene track (H) — small PRs, no wave dependency
+
+From the 2026-07 practice-delta pass (each verified against a primary
+source) and the v0.10.17 deferred queue:
+
+- **H1 — CycloneDX 1.6 → 1.7** (two-line change: `release.yml` `--sv` +
+  `gen_package_sboms.py` `specVersion`). 1.7 released 2025-10-21; this is
+  the pass's only verified RETIRE (of 1.6). Do not chase CycloneDX 2.0
+  (announced, unreleased).
+- **H2 — `actions/dependency-review-action@v4` as a PR check** — blocks a
+  PR introducing a vulnerable/bad-license dependency *before* it lands
+  (complements Dependabot, which reacts after).
+- **H3 — CI-test the published verification recipes** — the documented
+  `cosign verify` / `gh attestation verify` commands become a scheduled
+  workflow so they cannot rot. On-thesis: a compliance tool proves its own
+  provenance is verifiable.
+- **H4 — SBOM quality gate** — `ntia-conformance-checker` on the release
+  SBOMs (fail if supplier/version/unique-ID are missing). Pairs with
+  deferred-queue **#17** (release-asset SBOM supplier/pedigree enrichment) —
+  do both in one PR.
+- **H5 — pilot-graduation watcher** for `uv audit` / `UV_MALWARE_CHECK`
+  (both still preview per Astral 2026-06-08) — clone the
+  `python-ceiling-watch.yml` pattern; nudge when marked stable. Mechanizes
+  "a pilot that never graduates is noise."
+- **H6 — deferred-queue small items**: #18 changelog-vs-commits advisory
+  diff; `security-insights.yml` CI-validate gate; demo-image pyyaml
+  hash-pin (alert #180 precedent #128); `cflite-batch.yml` timeout cap.
+- **H7 (Tier-4, Allen-gated)** — GitHub **policy-level enforcement of
+  SHA-pinned actions** (allowed-actions policy, GA 2025-08-15): a
+  platform control layered over the existing hand-pinning + zizmor check.
+  Repo/org settings change — needs explicit approval, not a code PR.
+
+Explicitly **not** in the hygiene track: #12 hermetic `RUN --network=none`
+stays deferred (it breaks pip-from-PyPI; needs an offline-wheel design —
+Horizon-B, revisit at the next quarterly sweep).
+
+## Wave 1 — OSCAL 1.2.2 evaluation (decision gate)
+
+Assess the 1.2.1 → 1.2.2 schema delta against every emitting/parsing
+surface (AR exporter, POA&M, traceability profile, catalog serializations,
+`oscal verify`, trestle round-trip tests). Deliverable: a written verdict —
+adopt-now / defer-with-trigger — recorded in the ROADMAP entry and this
+plan. **All OSCAL-emitting work below waits for this verdict.**
+
+## Wave 2 — Federal core
+
+- **FedRAMP KSI emission** (FRMR JSON per the `FedRAMP/schemas` repo — not
+  OSCAL; re-based 2026-06-10) as the third output mode on `evidentia
+  conmon`. Evidentia's slot: OSS engine for the audit-quality middle layer
+  between Trestle and RegScale.
+- **OMB M-25-21 full minimum-practice tracking** — structured per-practice
+  status for the seven practices as an extension of
+  `OMBHighImpactAssessment` (carried obligation from v0.10.12).
+- **M-25-22 procurement-lifecycle surface** — Evidentia models no
+  procurement surface today; M-25-22 replaced M-24-18 on 2025-04-03.
+
+## Wave 3 — DORA
+
+- **`evidentia incident emit --format dora-art-17`** — `DoraIncident`
+  record + `classify_dora()` per RTS 2024/1772 Art. 8 + Art. 9;
+  auto-POA&M creation for the 4h / 24h / 72h / 1-month reporting clocks;
+  CIR 2025/302 Annex I–IV template alignment. First Apache-2.0 OSS DORA
+  Art. 17 reference emitter.
+- **DORA-metrics extractor** (`scripts/extract_dora_metrics.py`) — passive
+  collection across 30+ releases from per-run JSONs (MTTR / lead time /
+  change-failure rate / bypass rate); enables the ESEM 2027 SEIP
+  short-paper. Independent and low-risk; rides this wave for domain
+  affinity only.
+
+## Wave 4 — AI governance
+
+- **`nist-sp-800-218a-ai-coding` Tier-B catalog** (11 controls, the
+  AI-assisted-code-production subset) **+ `docs/ai-coding-policy.md`
+  template** (CLAUDE.md / .cursorrules / copilot-instructions.md skeleton).
+  Ship together (constraint 3).
+- **AI-governance crosswalk enrichment, 4 phases** (carried obligation):
+  (1) ISO 27001:2022 Amd 1:2024 climate addendum in `iso-27001-2022.yaml`;
+  (2) NIST AI 600-1 + ISO/IEC 23894 as Tier-B catalogs; (3) **first
+  Apache-2.0 machine-readable EU AI Act ↔ ISO/IEC 42001 crosswalk**
+  (clean-room from Annex III + ISO 42001 Clauses 4–10 / Annex A); (4)
+  Council of Europe AI Convention (CETS 225) Tier-C stub. Crosswalk SME
+  hand-verification remains deferred (ROADMAP-tracked).
+
+## Wave 5 — Attestation surface
+
+- **`evidentia vex publish --rekor`** — `cosign attest --type openvex`;
+  closes OSPS-VM-04 maturity-3 + CISA SbD Goal 6. Fold in the
+  practice-delta ADOPT #1: a **signed OpenVEX doc per release** (spec
+  baseline v0.2.0) stating exploitability of SBOM-surfaced CVEs — 3/4
+  cross-vendor convergence independently validated this roadmap item.
+- **SLSA VSA emit** per SLSA v1.2 — `evidentia oscal vsa <ar.json>`;
+  closes the Source Track L2 claim path. (Subject to the Wave 1 verdict
+  only where it touches OSCAL inputs.)
+
+## Wave 6 — Ingest + reporting
+
+- **SARIF-ingestion collector** (`evidentia collect sarif`) — per the
+  committed design doc
+  ([`sarif-ingestion-collector-design.md`](../../designs/sarif-ingestion-collector-design.md)):
+  one adapter for any SARIF 2.1.0 emitter into `Finding`s, reusing the
+  OCSF collector's SSRF guard; data-layer interop only.
+- **Auto-generate `docs/releases/reviews/security-review-vX.Y.Z.md`** from
+  per-run JSON (skill v5.1 Q9 mechanism).
+
+## Wave 7 — Positioning + paper
+
+- **arXiv preprint** — "Evidentia: OSS Reference Implementation of
+  Computational Compliance for Multi-Framework Regulatory Assurance"
+  (6–8 pp; establishes priority in the generalist-GRC-OSCAL niche).
+  Publishing is Tier-4 (Allen-gated submission).
+- **`docs/integration-survey.md` competitive-section refresh** (AWS OSCAL
+  MCP / Vanta MCP / ComplianceCow MCP / Snyk AI Trust Platform shifts).
+
+## Medical-device v0.11 rows — ratification decision
+
+The ROADMAP's medical-device line targets four features at v0.11, each
+requiring a dedicated research fleet at build time. Recommendation:
+
+- **IN (recommended): Threat→Control→Test traceability enrichment** —
+  OWASP Threat Dragon / pytm ingest + the forward-looking CycloneDX
+  representation + pre/post residual risk. It extends the shipped v0.10.11
+  signed-OSCAL matrix and depends on the Wave 1 verdict — natural fit
+  after Wave 1.
+- **DECIDE MID-CYCLE (capacity-gated): CBOM ingest → 524B mapping + PQC
+  roadmap; deterministic deficiency-pattern checker; QMS artifact
+  generator.** All three are self-contained; slot as v0.11.x patches if
+  the federal + AI-governance waves land on schedule, else slip to v0.12
+  (the ROADMAP already stages the line across v0.11 → v1.1+).
+
+## Explicitly out of scope (decisions locked — do not relitigate)
+
+- P3 FIPS container variant — gated on the federal-SI OpenPGP-interop
+  answer.
+- #12 hermetic container build — Horizon-B design task.
+- `py/path-injection` CodeQL class — dismissal-managed; the MaD
+  `barrierModel` is a forward-looking hook.
+- Two-person review — structural solo-maintainer ceiling; the
+  required-reviewer publish gate is a deliberate out-of-band pause and is
+  never to be described as two-person separation of duties.
+- CycloneDX 2.0, GitHub Actions workflow-dependency locking, scoped
+  secrets / native egress firewall — WATCH items (not shipped upstream);
+  do not adopt `harden-runner` while the native egress firewall is
+  pending.
+
+## Ratification asks
+
+1. **Wave order** as proposed (0 → H → 1 → 2 → 3 → 4 → 5 → 6 → 7)?
+2. **Medical-device rows**: confirm the IN/DECIDE-MID-CYCLE split above.
+3. **Release boundaries**: default proposal — v0.11.0 = Wave 0 + H + Waves
+   1–2; subsequent v0.11.x per-wave. Confirm or re-cut.
+4. **H7** (platform SHA-pin policy) — approve as a settings action, or
+   drop.
+5. **A4 residual**: the new gate's advisory notes v0.10.0–v0.10.4 have no
+   per-release ROADMAP entries (they predate the per-patch h3 convention).
+   Backfill them, or leave the advisory standing?

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12) are corrected to SHIPPED, the
   four missing entries (v0.10.10 / v0.10.13 / v0.10.16 / v0.10.17) are
   backfilled, and v0.11 is promoted to the open cycle linking its plan doc
-  (`docs/releases/plans/v0.11-plan.md`, pending ratification).
+  (`docs/releases/plans/v0.11-plan.md`, ratified 2026-07-09).
   `docs/enterprise-grade.md`'s header is restructured so its live currency
   claim sits on a single anchorable line. The quarterly safeguards-resweep
   issue template gains a practice-delta item (method recorded in

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,6 +10,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ROADMAP-currency gate** (`scripts/check_roadmap_currency.py`) — the
+  roadmap's status headings must agree with the CHANGELOG's shipped
+  `## [X.Y.Z]` blocks: nothing PLANNED/RESERVED that has shipped, no SHIPPED
+  entries inside a PLANNED cycle umbrella, exactly one open cycle, and the
+  open cycle must link an on-disk plan doc (plus an advisory that every
+  release in the latest cycle has its entry). CHANGELOG blocks are the
+  source of truth — deliberately not git tags, which the shallow CI checkout
+  cannot see and which unpublished ghost tags would poison. Runs in the
+  required `consistency` scope and the pre-push hook, and was observed
+  firing on the real v0.10.x roadmap drift (four shipped releases
+  mis-marked PLANNED) before the tree was fixed. Two prose currency anchors
+  registered alongside it (the deprecation-calendar closing line and the
+  enterprise-grade maintenance-summary claim), so those live lines now
+  force-update on every version bump and hard-fail when stale. Recorded as
+  lesson 11 in `docs/engineering-practices.md`: *a doc's currency claim is
+  a gate or it is a lie.*
+
+### Changed
+
+- **ROADMAP restructured at the v0.11 cycle open** — the v0.10.x line is
+  closed SHIPPED (16 published releases), the four mis-marked entries
+  (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12) are corrected to SHIPPED, the
+  four missing entries (v0.10.10 / v0.10.13 / v0.10.16 / v0.10.17) are
+  backfilled, and v0.11 is promoted to the open cycle linking its plan doc
+  (`docs/releases/plans/v0.11-plan.md`, pending ratification).
+  `docs/enterprise-grade.md`'s header is restructured so its live currency
+  claim sits on a single anchorable line. The quarterly safeguards-resweep
+  issue template gains a practice-delta item (method recorded in
+  `docs/engineering-practices.md` §Research rigor).
+
 ## [0.10.17] - 2026-07-09
 
 **Theme**: *v0.10.x hardening close-out.* The final v0.10.x release, completing the Horizon-A elite-engineering-practice arc. Lands a publish-safe release-pipeline **preflight dry-run** — a `workflow_dispatch` that runs the full build/validate path (gate + wheels + per-package SBOMs + reproducible double-build + container-from-local-wheels + smoke tests) but is *structurally unable to publish* (the publish jobs require `github.event_name == 'push'`) — backed by `v*`-tag-only PyPI/GHCR deployment environments with required-reviewer approval, so a real release now pauses for an explicit deployment sign-off. Also: **two real audit-logger security fixes** surfaced by an adversarial review of the CodeQL 2.26.0 findings (CWE-117 log CR/LF injection + CWE-312 cleartext credential in an exception field); the dead CodeQL `.qll` path-injection sanitizer pack replaced with a Models-as-Data `barrierModel` extension (honestly dismissal-managed until the stock query consumes it); the Tier-1 demo image reworked to a **shell-free distroless multi-stage build**; CodSpeed perf reporting activated; CI job timeout caps; and a refreshed distroless base digest. No package API changes.

--- a/docs/wiki/6-project/roadmap.md
+++ b/docs/wiki/6-project/roadmap.md
@@ -1592,12 +1592,16 @@ the operator self-test + demo/pitch phase.
 **3250 tests / 14 skipped / mypy strict 261 of 261 source files /
 ruff clean.**
 
-## v0.10.x — Research-driven integration & AI-governance line — PLANNED
+## v0.10.x — Research-driven integration & AI-governance line — SHIPPED
 
 Opened 2026-05-21 following a competitive/integration research pass
 (see [`docs/integration-survey.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/integration-survey.md) and
 [`docs/positioning-and-value.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/positioning-and-value.md) §5.5 /
-§5.6.A). The v0.10.x line is the home for the research-driven feature
+§5.6.A). **Closed 2026-07-09 with v0.10.17** — 16 published releases
+(v0.10.0 – v0.10.13 + v0.10.16 + v0.10.17; the v0.10.14 / v0.10.15
+tags were never published: the atomic-release gate stopped both runs
+with nothing shipped — see the v0.10.16 entry below). The v0.10.x
+line is the home for the research-driven feature
 surface: because it brings meaningful new feature surface, it is a
 minor bump from v0.9.9 rather than a continuation of v0.9.x patches.
 
@@ -1639,7 +1643,7 @@ referenced in the v0.9.9 entry above; it runs before the v1.0
 domain-expert walk-through, and any gaps it surfaces feed back into the
 backlog.
 
-### v0.10.5 — OSS first-mover artifacts — PLANNED (added 2026-05-24)
+### v0.10.5 — OSS first-mover artifacts — SHIPPED (released 2026-05-26)
 
 Sourced from the Phase B audit re-run + 6-stream Evidentia-integration
 research synthesis (`~/.claude/skills/pre-release-review/_audits/evidentia-integration-plan-2026-05-24.md`).
@@ -1896,7 +1900,7 @@ its size limit), and research-resync cadence.
 - Pre-push gate L1 / L3 — defer-or-skip; revisit if a new pattern
   justifies them.
 
-### v0.10.9 — Debt + robustness patch — PLANNED
+### v0.10.9 — Debt + robustness patch — SHIPPED (released 2026-06-10)
 
 Theme: close the v0.10.8 ship findings and skill-iteration debt, and
 harden the release machinery that cycle built. Full plan:
@@ -1937,7 +1941,23 @@ harden the release machinery that cycle built. Full plan:
   last full pass at v0.9.5) runs alongside the cycle; outputs land in
   `docs/positioning-and-value.md`.
 
-### v0.10.11 — Public demo completion + traceability + hygiene — PLANNED
+### v0.10.10 — Supply-chain hardening + the public demo suite + FDA 524B pack — SHIPPED (released 2026-06-15)
+
+Patch (v0.10.9 → v0.10.10). Container base Python 3.14 → 3.13 (removes
+three container CVEs at the root, incl. a litellm HIGH); the collectors
+SSRF guard lifted into a shared, default-on
+`evidentia_core.network_guard.enforce_public_host` across all 13
+outbound collectors, made DNS-rebind-resistant by pinning the validated
+resolution through the actual connection; `tuf` 6 → 7; a container
+osv-gate in `release.yml` + `container-build.yml`; the **FDA Section
+524B medical-device pack** (the `fda-524b-appendix1` Tier-A catalog,
+ISO 14971 / AAMI SW96 license-respecting stubs, two illustrative
+crosswalks, a demo-gated `#/demo/fda` console route, and the wiki
+guide); and the in-repo artifacts for the three-tier **public demo
+suite** (static demo-mode console build, asciinema cast, constrained
+Tier-1 runner + demo-profile Dockerfile).
+
+### v0.10.11 — Public demo completion + traceability + hygiene — SHIPPED (released 2026-06-17)
 
 Patch (0.10.10 → 0.10.11). Per-cycle detail: [`v0.10.11-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.10.11-plan.md). Three tracks:
 
@@ -1945,16 +1965,70 @@ Patch (0.10.10 → 0.10.11). Per-cycle detail: [`v0.10.11-plan.md`](https://gith
 - **Control↔Threat Traceability Matrix** — promote the threat→control→evidence view from a rendered demo into a first-class GUI + CLI capability that emits a **Sigstore-signable OSCAL** matrix (builds on `models/threat.py`; the OSCAL slice here sets up the v0.11 TM-BOM). Generalist OSS.
 - **Hygiene** — collector guard-before-driver-import + mock-driver SSRF test (the proper fix behind the v0.10.10 CI extras hotfix); the `MetricCard` `<p>`→`<div>` DOM-nesting fix (carried in the shipped `#/demo/fda`); the `oscal sign`→`gap analyze --sign-with-*` correction in `threat-model.md` + `troubleshooting.md`; `GapExportControl` jsdom `Blob.stream` cleanup; a CI `--no-extras` pytest fidelity smoke (the gate the v0.10.10 push exposed).
 
-### v0.10.12 — Full CLI↔GUI parity build-out — PLANNED (dedicated session)
+### v0.10.12 — Full CLI↔GUI parity build-out — SHIPPED (released 2026-06-23)
 
 A single, heavily-planned, subagent-driven, multi-step-verified push to bring the web console to (near-)full CLI parity in one sitting (the v0.10.7 GUI-rebuild / wiki-population playbook). **Planning deliverable: a comprehensive surface × tier matrix** — for every capability, decide its presence and scope on each surface (**CLI** / self-hosted **GUI** / hosted **web app**), and adopt a standing rule that every *new* feature gets an explicit surface decision. (The detailed breakdown is a private planning artifact, not this public roadmap.) The planning pass reconciles the prior surface/tier research via project-file synthesis + dedicated `polycentric-labcoat` research fleets. (Keeps v0.11 reserved for the federal theme below.) The cycle **closes with a docs/ curation + CHANGELOG trim** once the console is at parity — archive the accumulated per-cycle plan + security-review docs and tighten the CHANGELOG (housekeeping, run last).
 
 Also folded in (additive, backward-compatible): the AI-governance module **migrates from the rescinded OMB M-24-10 to the M-25-21 "high-impact AI" model**. M-24-10 (2024-03-28) was rescinded 2025-04-03 by M-25-21, which collapses the old rights-impacting / safety-impacting split into one **high-impact AI** category across six bases (civil rights/liberties/privacy, access to essential services, critical government resources, health & safety, critical infrastructure, strategic assets). New `evidentia_core.ai_governance.omb_m_25_21` module (`HighImpactDetermination` + `HighImpactBasis` enums + `OMBHighImpactAssessment` model + `triggers_minimum_practices()` + `crosswalk_from_legacy()`), `evidentia ai-gov set-high-impact` CLI verb, `POST /api/ai-gov/systems/{system_id}/set-high-impact` REST route, `AI_SYSTEM_HIGH_IMPACT_CLASSIFIED` audit event, and an additive `omb_high_impact` registry field. The legacy M-24-10 module + `OMBImpactCategory` + `set-omb-impact` CLI/REST verb + `omb_impact` field remain DEPRECATED-but-functional (no behaviour change). The seven M-25-21 minimum risk-management practices are DOCUMENTED this cycle; structured per-practice tracking is deferred to v0.11 (see below).
 
-### v0.11 — Federal-compliance theme + AI governance — PLANNED (post-deep-dive)
+### v0.10.13 — Container-base restore patch — SHIPPED (released 2026-06-23)
 
-Sourced from Phase B audit v3 + integration plan §"Per-release
-detailed integration plan" §v0.11. Substantive minor (~6-8 weeks):
+Patch on v0.10.12, same day. v0.10.12 published to PyPI cleanly but its
+container build failed afterward: a Dependabot bump to
+`python:3.14-slim` meant the resolver could only reach a CVE-carrying
+litellm, so the CVE-clean pin was uninstallable. Reverts the base to the
+digest-pinned `python:3.13-slim` and un-breaks the container smoke test
+that should have caught it (it had silently exited at version-extraction
+since v0.10.11 — the chronically-red-gate failure class; it now reads
+the version from PyPI, self-correcting). The Python packages are
+identical to v0.10.12. This packages-only half-release is the direct
+spur for the v0.10.16 atomic-release reorder.
+
+### v0.10.16 — Engineering hardening + distroless container base — SHIPPED (released 2026-07-02)
+
+*Never ship a failed test again.* Cryptography-native **DSSE/in-toto
+air-gap signing** (`--sign-with-key`, Ed25519 / RSA-PSS, fail-closed
+pinned-key verify — works inside distroless containers with no `gpg`
+binary); the **atomic validate-before-publish release pipeline** (every
+artifact builds and validates before anything publishes); the published
+container migrated to a distroless **Docker Hardened Images** base
+(`dhi.io/python:3.13`, nonroot uid 65532, no shell / `curl` / `gpg`)
+with a scheduled base-freshness sentinel; **PR-flow + merge queue** on
+`main` with an empty bypass list; the fixable-only post-publish
+container-rescan gate; and the public
+[`docs/engineering-practices.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/engineering-practices.md) + security
+posture docs (SECURE-BY-DESIGN-PLEDGE, slsa-source-track, GHSA/rollback
+runbooks, `security-insights.yml`). **The v0.10.14 and v0.10.15 tags
+were never published**: the atomic gate stopped both runs with nothing
+shipped (a `pip-compile` hash-reuse, then a missing tool in the publish
+job's first-ever live execution) — v0.10.16 is the same release content
+plus both pipeline fixes, so those two versions have no CHANGELOG block
+by design.
+
+### v0.10.17 — v0.10.x hardening close-out — SHIPPED (released 2026-07-09)
+
+The final v0.10.x release. A publish-safe **release preflight dry-run**
+(`workflow_dispatch` runs the full build/validate path but is
+structurally unable to publish) backed by `v*`-tag-only PyPI/GHCR
+deployment environments with **required-reviewer approval** — the gate
+paused for sign-off twice on its first live release, as designed; **two
+real audit-logger security fixes** (CWE-117 log CR/LF injection +
+CWE-312 cleartext credential in an exception field) surfaced by an
+adversarial review of the CodeQL 2.26.0 findings; the Tier-1 demo image
+reworked to a shell-free distroless multi-stage build; CodSpeed
+performance reporting activated (its prior "green" job had never
+uploaded — a lesson-9 catch); CI job timeout caps; and three
+doc-accuracy fixes.
+
+## v0.11 — Federal-compliance theme + AI governance — PLANNED
+
+**The open cycle** (opened 2026-07-09). Full plan:
+[`v0.11-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.11-plan.md) — wave sequencing, the
+cycle-hygiene track (the 2026-07 practice-delta adoptions + the
+v0.10.17 deferred queue), the medical-device row split, and the
+ratification asks. Sourced from Phase B audit v3 + integration plan
+§"Per-release detailed integration plan" §v0.11. Substantive minor
+(~6-8 weeks):
 
 - **KSI (Key Security Indicators) emission** per FedRAMP's
   machine-readable schemas (FRMR JSON; the `FedRAMP/schemas`

--- a/scripts/check_roadmap_currency.py
+++ b/scripts/check_roadmap_currency.py
@@ -33,9 +33,12 @@ Assertions:
   A2 — a ``PLANNED`` umbrella h2 contains no ``SHIPPED`` entry inside its own
        section (structural self-consistency, CHANGELOG-independent — the
        v0.10.x umbrella sat PLANNED over three SHIPPED h3s).
-  A3 — the top ``PLANNED`` h2 links a ``releases/plans/v<x>-plan.md`` whose
-       version matches its cycle and which EXISTS on disk (an open cycle
-       without a plan doc is unratified work).
+  A3 — the top ``PLANNED`` h2's INTRO (the text before its first sub-heading)
+       links a ``releases/plans/v<x>-plan.md`` whose version matches its cycle
+       and which EXISTS on disk (an open cycle without a plan doc is
+       unratified work). Intro-scoped deliberately: an umbrella's h3 bodies
+       legitimately link OLD per-patch plan docs, which must not satisfy the
+       cycle-level claim.
   A4 — ADVISORY (reported, never failing): every CHANGELOG version in the
        LATEST shipped cycle has a concrete ``SHIPPED`` heading. Advisory-first
        per the wiring rule — a check that becomes required must be observed
@@ -231,13 +234,28 @@ def check_a2_planned_umbrella_pure(
     return failures
 
 
+def _intro_end(start_line: int, roadmap_lines: list[str], section_end: int) -> int:
+    """The last line (inclusive) of a heading's INTRO — up to its first
+    sub-heading (any ``##``/``###`` line, status-bearing or not), fence-aware.
+    """
+    in_fence = False
+    for idx in range(start_line + 1, section_end + 1):
+        line = roadmap_lines[idx - 1]
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and line.startswith("##"):
+            return idx - 1
+    return section_end
+
+
 def check_a3_open_cycle_has_plan(
     headings: list[Heading],
     h2_lines: list[int],
     roadmap_lines: list[str],
     docs_dir: Path,
 ) -> list[str]:
-    """A3 — the top PLANNED h2 links an on-disk, version-matching plan doc."""
+    """A3 — the top PLANNED h2's intro links an on-disk, version-matching plan doc."""
     planned_h2 = [h for h in headings if h.level == 2 and h.status == "PLANNED"]
     if not planned_h2:
         return [
@@ -245,14 +263,15 @@ def check_a3_open_cycle_has_plan(
             "(see the A0 failure)"
         ]
     top = min(planned_h2, key=lambda h: h.line_no)
-    end = _section_end(top.line_no, h2_lines, len(roadmap_lines))
-    section = "\n".join(roadmap_lines[top.line_no - 1 : end])
-    links = _PLAN_LINK_RE.findall(section)
+    section_end = _section_end(top.line_no, h2_lines, len(roadmap_lines))
+    end = _intro_end(top.line_no, roadmap_lines, section_end)
+    intro = "\n".join(roadmap_lines[top.line_no - 1 : end])
+    links = _PLAN_LINK_RE.findall(intro)
     if not links:
         return [
             f"line {top.line_no}: the open cycle '{top.text}' links no "
-            f"releases/plans/v<x>-plan.md — the current cycle must link its "
-            f"plan doc"
+            f"releases/plans/v<x>-plan.md in its intro (before the first "
+            f"sub-heading) — the current cycle must link its plan doc"
         ]
     expected = f"v{top.version if not top.is_umbrella else top.cycle}"
     problems: list[str] = []

--- a/scripts/check_roadmap_currency.py
+++ b/scripts/check_roadmap_currency.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Doc-currency gate: the ROADMAP must agree with the CHANGELOG about what shipped.
+
+v0.11 cycle-open. Motivation: v0.10.17 shipped with four ROADMAP entries still
+marked PLANNED although their releases had shipped (v0.10.5 / v0.10.9 /
+v0.10.11 / v0.10.12), the shipped ``## v0.10.x`` cycle umbrella still marked
+PLANNED, and four shipped patches with no ROADMAP entry at all — none of it
+caught mechanically (engineering-practices lesson 11: a doc's currency claim
+is a gate or it is a lie). The version-anchor overlay cannot express these
+STRUCTURAL claims (a status word on a heading, a section that must exist), so
+this dedicated gate covers them.
+
+The source of truth for "shipped" is CHANGELOG.md's ``## [X.Y.Z]`` blocks —
+deliberately NOT git tags: the CI checkout does not fetch tags (a tag-based
+gate would pass locally and break in CI), and unpublished ghost tags exist
+(v0.10.14 / v0.10.15) whose releases never published and therefore must NOT
+demand ROADMAP entries; both have no CHANGELOG block, which is exactly right.
+
+Headings parse as ``## / ### v<version> — <title> — <STATUS>[ (note)]``, keyed
+off the LEADING version token and the TRAILING status word. Headings without a
+leading version token are skipped (``### Medical-device GRC feature line
+(v0.11 → v1.1+) — PLANNED`` and ``### 1. Web UI — … — SHIPPED (v0.4.1)`` carry
+versions mid-line only), as are version headings with no status word
+(``## v0.7.0+ — Quality signals, …``). A version is a cycle UMBRELLA when it
+has no concrete patch part (``0.10.x`` / ``0.11`` / ``1.1+``), else CONCRETE.
+
+Assertions:
+
+  A0 — exactly ONE ``PLANNED`` h2 exists (the single open cycle).
+  A1 — nothing marked ``PLANNED`` / ``RESERVED`` has shipped: a concrete
+       heading must have no CHANGELOG ``## [X.Y.Z]`` block; an umbrella must
+       have no ``## [X.Y.*]`` block at all. (The workhorse.)
+  A2 — a ``PLANNED`` umbrella h2 contains no ``SHIPPED`` entry inside its own
+       section (structural self-consistency, CHANGELOG-independent — the
+       v0.10.x umbrella sat PLANNED over three SHIPPED h3s).
+  A3 — the top ``PLANNED`` h2 links a ``releases/plans/v<x>-plan.md`` whose
+       version matches its cycle and which EXISTS on disk (an open cycle
+       without a plan doc is unratified work).
+  A4 — ADVISORY (reported, never failing): every CHANGELOG version in the
+       LATEST shipped cycle has a concrete ``SHIPPED`` heading. Advisory-first
+       per the wiring rule — a check that becomes required must be observed
+       false-positive-free before it may block; harden once the backfill
+       policy for pre-convention patches is settled.
+
+Pure-filesystem: reads ``docs/ROADMAP.md`` + ``CHANGELOG.md`` and stats
+plan-doc paths. No git, no workspace import — safe in shallow CI checkouts
+and light installs, so it lives in the fast ``consistency`` gate scope.
+
+Exit codes:
+    0 — PASS (A0–A3 hold; A4 advisories do not fail the gate)
+    1 — FAIL (at least one A0–A3 assertion failed)
+    2 — usage / IO error
+
+Usage:
+    python scripts/check_roadmap_currency.py
+    python scripts/check_roadmap_currency.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parent
+ROADMAP_PATH = REPO_ROOT / "docs" / "ROADMAP.md"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+DOCS_DIR = REPO_ROOT / "docs"
+
+# The LEADING version token right after the hashes: `## v0.10.x`, `### v0.11`,
+# `## v1.1+`, `### v0.10.5`. The lookahead requires whitespace/EOL after the
+# token so `v0.10.x` is one token (never `v0.10` + trailing `.x`) and a heading
+# like `## version notes` cannot half-match.
+_HEADING_RE = re.compile(r"^(?P<hashes>#{2,3})\s+v(?P<version>\d+\.\d+(?:\.(?:\d+|x))?\+?)(?=\s|$)")
+_STATUS_RE = re.compile(r"\b(SHIPPED|PLANNED|RESERVED)\b")
+_CHANGELOG_VERSION_RE = re.compile(r"^## \[(\d+\.\d+\.\d+(?:\.\d+)?)\]", re.MULTILINE)
+# A markdown link target of the form `releases/plans/v<...>.md` (hrefs in the
+# ROADMAP are docs/-relative).
+_PLAN_LINK_RE = re.compile(r"\(((?:\./)?releases/plans/v[0-9][\w.+-]*\.md)\)")
+
+
+@dataclass(frozen=True)
+class Heading:
+    """One parsed ROADMAP status heading."""
+
+    line_no: int  # 1-based
+    level: int  # 2 (h2) or 3 (h3)
+    version: str  # "0.10.x" | "0.11" | "1.1+" | "0.10.5" | ...
+    status: str  # "SHIPPED" | "PLANNED" | "RESERVED"
+    text: str  # the full heading line (for messages)
+
+    @property
+    def is_umbrella(self) -> bool:
+        """A cycle umbrella (no concrete patch part) vs a concrete release."""
+        if self.version.endswith("+") or self.version.endswith(".x"):
+            return True
+        return self.version.count(".") < 2
+
+    @property
+    def cycle(self) -> str:
+        """The `X.Y` cycle prefix of this heading's version."""
+        parts = self.version.rstrip("+").split(".")
+        return ".".join(parts[:2])
+
+
+def parse_roadmap(text: str) -> tuple[list[Heading], list[int]]:
+    """Parse status headings + ALL h2 line numbers (section boundaries).
+
+    Fenced code blocks are skipped so an example heading inside a ``` fence
+    can never register. The h2 boundary list includes EVERY `## ` heading
+    (status-bearing or not) — a section ends at the next h2, whatever it is.
+    """
+    headings: list[Heading] = []
+    h2_lines: list[int] = []
+    in_fence = False
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if line.startswith("## ") and not line.startswith("###"):
+            h2_lines.append(idx)
+        m = _HEADING_RE.match(line)
+        if m is None:
+            continue
+        rest = line[m.end() :]
+        statuses = _STATUS_RE.findall(rest)
+        if not statuses:
+            continue  # a version heading with no status word is not tracked
+        headings.append(
+            Heading(
+                line_no=idx,
+                level=len(m.group("hashes")),
+                version=m.group("version"),
+                status=statuses[-1],
+                text=line.strip(),
+            )
+        )
+    return headings, h2_lines
+
+
+def parse_changelog_versions(text: str) -> list[str]:
+    """Every shipped `## [X.Y.Z]` version in CHANGELOG.md ([Unreleased] never matches)."""
+    return _CHANGELOG_VERSION_RE.findall(text)
+
+
+def _numeric_key(version: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in version.split("."))
+
+
+def _section_end(start_line: int, h2_lines: list[int], total_lines: int) -> int:
+    """The last line (inclusive) of the h2 section starting at ``start_line``."""
+    later = [ln for ln in h2_lines if ln > start_line]
+    return (min(later) - 1) if later else total_lines
+
+
+def check_a0_single_open_cycle(headings: list[Heading]) -> list[str]:
+    """A0 — exactly one PLANNED h2 (the single open cycle)."""
+    planned_h2 = [h for h in headings if h.level == 2 and h.status == "PLANNED"]
+    if len(planned_h2) == 1:
+        return []
+    if not planned_h2:
+        return [
+            "no PLANNED h2 found — the roadmap must carry exactly one open "
+            "cycle (`## v<x> — ... — PLANNED`)"
+        ]
+    listed = "; ".join(f"line {h.line_no}: {h.text}" for h in planned_h2)
+    return [
+        f"{len(planned_h2)} PLANNED h2 headings found (exactly one open cycle "
+        f"allowed): {listed}"
+    ]
+
+
+def check_a1_planned_never_shipped(
+    headings: list[Heading], shipped: list[str]
+) -> list[str]:
+    """A1 — nothing marked PLANNED/RESERVED has a shipped CHANGELOG block."""
+    failures: list[str] = []
+    shipped_set = set(shipped)
+    for h in headings:
+        if h.status not in ("PLANNED", "RESERVED"):
+            continue
+        if h.is_umbrella:
+            cycle_hits = sorted(
+                (v for v in shipped_set if v.startswith(h.cycle + ".")),
+                key=_numeric_key,
+            )
+            if cycle_hits:
+                failures.append(
+                    f"line {h.line_no}: '{h.text}' is {h.status} but the "
+                    f"v{h.cycle}.x cycle has {len(cycle_hits)} shipped "
+                    f"CHANGELOG release(s) ({', '.join(cycle_hits[:4])}"
+                    f"{', ...' if len(cycle_hits) > 4 else ''}) — mark the "
+                    f"cycle SHIPPED or fix the heading"
+                )
+        elif h.version in shipped_set:
+            failures.append(
+                f"line {h.line_no}: '{h.text}' is {h.status} but CHANGELOG "
+                f"has a shipped [{h.version}] block — mark it SHIPPED"
+            )
+    return failures
+
+
+def check_a2_planned_umbrella_pure(
+    headings: list[Heading], h2_lines: list[int], total_lines: int
+) -> list[str]:
+    """A2 — a PLANNED umbrella h2 contains no SHIPPED entry in its section."""
+    failures: list[str] = []
+    for h in headings:
+        if not (h.level == 2 and h.status == "PLANNED" and h.is_umbrella):
+            continue
+        end = _section_end(h.line_no, h2_lines, total_lines)
+        shipped_inside = [
+            s
+            for s in headings
+            if h.line_no < s.line_no <= end and s.status == "SHIPPED"
+        ]
+        if shipped_inside:
+            listed = ", ".join(f"v{s.version} (line {s.line_no})" for s in shipped_inside)
+            failures.append(
+                f"line {h.line_no}: PLANNED umbrella '{h.text}' contains "
+                f"{len(shipped_inside)} SHIPPED entr(ies) inside its own "
+                f"section ({listed}) — a cycle with shipped releases is not "
+                f"PLANNED"
+            )
+    return failures
+
+
+def check_a3_open_cycle_has_plan(
+    headings: list[Heading],
+    h2_lines: list[int],
+    roadmap_lines: list[str],
+    docs_dir: Path,
+) -> list[str]:
+    """A3 — the top PLANNED h2 links an on-disk, version-matching plan doc."""
+    planned_h2 = [h for h in headings if h.level == 2 and h.status == "PLANNED"]
+    if not planned_h2:
+        return [
+            "no PLANNED h2 exists to carry the current-cycle plan link "
+            "(see the A0 failure)"
+        ]
+    top = min(planned_h2, key=lambda h: h.line_no)
+    end = _section_end(top.line_no, h2_lines, len(roadmap_lines))
+    section = "\n".join(roadmap_lines[top.line_no - 1 : end])
+    links = _PLAN_LINK_RE.findall(section)
+    if not links:
+        return [
+            f"line {top.line_no}: the open cycle '{top.text}' links no "
+            f"releases/plans/v<x>-plan.md — the current cycle must link its "
+            f"plan doc"
+        ]
+    expected = f"v{top.version if not top.is_umbrella else top.cycle}"
+    problems: list[str] = []
+    for link in links:
+        name = Path(link).name
+        rest = name[len(expected) :] if name.startswith(expected) else None
+        if rest is None or rest[:1] not in (".", "-"):
+            problems.append(f"'{link}' does not match the cycle ({expected})")
+            continue
+        if not (docs_dir / link).is_file():
+            problems.append(f"'{link}' does not exist on disk under docs/")
+            continue
+        return []  # one version-matching, on-disk plan link satisfies A3
+    return [
+        f"line {top.line_no}: the open cycle '{top.text}' has no satisfying "
+        f"plan link — " + "; ".join(problems)
+    ]
+
+
+def check_a4_latest_cycle_backfilled(
+    headings: list[Heading], shipped: list[str]
+) -> list[str]:
+    """A4 (ADVISORY) — every shipped version in the latest cycle has a SHIPPED heading."""
+    if not shipped:
+        return []
+    latest = max(shipped, key=_numeric_key)
+    cycle_prefix = ".".join(latest.split(".")[:2]) + "."
+    members = sorted(
+        (v for v in shipped if v.startswith(cycle_prefix)), key=_numeric_key
+    )
+    covered = {
+        h.version for h in headings if h.status == "SHIPPED" and not h.is_umbrella
+    }
+    return [
+        f"shipped [{v}] has no `SHIPPED` roadmap heading — backfill a "
+        f"`### v{v} — ... — SHIPPED` entry"
+        for v in members
+        if v not in covered
+    ]
+
+
+@dataclass
+class Report:
+    """The per-assertion findings of one gate run."""
+
+    a0: list[str]
+    a1: list[str]
+    a2: list[str]
+    a3: list[str]
+    a4_advisory: list[str]
+    heading_count: int
+    shipped_count: int
+
+    @property
+    def failures(self) -> list[str]:
+        return self.a0 + self.a1 + self.a2 + self.a3
+
+
+def run_checks(roadmap_text: str, changelog_text: str, docs_dir: Path) -> Report:
+    """Run every assertion against the given documents."""
+    headings, h2_lines = parse_roadmap(roadmap_text)
+    roadmap_lines = roadmap_text.splitlines()
+    shipped = parse_changelog_versions(changelog_text)
+    return Report(
+        a0=check_a0_single_open_cycle(headings),
+        a1=check_a1_planned_never_shipped(headings, shipped),
+        a2=check_a2_planned_umbrella_pure(headings, h2_lines, len(roadmap_lines)),
+        a3=check_a3_open_cycle_has_plan(headings, h2_lines, roadmap_lines, docs_dir),
+        a4_advisory=check_a4_latest_cycle_backfilled(headings, shipped),
+        heading_count=len(headings),
+        shipped_count=len(shipped),
+    )
+
+
+_SECTIONS = (
+    ("a0", "A0 single-open-cycle", "exactly one PLANNED h2."),
+    ("a1", "A1 planned-never-shipped", "no PLANNED/RESERVED heading has shipped."),
+    ("a2", "A2 umbrella-consistency", "no PLANNED umbrella holds SHIPPED entries."),
+    ("a3", "A3 open-cycle-plan-doc", "the open cycle links an on-disk plan doc."),
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json", action="store_true", help="emit a machine-readable JSON report"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        roadmap_text = ROADMAP_PATH.read_text(encoding="utf-8")
+        changelog_text = CHANGELOG_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"check_roadmap_currency: cannot read input: {exc}", file=sys.stderr)
+        return 2
+
+    report = run_checks(roadmap_text, changelog_text, DOCS_DIR)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": not report.failures,
+                    "a0_failures": report.a0,
+                    "a1_failures": report.a1,
+                    "a2_failures": report.a2,
+                    "a3_failures": report.a3,
+                    "a4_advisory": report.a4_advisory,
+                },
+                indent=2,
+            )
+        )
+        return 0 if not report.failures else 1
+
+    print(
+        f"check_roadmap_currency: {report.heading_count} status heading(s), "
+        f"{report.shipped_count} shipped CHANGELOG version(s)"
+    )
+    for attr, label, pass_text in _SECTIONS:
+        findings: list[str] = getattr(report, attr)
+        if findings:
+            print()
+            print(f"{label} FAILURES ({len(findings)}):")
+            for f in findings:
+                print(f"  - {f}")
+        else:
+            print(f"  {label}: PASS — {pass_text}")
+
+    if report.a4_advisory:
+        print()
+        print(f"A4 latest-cycle-backfill ADVISORY ({len(report.a4_advisory)} — does not fail the gate):")
+        for f in report.a4_advisory:
+            print(f"  - {f}")
+    else:
+        print("  A4 latest-cycle-backfill: clean — every shipped release in the latest cycle has its entry.")
+
+    print()
+    if report.failures:
+        print(
+            f"check_roadmap_currency: FAIL ({len(report.failures)} issue(s)). "
+            "The ROADMAP's status headings disagree with the CHANGELOG."
+        )
+        return 1
+    print("check_roadmap_currency: PASS.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_gate_suite.py
+++ b/scripts/run_gate_suite.py
@@ -138,6 +138,17 @@ _CONSISTENCY_CHECKS: tuple[Check, ...] = (
         "wiki_api_docs_drift",
         ("python", "scripts/wiki/sync_api_docs.py", "--check"),
     ),
+    # ROADMAP↔CHANGELOG currency gate (v0.11 cycle-open; engineering-practices
+    # lesson 11). Status headings must agree with the CHANGELOG's shipped
+    # blocks (four shipped releases sat mis-marked PLANNED through v0.10.17),
+    # exactly one cycle may be open, and the open cycle must link an on-disk
+    # plan doc. Pure-filesystem (reads docs/ROADMAP.md + CHANGELOG.md, stats
+    # plan-doc paths — deliberately NOT git tags, which the shallow CI
+    # checkout cannot see), so it stays in the fast consistency scope.
+    Check(
+        "roadmap_currency",
+        ("python", "scripts/check_roadmap_currency.py"),
+    ),
 )
 
 # The heavyweight gates, appended to the consistency tuple to form

--- a/scripts/version_tracked_files.yaml
+++ b/scripts/version_tracked_files.yaml
@@ -369,6 +369,29 @@ anchors:
       example in the "Verify a release wheel" block — a LIVE verification recipe
       that must name the current wheel. Single in-family literal on the line.
 
+  # ── docs/deprecation-calendar.md (frozen via docs/**) ──────────────────
+  - path: "docs/deprecation-calendar.md"
+    line_contains: "No other surfaces are currently deprecated as of"
+    desc: >-
+      The closing "No other surfaces are currently deprecated as of vX.Y.Z"
+      line under the Active-deprecations table — a LIVE "the table above is
+      complete at release X" claim. It drifted stale across two releases
+      before the v0.11 cycle-open registered it (the machinery existed; the
+      anchor was simply never added). Single in-family literal on the line.
+
+  # ── docs/enterprise-grade.md (frozen via docs/**) ──────────────────────
+  - path: "docs/enterprise-grade.md"
+    line_contains: "Maintenance summary current as of release"
+    desc: >-
+      The header blockquote's "Maintenance summary current as of release
+      vX.Y.Z." line — the doc's LIVE currency claim. Restructured at the
+      v0.11 cycle-open so the live claim sits alone on a single-literal line
+      (the old h1 carried three in-family literals, which trips the
+      EXACTLY-ONE >1 guard) and the old versioned "Status through vX.Y.Z"
+      heading is de-versioned (an anchor can rewrite a heading's literal but
+      never its generated TOC slug, so a versioned heading breaks its own
+      anchor link on every bump). Single in-family literal on the line.
+
   # ── docs/ROADMAP.md (frozen via docs/**) ───────────────────────────────
   - path: "docs/ROADMAP.md"
     line_contains: "Last updated:"

--- a/tests/scripts/test_run_gate_suite.py
+++ b/tests/scripts/test_run_gate_suite.py
@@ -28,7 +28,13 @@ def test_scopes_are_declarative() -> None:
     full = {c.name for c in g.checks_for_scope("full")}
     consistency = {c.name for c in g.checks_for_scope("consistency")}
     # The staleness guards are the consistency scope and a subset of full.
-    assert {"version_consistency", "docs_health", "readme_releases"} <= consistency
+    # roadmap_currency is the v0.11 cycle-open doc-currency gate (lesson 11).
+    assert {
+        "version_consistency",
+        "docs_health",
+        "readme_releases",
+        "roadmap_currency",
+    } <= consistency
     assert consistency < full
     assert {"pytest", "mypy", "ruff", "osv", "parity"} <= full
     # parity is full-only (v0.10.9 item D): the tag-time gate hard-blocks a

--- a/tests/unit/test_scripts/test_check_roadmap_currency.py
+++ b/tests/unit/test_scripts/test_check_roadmap_currency.py
@@ -288,6 +288,25 @@ def test_a3_link_must_live_inside_the_open_cycle_section(rc, tmp_path: Path) -> 
     assert len(failures) == 1
 
 
+def test_a3_is_intro_scoped_a_sub_entry_plan_link_does_not_count(
+    rc, tmp_path: Path
+) -> None:
+    """The exact v0.10.x shape: the PLANNED umbrella's own intro links no plan
+    doc, while a sub-h3 body links an OLD per-patch plan — that must NOT
+    satisfy the cycle-level claim."""
+    text = (
+        "## v0.10.x — research line — PLANNED\n"
+        "Umbrella intro with no plan link.\n"
+        "### v0.10.5 — artifacts — PLANNED\n"
+        "Full plan at [v0.10.5-plan.md](releases/plans/v0.10.5-plan.md).\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    failures = rc.check_a3_open_cycle_has_plan(
+        headings, h2_lines, text.splitlines(), _docs_tree(tmp_path, "v0.10.5-plan.md")
+    )
+    assert len(failures) == 1 and "links no" in failures[0]
+
+
 def test_a3_concrete_planned_h2_expects_full_version(rc, tmp_path: Path) -> None:
     text = (
         "## v0.11.2 — hot patch — PLANNED\n"
@@ -346,15 +365,16 @@ def test_broken_tree_shape_fires_a1_a2_a3(rc, tmp_path: Path) -> None:
     roadmap = (
         "## v0.10.x — research line — PLANNED\n"
         "### v0.10.5 — artifacts — PLANNED (added 2026-05-24)\n"
+        "Full plan at [v0.10.5-plan.md](releases/plans/v0.10.5-plan.md).\n"
         "### v0.10.6 — crosswalks — SHIPPED\n"
         "### v0.11 — federal theme — PLANNED (post-deep-dive)\n"
     )
     report = rc.run_checks(
-        roadmap, changelog("0.10.5", "0.10.6"), _docs_tree(tmp_path)
+        roadmap, changelog("0.10.5", "0.10.6"), _docs_tree(tmp_path, "v0.10.5-plan.md")
     )
     assert len(report.a1) == 2  # the PLANNED umbrella + the PLANNED v0.10.5
     assert len(report.a2) == 1  # SHIPPED v0.10.6 inside the PLANNED umbrella
-    assert len(report.a3) == 1  # the open cycle links no plan doc
+    assert len(report.a3) == 1  # the cycle's own intro links no plan doc
     assert report.failures
 
 

--- a/tests/unit/test_scripts/test_check_roadmap_currency.py
+++ b/tests/unit/test_scripts/test_check_roadmap_currency.py
@@ -1,0 +1,385 @@
+"""Tests for scripts/check_roadmap_currency.py (v0.11 cycle-open doc-currency gate).
+
+The gate cross-checks docs/ROADMAP.md status headings against CHANGELOG.md's
+shipped ``## [X.Y.Z]`` blocks (the source of truth a shallow CI checkout can
+see — NOT git tags, which unpublished ghost tags and tagless checkouts both
+betray). These tests pin the parser's leading-version-token / trailing-status
+contract against the real heading shapes in the ROADMAP, and each assertion
+(A0 single open cycle, A1 planned-never-shipped, A2 umbrella consistency,
+A3 open-cycle plan doc, A4 advisory backfill) on synthetic fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_roadmap_currency.py"
+
+
+@pytest.fixture(scope="module")
+def rc() -> object:
+    """Import scripts/check_roadmap_currency.py as a module (no __init__.py)."""
+    spec = importlib.util.spec_from_file_location(
+        "check_roadmap_currency", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_roadmap_currency"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def changelog(*versions: str) -> str:
+    """A minimal CHANGELOG with one shipped block per version."""
+    blocks = "\n\n".join(f"## [{v}] - 2026-01-01\n\n- something." for v in versions)
+    return f"# Changelog\n\n## [Unreleased]\n\n{blocks}\n"
+
+
+# ── parser ──────────────────────────────────────────────────────────────────
+
+
+def test_parser_requires_leading_version_token(rc) -> None:
+    """Headings whose version appears mid-line only are NOT status headings."""
+    text = (
+        "## v0.10.x — Research line — PLANNED\n"
+        "### Medical-device GRC feature line (v0.11 → v1.1+) — PLANNED\n"
+        "### 1. Web UI — `evidentia serve` — SHIPPED (v0.4.1)\n"
+        "### Planned for v0.4.2 polish:\n"
+        "### Operator deep-dive — PLANNED (after the v0.10.x feature surface)\n"
+    )
+    headings, _ = rc.parse_roadmap(text)
+    assert [h.version for h in headings] == ["0.10.x"]
+
+
+def test_parser_skips_version_heading_without_status(rc) -> None:
+    """`## v0.7.0+ — Quality signals, ...` has no status word — skipped."""
+    headings, _ = rc.parse_roadmap(
+        "## v0.7.0+ — Quality signals, more integrations, UI polish\n"
+    )
+    assert headings == []
+
+
+def test_parser_accepts_status_with_trailing_note(rc) -> None:
+    text = (
+        "### v0.10.5 — OSS first-mover artifacts — PLANNED (added 2026-05-24)\n"
+        "### v0.10.12 — Parity build-out — PLANNED (dedicated session)\n"
+        "## v0.7.7 — SQL collectors — SHIPPED (+ v0.7.7.1 same-day hot-fix)\n"
+    )
+    headings, _ = rc.parse_roadmap(text)
+    assert [(h.version, h.status) for h in headings] == [
+        ("0.10.5", "PLANNED"),
+        ("0.10.12", "PLANNED"),
+        ("0.7.7", "SHIPPED"),
+    ]
+
+
+def test_parser_umbrella_vs_concrete_classification(rc) -> None:
+    text = (
+        "## v0.10.x — line — PLANNED\n"
+        "## v0.11 — theme — PLANNED\n"
+        "### v1.1+ — later — RESERVED\n"
+        "## v1.0 — stability — RESERVED\n"
+        "### v0.10.5 — artifacts — SHIPPED\n"
+    )
+    headings, _ = rc.parse_roadmap(text)
+    by_version = {h.version: h for h in headings}
+    assert by_version["0.10.x"].is_umbrella and by_version["0.10.x"].cycle == "0.10"
+    assert by_version["0.11"].is_umbrella and by_version["0.11"].cycle == "0.11"
+    assert by_version["1.1+"].is_umbrella and by_version["1.1+"].cycle == "1.1"
+    assert by_version["1.0"].is_umbrella and by_version["1.0"].cycle == "1.0"
+    assert not by_version["0.10.5"].is_umbrella
+    assert by_version["0.10.5"].cycle == "0.10"
+
+
+def test_parser_skips_fenced_code_blocks(rc) -> None:
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "```\n"
+        "## v0.12 — example inside a fence — SHIPPED\n"
+        "```\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    assert [h.version for h in headings] == ["0.11"]
+    assert h2_lines == [1]
+
+
+def test_parser_h2_boundaries_include_statusless_h2(rc) -> None:
+    """Every `## ` line is a section boundary, status-bearing or not."""
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "body\n"
+        "## Deferred / rejected items\n"
+    )
+    _, h2_lines = rc.parse_roadmap(text)
+    assert h2_lines == [1, 3]
+
+
+# ── A0 ──────────────────────────────────────────────────────────────────────
+
+
+def test_a0_exactly_one_planned_h2(rc) -> None:
+    one, _ = rc.parse_roadmap("## v0.11 — theme — PLANNED\n")
+    assert rc.check_a0_single_open_cycle(one) == []
+
+    none, _ = rc.parse_roadmap("## v0.10.x — line — SHIPPED\n")
+    assert len(rc.check_a0_single_open_cycle(none)) == 1
+
+    two, _ = rc.parse_roadmap(
+        "## v0.11 — theme — PLANNED\n## v0.12 — next — PLANNED\n"
+    )
+    (failure,) = rc.check_a0_single_open_cycle(two)
+    assert "2 PLANNED h2" in failure
+
+
+def test_a0_planned_h3_does_not_count(rc) -> None:
+    """Only h2 headings define the open cycle; PLANNED h3s are cycle content."""
+    headings, _ = rc.parse_roadmap(
+        "## v0.11 — theme — PLANNED\n### v0.11.3 — later patch — PLANNED\n"
+    )
+    assert rc.check_a0_single_open_cycle(headings) == []
+
+
+# ── A1 ──────────────────────────────────────────────────────────────────────
+
+
+def test_a1_concrete_planned_with_shipped_block_fires(rc) -> None:
+    headings, _ = rc.parse_roadmap(
+        "### v0.10.5 — artifacts — PLANNED\n### v0.10.9 — debt — PLANNED\n"
+    )
+    failures = rc.check_a1_planned_never_shipped(headings, ["0.10.5"])
+    assert len(failures) == 1 and "[0.10.5]" in failures[0]
+
+
+def test_a1_reserved_with_shipped_block_fires(rc) -> None:
+    headings, _ = rc.parse_roadmap("## v1.0 — stability — RESERVED\n")
+    assert rc.check_a1_planned_never_shipped(headings, ["1.0.0"]) != []
+
+
+def test_a1_umbrella_planned_with_cycle_blocks_fires(rc) -> None:
+    headings, _ = rc.parse_roadmap("## v0.10.x — line — PLANNED\n")
+    failures = rc.check_a1_planned_never_shipped(
+        headings, ["0.10.0", "0.10.5", "0.9.9"]
+    )
+    assert len(failures) == 1 and "2 shipped" in failures[0]
+
+
+def test_a1_umbrella_cycle_prefix_is_exact(rc) -> None:
+    """A v0.1 umbrella must not match 0.10.x releases (prefix, not substring)."""
+    headings, _ = rc.parse_roadmap("## v0.1 — ancient — RESERVED\n")
+    assert rc.check_a1_planned_never_shipped(headings, ["0.10.5"]) == []
+
+
+def test_a1_shipped_and_unshipped_planned_pass(rc) -> None:
+    headings, _ = rc.parse_roadmap(
+        "### v0.10.6 — shipped fine — SHIPPED\n### v0.12.0 — future — PLANNED\n"
+    )
+    assert rc.check_a1_planned_never_shipped(headings, ["0.10.6"]) == []
+
+
+# ── A2 ──────────────────────────────────────────────────────────────────────
+
+
+def test_a2_planned_umbrella_holding_shipped_entries_fires(rc) -> None:
+    text = (
+        "## v0.10.x — line — PLANNED\n"
+        "### v0.10.6 — a — SHIPPED\n"
+        "### v0.10.9 — b — PLANNED\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    failures = rc.check_a2_planned_umbrella_pure(headings, h2_lines, 3)
+    assert len(failures) == 1 and "v0.10.6" in failures[0]
+
+
+def test_a2_section_is_bounded_by_the_next_h2(rc) -> None:
+    """A SHIPPED entry after the next h2 belongs to that section, not the umbrella."""
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "### v0.11.9 — future patch — PLANNED\n"
+        "## Deferred / rejected items\n"
+        "### v0.10.6 — old — SHIPPED\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    assert rc.check_a2_planned_umbrella_pure(headings, h2_lines, 4) == []
+
+
+def test_a2_shipped_umbrella_with_planned_h3_passes(rc) -> None:
+    """Mid-cycle shape: SHIPPED umbrella, future patches PLANNED inside it."""
+    text = "## v0.10.x — line — SHIPPED\n### v0.10.9 — next — PLANNED\n"
+    headings, h2_lines = rc.parse_roadmap(text)
+    assert rc.check_a2_planned_umbrella_pure(headings, h2_lines, 2) == []
+
+
+# ── A3 ──────────────────────────────────────────────────────────────────────
+
+
+def _docs_tree(tmp_path: Path, *plan_names: str) -> Path:
+    docs = tmp_path / "docs"
+    (docs / "releases" / "plans").mkdir(parents=True)
+    for name in plan_names:
+        (docs / "releases" / "plans" / name).write_text("# plan\n", encoding="utf-8")
+    return docs
+
+
+def test_a3_open_cycle_without_plan_link_fires(rc, tmp_path: Path) -> None:
+    text = "## v0.11 — theme — PLANNED\n\nNo plan link here.\n"
+    headings, h2_lines = rc.parse_roadmap(text)
+    failures = rc.check_a3_open_cycle_has_plan(
+        headings, h2_lines, text.splitlines(), _docs_tree(tmp_path)
+    )
+    assert len(failures) == 1 and "links no" in failures[0]
+
+
+def test_a3_version_mismatched_plan_link_fires(rc, tmp_path: Path) -> None:
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "Full plan: [old](releases/plans/v0.10.9-plan.md).\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    failures = rc.check_a3_open_cycle_has_plan(
+        headings, h2_lines, text.splitlines(), _docs_tree(tmp_path, "v0.10.9-plan.md")
+    )
+    assert len(failures) == 1 and "does not match the cycle (v0.11)" in failures[0]
+
+
+def test_a3_missing_plan_file_fires(rc, tmp_path: Path) -> None:
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "Full plan: [plan](releases/plans/v0.11-plan.md).\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    failures = rc.check_a3_open_cycle_has_plan(
+        headings, h2_lines, text.splitlines(), _docs_tree(tmp_path)
+    )
+    assert len(failures) == 1 and "does not exist on disk" in failures[0]
+
+
+def test_a3_matching_on_disk_plan_passes(rc, tmp_path: Path) -> None:
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "Full plan: [plan](releases/plans/v0.11-plan.md).\n"
+        "## v1.0 — stability — RESERVED\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    assert (
+        rc.check_a3_open_cycle_has_plan(
+            headings, h2_lines, text.splitlines(), _docs_tree(tmp_path, "v0.11-plan.md")
+        )
+        == []
+    )
+
+
+def test_a3_link_must_live_inside_the_open_cycle_section(rc, tmp_path: Path) -> None:
+    """A plan link in a LATER section cannot satisfy the open cycle."""
+    text = (
+        "## v0.11 — theme — PLANNED\n"
+        "No link in this section.\n"
+        "## Release-runbook follow-ups\n"
+        "See [plan](releases/plans/v0.11-plan.md).\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    failures = rc.check_a3_open_cycle_has_plan(
+        headings, h2_lines, text.splitlines(), _docs_tree(tmp_path, "v0.11-plan.md")
+    )
+    assert len(failures) == 1
+
+
+def test_a3_concrete_planned_h2_expects_full_version(rc, tmp_path: Path) -> None:
+    text = (
+        "## v0.11.2 — hot patch — PLANNED\n"
+        "Full plan: [plan](releases/plans/v0.11.2-plan.md).\n"
+    )
+    headings, h2_lines = rc.parse_roadmap(text)
+    assert (
+        rc.check_a3_open_cycle_has_plan(
+            headings,
+            h2_lines,
+            text.splitlines(),
+            _docs_tree(tmp_path, "v0.11.2-plan.md"),
+        )
+        == []
+    )
+
+
+# ── A4 (advisory) ───────────────────────────────────────────────────────────
+
+
+def test_a4_reports_missing_latest_cycle_entries_only(rc) -> None:
+    headings, _ = rc.parse_roadmap(
+        "## v0.10.x — line — SHIPPED\n### v0.10.16 — a — SHIPPED\n"
+    )
+    advisory = rc.check_a4_latest_cycle_backfilled(
+        headings, ["0.9.9", "0.10.16", "0.10.17"]
+    )
+    # 0.10.17 is missing; 0.9.9 is a PRIOR cycle (not checked); the umbrella
+    # heading does not cover a concrete version.
+    assert len(advisory) == 1 and "[0.10.17]" in advisory[0]
+
+
+def test_a4_latest_cycle_is_numeric_not_lexicographic(rc) -> None:
+    """0.10.16 > 0.10.9 numerically — the latest cycle must be 0.10, complete."""
+    headings, _ = rc.parse_roadmap(
+        "### v0.10.9 — a — SHIPPED\n### v0.10.16 — b — SHIPPED\n"
+    )
+    assert rc.check_a4_latest_cycle_backfilled(headings, ["0.10.9", "0.10.16"]) == []
+
+
+def test_a4_is_advisory_never_a_failure(rc, tmp_path: Path) -> None:
+    report = rc.run_checks(
+        "## v0.11 — theme — PLANNED\nFull plan: [p](releases/plans/v0.11-plan.md).\n",
+        changelog("0.10.17"),
+        _docs_tree(tmp_path, "v0.11-plan.md"),
+    )
+    assert report.a4_advisory != []  # 0.10.17 has no SHIPPED heading
+    assert report.failures == []  # ...and that does not fail the gate
+
+
+# ── end-to-end shapes ───────────────────────────────────────────────────────
+
+
+def test_broken_tree_shape_fires_a1_a2_a3(rc, tmp_path: Path) -> None:
+    """The exact defect shape the v0.11 cycle-open found (miniaturized)."""
+    roadmap = (
+        "## v0.10.x — research line — PLANNED\n"
+        "### v0.10.5 — artifacts — PLANNED (added 2026-05-24)\n"
+        "### v0.10.6 — crosswalks — SHIPPED\n"
+        "### v0.11 — federal theme — PLANNED (post-deep-dive)\n"
+    )
+    report = rc.run_checks(
+        roadmap, changelog("0.10.5", "0.10.6"), _docs_tree(tmp_path)
+    )
+    assert len(report.a1) == 2  # the PLANNED umbrella + the PLANNED v0.10.5
+    assert len(report.a2) == 1  # SHIPPED v0.10.6 inside the PLANNED umbrella
+    assert len(report.a3) == 1  # the open cycle links no plan doc
+    assert report.failures
+
+
+def test_fixed_tree_shape_is_green(rc, tmp_path: Path) -> None:
+    roadmap = (
+        "## v0.10.x — research line — SHIPPED\n"
+        "### v0.10.5 — artifacts — SHIPPED\n"
+        "### v0.10.6 — crosswalks — SHIPPED\n"
+        "## v0.11 — federal theme — PLANNED\n"
+        "Full plan: [v0.11-plan.md](releases/plans/v0.11-plan.md).\n"
+        "### v1.1+ — later — RESERVED\n"
+        "## v1.0 — stability — RESERVED\n"
+    )
+    report = rc.run_checks(
+        roadmap, changelog("0.10.5", "0.10.6"), _docs_tree(tmp_path, "v0.11-plan.md")
+    )
+    assert report.failures == []
+    assert report.a4_advisory == []
+
+
+def test_real_repo_documents_parse(rc) -> None:
+    """Structural smoke on the live docs: the parser sees the real shapes."""
+    roadmap_text = (REPO_ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+    changelog_text = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    headings, h2_lines = rc.parse_roadmap(roadmap_text)
+    assert len(headings) >= 40
+    assert len(h2_lines) >= 30
+    assert len(rc.parse_changelog_versions(changelog_text)) >= 40


### PR DESCRIPTION
## Summary

Opens the v0.11 cycle, root-cause work first: v0.10.17 shipped with four ROADMAP entries mis-marked `PLANNED`, the shipped `v0.10.x` umbrella itself still `PLANNED`, four shipped patches missing from the roadmap entirely, and two stale "current as of release X" prose lines — none of it caught mechanically. This PR turns every one of those defect classes into a gate, then fixes the tree under it.

### The gate — built first, observed firing, then the tree fixed

- **`scripts/check_roadmap_currency.py`** — A0: exactly one open (`PLANNED`) cycle h2 · A1: nothing `PLANNED`/`RESERVED` that has a shipped CHANGELOG block (concrete + umbrella) · A2: no `SHIPPED` entries inside a `PLANNED` umbrella · A3: the open cycle's intro links an on-disk, version-matching plan doc · A4 (advisory): every release in the latest cycle has its entry. CHANGELOG `## [X.Y.Z]` blocks are the source of truth — deliberately **not git tags** (the CI checkout fetches no tags, and the unpublished v0.10.14/15 ghost tags must not demand entries).
- Wired into `run_gate_suite._CONSISTENCY_CHECKS` (→ the required `consistency` check) and `.githooks/pre-push` (check 16). 29 unit tests pin the parser contract (leading version token, trailing status, fences, umbrella vs concrete) and every assertion both ways.
- **Observed firing before the fix** (engineering-practices lesson 9): on the pre-fix tree the gate reported A1 ×5 (v0.10.5/9/11/12 + the v0.10.x umbrella), A2 ×1, A3 ×1, exit 1. The observation itself caught a gate bug — A3 had to be scoped to the cycle's *intro*, or old per-patch plan links inside the umbrella's sub-entries satisfied it.
- **Two prose currency anchors registered** (`docs/deprecation-calendar.md` closing line; `docs/enterprise-grade.md` maintenance-summary claim — its header restructured onto a single-literal line, its versioned heading de-versioned because an anchor can rewrite a heading's literal but never its generated TOC slug). The stale-anchor hard-fail was verified by drill and reverted.

### The tree, fixed

- **ROADMAP**: `v0.10.x` closed `SHIPPED` (16 published releases; the ghost tags documented); v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12 corrected; v0.10.10 / v0.10.13 / v0.10.16 / v0.10.17 backfilled from their CHANGELOG blocks; **v0.11 promoted to the open-cycle h2** linking its plan.
- **`docs/releases/plans/v0.11-plan.md`** — the ratified cycle plan: wave sequencing (the OSCAL 1.2.2 evaluation gates every OSCAL emitter), the cycle-hygiene track (including the 2026-07 practice-delta adoptions), and the medical-device row split.
- **Lesson 11** in `docs/engineering-practices.md` — *a doc's currency claim is a gate or it is a lie* — plus the quarterly practice-delta cadence in §Research rigor; the safeguards-resweep issue template carries the new item (next due 2026-10-01).

## Validation

- Full gate suite: **all 13 checks green** (pytest / mypy strict / ruff / osv / parity + the 8-check consistency scope with `roadmap_currency` included).
- `audit_workflow_permissions.py --strict`: PASS (29 workflows).
- Pre-push hook: all 16 Layer-2 checks green on push.
- Residual A4 advisory (v0.10.0–v0.10.4 predate the per-patch entry convention) is accepted; backfill optional.
