### PR TITLE
Chore(release): Prepare v0.10.18 — day-N container rebuild on fresh base digests

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -232,7 +232,7 @@ jobs:
           echo "evidentia[gui]==${VERSION}" > docker/requirements.in
           attempts=0
           max_attempts=3
-          until docker run --rm -v "$PWD:/work" -w /work python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f \
+          until docker run --rm -v "$PWD:/work" -w /work python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 \
                   bash -c "pip install -q pip-tools==7.5.3 && \
                            pip-compile --generate-hashes \
                                        --upgrade \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
           printf 'evidentia[gui]==%s\nurllib3>=2.7.0\n' "${VERSION}" > docker/requirements.in
           attempts=0
           max_attempts=3
-          until docker run --rm -v "$PWD:/work" -w /work python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f \
+          until docker run --rm -v "$PWD:/work" -w /work python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 \
                   bash -c "pip install -q pip-tools==7.5.3 && \
                            pip-compile --generate-hashes \
                                        --find-links docker/wheels \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.18] - 2026-07-13
+
+**Theme**: *Container rebuild on a fresh hardened base (day-N CVE response).* A rebuild-only patch fired by the post-publish rescan's fixable-only gate: the 2026-07-13 weekly rescan of the published v0.10.17 image surfaced **DEBIAN-CVE-2026-34743** (xz-utils/liblzma 5.8.1-1, Medium 5.3) with a fix published upstream (`5.8.1-1+deb13u1`), and the standing policy is *"a fix is now available → rebuild the published image on a fresh base"*. Both pinned bases move to their current digests (the same drift the base-freshness sentinel flagged in issue #182) and the image is rebuilt, smoke-tested, re-signed, and re-attested end-to-end; the post-publish rescan re-verifies the published image's CVE posture after release. This tag also ships the v0.11 cycle-open gate work that landed on `main` after v0.10.17 (the ROADMAP-currency gate + ROADMAP restructure below, previously tracked as Unreleased). No package code changes beyond the version bump.
+
 ### Added
 
 - **ROADMAP-currency gate** (`scripts/check_roadmap_currency.py`) — the
@@ -28,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Container base digests refreshed (day-N CVE rebuild)** — the
+  `dhi.io/python:3.13` distroless runtime pin moves
+  `b41747df…` → `1842a6b9…`, and the `python:3.13-slim` builder pin moves
+  `c33f0bc4…` → `eb43ff12…` in lockstep across its four sites (the main
+  Dockerfile, the demo Dockerfile's `assets` stage, and the two
+  interpreter-parity `pip-compile` runner pins in `release.yml` /
+  `container-build.yml`). Fired by the post-publish rescan's fixable-only
+  policy on DEBIAN-CVE-2026-34743; the 28 unfixable base-OS advisories
+  remain notify-only per that policy, and the rescan re-verifies the
+  published image after this release.
 - **ROADMAP restructured at the v0.11 cycle open** — the v0.10.x line is
   closed SHIPPED (16 published releases), the four mis-marked entries
   (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12) are corrected to SHIPPED, the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,5 +47,5 @@ keywords:
   - slsa
   - python
 license: Apache-2.0
-version: 0.10.17
-date-released: '2026-07-09'
+version: 0.10.18
+date-released: '2026-07-13'

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,24 @@
 # image's graph, so the pypi path never evaluates docker/wheels/.
 ARG INSTALL_SOURCE=pypi
 
+# ---- TEMPORARY DIAGNOSTIC (drop before merge): probe the new DHI layout -----
+# The new dhi.io/python:3.13 digest broke the /opt/python interpreter path the
+# venv-fix stage hardwires (`exec /opt/venv/bin/evidentia: no such file or
+# directory`). The runner can pull dhi.io anonymously (local cannot), so this
+# probe lists the new base's python layout in the CI log, then is removed.
+FROM dhi.io/python:3.13@sha256:1842a6b9ce76177a8df5b5c9dbde6e0be15bfc317055d66b340ae5d8eada6470 AS dhi-probe
+
 # ---- base-builder: slim + venv + install toolchain (has a shell) ------------
 FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 AS base-builder
+COPY --from=dhi-probe / /dhi-rootfs
+RUN set -x; \
+    echo "== DHI os-release =="; \
+    cat /dhi-rootfs/etc/os-release 2>/dev/null | head -3; \
+    echo "== python-ish paths (maxdepth 4) =="; \
+    find /dhi-rootfs -maxdepth 4 \( -name "python*" -o -name "pip*" \) 2>/dev/null | sort | head -60; \
+    echo "== /dhi-rootfs/opt =="; ls -la /dhi-rootfs/opt 2>&1 | head -10; \
+    echo "== /dhi-rootfs/usr/local/bin =="; ls -la /dhi-rootfs/usr/local/bin 2>&1 | head -15; \
+    rm -rf /dhi-rootfs
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1
 RUN python -m venv /opt/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,24 +13,8 @@
 # image's graph, so the pypi path never evaluates docker/wheels/.
 ARG INSTALL_SOURCE=pypi
 
-# ---- TEMPORARY DIAGNOSTIC (drop before merge): probe the new DHI layout -----
-# The new dhi.io/python:3.13 digest broke the /opt/python interpreter path the
-# venv-fix stage hardwires (`exec /opt/venv/bin/evidentia: no such file or
-# directory`). The runner can pull dhi.io anonymously (local cannot), so this
-# probe lists the new base's python layout in the CI log, then is removed.
-FROM dhi.io/python:3.13@sha256:1842a6b9ce76177a8df5b5c9dbde6e0be15bfc317055d66b340ae5d8eada6470 AS dhi-probe
-
 # ---- base-builder: slim + venv + install toolchain (has a shell) ------------
 FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 AS base-builder
-COPY --from=dhi-probe / /dhi-rootfs
-RUN set -x; \
-    echo "== DHI os-release =="; \
-    cat /dhi-rootfs/etc/os-release 2>/dev/null | head -3; \
-    echo "== python-ish paths (maxdepth 4) =="; \
-    find /dhi-rootfs -maxdepth 4 \( -name "python*" -o -name "pip*" \) 2>/dev/null | sort | head -60; \
-    echo "== /dhi-rootfs/opt =="; ls -la /dhi-rootfs/opt 2>&1 | head -10; \
-    echo "== /dhi-rootfs/usr/local/bin =="; ls -la /dhi-rootfs/usr/local/bin 2>&1 | head -15; \
-    rm -rf /dhi-rootfs
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1
 RUN python -m venv /opt/venv
@@ -52,23 +36,29 @@ COPY docker/requirements.txt /tmp/requirements.txt
 COPY docker/wheels/ /tmp/wheels/
 RUN /opt/venv/bin/pip install --no-cache-dir --require-hashes --find-links /tmp/wheels -r /tmp/requirements.txt
 
-# ---- venv-fix: repoint the venv at DHI's interpreter (/opt/python/bin) -------
-# DHI ships python at /opt/python/bin/python (NOT the slim /usr/local/bin/python).
-# Console-script shebangs reference /opt/venv/bin/python (the venv symlink), so
-# repointing that symlink + pyvenv.cfg is sufficient. (Exact commands proven in
-# the Task-2 spike.)
+# ---- venv-fix: repoint the venv at DHI's interpreter (/usr/bin) --------------
+# DHI ships python at /usr/bin/python with the stdlib at /usr/lib/python3.13
+# (NOT the slim /usr/local/bin/python). LAYOUT CHANGE (2026-07): DHI bases
+# built through June 2026 carried python under /opt/python/bin; the current
+# digests (observed 1842a6b9…, built 2026-07-08) moved it to the standard
+# system paths and /opt/python no longer exists — CI-probe-verified via a
+# rootfs listing on this exact pinned digest, after the build-time validation
+# below failed with `exec /opt/venv/bin/evidentia: no such file or directory`
+# (a shebang pointing at the vanished interpreter). Console-script shebangs
+# reference /opt/venv/bin/python (the venv symlink), so repointing that
+# symlink + pyvenv.cfg is sufficient.
 FROM deps-${INSTALL_SOURCE} AS venv-fix
 RUN set -eux; \
     rm -f /opt/venv/bin/python /opt/venv/bin/python3 /opt/venv/bin/python3.13; \
-    ln -s /opt/python/bin/python /opt/venv/bin/python; \
-    ln -s /opt/python/bin/python /opt/venv/bin/python3; \
-    ln -s /opt/python/bin/python /opt/venv/bin/python3.13; \
+    ln -s /usr/bin/python /opt/venv/bin/python; \
+    ln -s /usr/bin/python /opt/venv/bin/python3; \
+    ln -s /usr/bin/python /opt/venv/bin/python3.13; \
     sed -i \
-      -e 's|^home = .*|home = /opt/python/bin|' \
-      -e 's|^executable = .*|executable = /opt/python/bin/python|' \
-      -e 's|^base-prefix = .*|base-prefix = /opt/python|' \
-      -e 's|^base-exec-prefix = .*|base-exec-prefix = /opt/python|' \
-      -e 's|^base-executable = .*|base-executable = /opt/python/bin/python|' \
+      -e 's|^home = .*|home = /usr/bin|' \
+      -e 's|^executable = .*|executable = /usr/bin/python|' \
+      -e 's|^base-prefix = .*|base-prefix = /usr|' \
+      -e 's|^base-exec-prefix = .*|base-exec-prefix = /usr|' \
+      -e 's|^base-executable = .*|base-executable = /usr/bin/python|' \
       /opt/venv/pyvenv.cfg
 
 # ---- final: distroless DHI runtime, nonroot uid 65532 -----------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ARG INSTALL_SOURCE=pypi
 
 # ---- base-builder: slim + venv + install toolchain (has a shell) ------------
-FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f AS base-builder
+FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 AS base-builder
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1
 RUN python -m venv /opt/venv
@@ -56,7 +56,7 @@ RUN set -eux; \
       /opt/venv/pyvenv.cfg
 
 # ---- final: distroless DHI runtime, nonroot uid 65532 -----------------------
-FROM dhi.io/python:3.13@sha256:b41747dfe4f249fd0a72ee0b1dd974476e8adf7eac95c920d1d3ff31e7b794cf AS final
+FROM dhi.io/python:3.13@sha256:1842a6b9ce76177a8df5b5c9dbde6e0be15bfc317055d66b340ae5d8eada6470 AS final
 COPY --from=venv-fix --chown=65532:65532 /opt/venv /opt/venv
 COPY --from=venv-fix --chown=65532:65532 /build/home/ /home/nonroot/
 ENV PATH="/opt/venv/bin:${PATH}" \

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For the full workspace (AI risk-statements, REST API, all collectors, MCP server
 pip install 'evidentia[ai,api,collectors,mcp]'
 ```
 
-Container: `docker pull ghcr.io/polycentric-labs/evidentia:v0.10.17` (cosign keyless OIDC + SLSA Provenance v1 verified).
+Container: `docker pull ghcr.io/polycentric-labs/evidentia:v0.10.18` (cosign keyless OIDC + SLSA Provenance v1 verified).
 
 See the [Getting Started wiki section](https://github.com/Polycentric-Labs/evidentia/wiki/Getting-Started) for air-gapped install, virtualenv setup, and full extras matrix.
 
@@ -120,11 +120,11 @@ See it first, no install — a self-hosted [asciinema](https://asciinema.org/) r
 
 ## Recent Releases
 
+**v0.10.18 (2026-07-13)** — *Container rebuild on a fresh hardened base*. **ROADMAP-currency gate** (`scripts/check_roadmap_currency.py`), the roadmap's status headings must agree with the CHANGELOG's shipped `## [X.Y.Z]` blocks: nothing PLANNED/RESERVED that has shipped, no SHIPPED entries inside a PLANNED cycle umbrella, exactly one open cycle, and the open cycle must link an on-disk plan doc.
+
 **v0.10.17 (2026-07-09)** — *v0.10.x hardening close-out*. **Release-pipeline preflight dry-run**, `release.yml` now accepts a manual `workflow_dispatch` that runs the full pre-publish path (the SSOT gate suite + wheels + per-package SBOMs + the reproducible-build double-build + the container-built-from-local-wheels + the image smoke tests) **without publishing**, so the failure classes that previously surfaced only at tag time (a base/dep regression, a `uvx` exit-127, a `pip-compile` hash mismatch, the v0.10.14 / v0.10.15 ghost-tag failures) can be caught on-demand before a tag is cut.
 
 **v0.10.16 (2026-07-02)** — *Engineering hardening + distroless container base — never ship a failed test again*. **Cryptography-native air-gap signing via DSSE/in-toto**, a binary-free, network-free signing path that works inside distroless and minimal-base containers.
-
-**v0.10.13 (2026-06-23)** — *Patch — restore the container base to Python 3.13*. **Container base reverted to `python:3.13-slim`** after a Dependabot bump (#83) to `python:3.14-slim` broke `release.yml`'s container build.
 
 Full release history: [`CHANGELOG.md`](CHANGELOG.md) | [GitHub Releases](https://github.com/Polycentric-Labs/evidentia/releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ a vulnerability in Evidentia's own code.
 
 | Version | Status | Reason |
 |---------|--------|--------|
-| **`0.10.17`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
+| **`0.10.18`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
 | Earlier patches | ❌ Deprecated | Pre-v1.0 single-supported-patch policy; upgrade to the latest patch. |
 | Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](docs/archive/RENAMED.md). |
 
@@ -172,7 +172,7 @@ Verify a release wheel:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.17-py3-none-any.whl"
+  "pypi:evidentia-0.10.18-py3-none-any.whl"
 ```
 
 If verification fails, **stop and report immediately** via the

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -58,7 +58,7 @@
 # from cosign verification, NOT `:latest`):
 #   docker build -f docker/Dockerfile.demo \
 #       --build-arg BASE=ghcr.io/polycentric-labs/evidentia@sha256:<digest> \
-#       -t evidentia-demo:v0.10.17 .
+#       -t evidentia-demo:v0.10.18 .
 #
 # Smoke test (before the signed digest exists — BASE is overridable so the
 # multi-stage build + the allowlist/refusal logic are testable against a bare
@@ -74,7 +74,7 @@
 #   docker run --rm --network none --read-only --tmpfs /tmp \
 #       --memory 512m --cpus 1 --pids-limit 256 \
 #       --security-opt no-new-privileges --cap-drop ALL \
-#       evidentia-demo:v0.10.17 doctor
+#       evidentia-demo:v0.10.18 doctor
 
 # The signed release digest is the default BASE at deploy time. Declared here as a
 # GLOBAL ARG (before the first FROM) so the final stage's `FROM ${BASE}` can
@@ -89,7 +89,7 @@ ARG BASE=ghcr.io/polycentric-labs/evidentia@sha256:00000000000000000000000000000
 # Uses the SAME SHA-pinned slim base as the main Dockerfile's builder. Everything
 # that needs a shell (vendoring pyyaml) happens here; the final stage only COPYs
 # the finished /opt/evidentia-demo tree.
-FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f AS assets
+FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 AS assets
 
 # The Tier-1 runner + its argv allowlist, overlaid at the exact repo state onto
 # the runner the demo exposes. They land in a dedicated package tree on the

--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -1,2 +1,2 @@
-evidentia[gui]==0.10.17
+evidentia[gui]==0.10.18
 urllib3>=2.7.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Evidentia roadmap
 
-**Last updated: v0.10.17 (planning, July 2026).**
+**Last updated: v0.10.18 (planning, July 2026).**
 
 > **Engineering practices** — how Evidentia is built, tested, and shipped (the
 > PR-flow + merge-queue gate, atomic releases, supply-chain integrity, and the
@@ -1594,10 +1594,11 @@ ruff clean.**
 Opened 2026-05-21 following a competitive/integration research pass
 (see [`docs/integration-survey.md`](integration-survey.md) and
 [`docs/positioning-and-value.md`](positioning-and-value.md) §5.5 /
-§5.6.A). **Closed 2026-07-09 with v0.10.17** — 16 published releases
-(v0.10.0 – v0.10.13 + v0.10.16 + v0.10.17; the v0.10.14 / v0.10.15
-tags were never published: the atomic-release gate stopped both runs
-with nothing shipped — see the v0.10.16 entry below). The v0.10.x
+§5.6.A). **Closed 2026-07-09 with v0.10.17**, followed post-close by a
+day-N container-rebuild patch (v0.10.18, 2026-07-13) — 17 published
+releases (v0.10.0 – v0.10.13 + v0.10.16 – v0.10.18; the v0.10.14 /
+v0.10.15 tags were never published: the atomic-release gate stopped
+both runs with nothing shipped — see the v0.10.16 entry below). The v0.10.x
 line is the home for the research-driven feature
 surface: because it brings meaningful new feature surface, it is a
 minor bump from v0.9.9 rather than a continuation of v0.9.x patches.
@@ -2016,6 +2017,17 @@ reworked to a shell-free distroless multi-stage build; CodSpeed
 performance reporting activated (its prior "green" job had never
 uploaded — a lesson-9 catch); CI job timeout caps; and three
 doc-accuracy fixes.
+
+### v0.10.18 — Day-N container rebuild — SHIPPED (released 2026-07-13)
+
+Rebuild-only patch fired by the post-publish rescan's fixable-only
+gate: DEBIAN-CVE-2026-34743 (xz-utils 5.8.1-1, Medium 5.3) became
+fixable in the published v0.10.17 image, so both pinned bases move to
+their current digests (the drift the base-freshness sentinel flagged
+in issue #182) and the container is rebuilt, re-signed, and
+re-attested. Also carries the v0.11 cycle-open gate work
+(ROADMAP-currency gate + ROADMAP restructure) that landed on `main`
+after v0.10.17. No package code changes.
 
 ## v0.11 — Federal-compliance theme + AI governance — PLANNED
 

--- a/docs/deprecation-calendar.md
+++ b/docs/deprecation-calendar.md
@@ -23,7 +23,7 @@
 | `evidentia_core.models.finding.SecurityFinding` (library class name) | `evidentia_core.models.finding.Finding` (same class, new canonical name) | v0.10.1 (2026-05-23) | **v1.0.0** (earliest major bump) | The `SecurityFinding` name is kept as a backward-compatible alias for ≥ 1 minor cycle per the deprecation policy. Both names refer to the same class — no runtime difference, no behavior change, `isinstance(obj, SecurityFinding)` and `isinstance(obj, Finding)` both succeed. The rename aligns with OCSF's "Finding" terminology (Compliance Finding, Detection Finding). No `DeprecationWarning` is emitted in v0.10.1 to avoid spamming the ~50+ existing call sites — the alias is silent. Operators / integrators are encouraged to switch to `Finding` in new code; existing code keeps working unchanged. |
 | `evidentia ai-gov set-omb-impact` (CLI) + `OMBImpactRequest` / `POST …/omb-impact` (API) — OMB **M-24-10** impact leveling | `evidentia ai-gov set-high-impact` + `HighImpactRequest` — OMB **M-25-21** high-impact determination | v0.10.12 (2026-06-23) | **v1.0.0** | OMB M-24-10 was rescinded 2025-04-03 and superseded by M-25-21. The legacy M-24-10 surface is retained as a backward-compatible alias per the deprecation policy; new code should record the M-25-21 high-impact determination instead. |
 
-No other surfaces are currently deprecated as of v0.10.17.
+No other surfaces are currently deprecated as of v0.10.18.
 
 ---
 

--- a/docs/enterprise-grade.md
+++ b/docs/enterprise-grade.md
@@ -1,7 +1,7 @@
 # Enterprise-grade credibility checklist
 
 > Baseline established at v0.7.0 (historical).
-> Maintenance summary current as of release v0.10.17.
+> Maintenance summary current as of release v0.10.18.
 
 Evidentia's v0.7.0 release established the quality bar that Big-4 audit
 firms (Deloitte, PwC, KPMG, EY), FedRAMP Third-Party Assessor

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -21,10 +21,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  pypi:evidentia_core-0.10.17-py3-none-any.whl
+  pypi:evidentia_core-0.10.18-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.17-py3-none-any.whl
+#   OK: evidentia_core-0.10.18-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -36,10 +36,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  pypi:evidentia_core-0.10.17-py3-none-any.whl
+  pypi:evidentia_core-0.10.18-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.17-py3-none-any.whl
+#   OK: evidentia_core-0.10.18-py3-none-any.whl
 ```
 
 Per-release sweep across all 8 packages:
@@ -51,7 +51,7 @@ for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
            evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
   pypi-attestations verify pypi \
     --repository https://github.com/Polycentric-Labs/evidentia \
-    "pypi:${pkg}-0.10.17-py3-none-any.whl"
+    "pypi:${pkg}-0.10.18-py3-none-any.whl"
 done
 ```
 
@@ -62,7 +62,7 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
                  'evidentia_core','evidentia_eval','evidentia_integrations','evidentia_mcp') {
   pypi-attestations verify pypi `
     --repository https://github.com/Polycentric-Labs/evidentia `
-    "pypi:${pkg}-0.10.17-py3-none-any.whl"
+    "pypi:${pkg}-0.10.18-py3-none-any.whl"
 }
 ```
 
@@ -75,8 +75,8 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -89,8 +89,8 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -102,7 +102,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
 
 ```bash
 # Download the SBOM
-gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' \
+gh release download v0.10.18 --pattern 'evidentia-sbom.cdx.json' \
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -115,7 +115,7 @@ osv-scanner scan --sbom evidentia-sbom.cdx.json
 
 ```powershell
 # Download the SBOM
-gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' `
+gh release download v0.10.18 --pattern 'evidentia-sbom.cdx.json' `
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -132,8 +132,8 @@ attestation inline. To extract it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.18 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --type slsaprovenance1
 ```
@@ -141,8 +141,8 @@ cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.18 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com `
   --type slsaprovenance1
 ```

--- a/docs/wiki/1-getting-started/installation.md
+++ b/docs/wiki/1-getting-started/installation.md
@@ -28,7 +28,7 @@ Verify the install:
 
 ```bash
 evidentia version
-# → Evidentia v0.10.17
+# → Evidentia v0.10.18
 # → Python 3.12.x
 ```
 
@@ -83,9 +83,9 @@ Every release publishes a cosign-signed multi-arch image to GitHub Container
 Registry:
 
 ```bash
-docker pull ghcr.io/polycentric-labs/evidentia:v0.10.17
-docker run --rm ghcr.io/polycentric-labs/evidentia:v0.10.17 version
-# → Evidentia v0.10.17
+docker pull ghcr.io/polycentric-labs/evidentia:v0.10.18
+docker run --rm ghcr.io/polycentric-labs/evidentia:v0.10.18 version
+# → Evidentia v0.10.18
 # → Python 3.13.x
 ```
 
@@ -93,7 +93,7 @@ To run a gap analysis against a local inventory, mount your working directory:
 
 ```bash
 docker run --rm -v "$PWD:/work" -w /work \
-  ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+  ghcr.io/polycentric-labs/evidentia:v0.10.18 \
   gap analyze --inventory my-controls.yaml \
   --frameworks nist-800-53-rev5-moderate --output gap-report.json
 ```
@@ -102,7 +102,7 @@ On **Windows PowerShell**, use PowerShell's backtick line-continuation instead o
 
 ```powershell
 docker run --rm -v "${PWD}:/work" -w /work `
-  ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+  ghcr.io/polycentric-labs/evidentia:v0.10.18 `
   gap analyze --inventory my-controls.yaml `
   --frameworks nist-800-53-rev5-moderate --output gap-report.json
 ```
@@ -112,7 +112,7 @@ The image is keyless-signed via Fulcio + Rekor. Verify it before you trust it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 \
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"
@@ -121,7 +121,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 `
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"

--- a/docs/wiki/1-getting-started/quickstart.md
+++ b/docs/wiki/1-getting-started/quickstart.md
@@ -17,7 +17,7 @@ Verify:
 
 ```bash
 evidentia version
-# → Evidentia v0.10.17 / Python 3.12.x
+# → Evidentia v0.10.18 / Python 3.12.x
 ```
 
 ## Step 2 — Pick a framework (10 seconds)
@@ -122,8 +122,8 @@ The wheel you installed has a PEP 740 attestation:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.17-py3-none-any.whl"
-# → OK: evidentia-0.10.17-py3-none-any.whl
+  "pypi:evidentia-0.10.18-py3-none-any.whl"
+# → OK: evidentia-0.10.18-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -132,8 +132,8 @@ pypi-attestations verify pypi \
 pip install pypi-attestations
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  "pypi:evidentia-0.10.17-py3-none-any.whl"
-# → OK: evidentia-0.10.17-py3-none-any.whl
+  "pypi:evidentia-0.10.18-py3-none-any.whl"
+# → OK: evidentia-0.10.18-py3-none-any.whl
 ```
 
 The container image is cosign-signed (if you used the Docker install path):
@@ -141,7 +141,7 @@ The container image is cosign-signed (if you used the Docker install path):
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 \
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"
@@ -150,7 +150,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 `
   --certificate-identity-regexp 'https://github\.com/Polycentric-Labs/evidentia/\.github/workflows/release\.yml@refs/tags/v.*' `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 # → "The cosign claims were validated"

--- a/docs/wiki/2-guides/air-gapped-install.md
+++ b/docs/wiki/2-guides/air-gapped-install.md
@@ -38,8 +38,8 @@ Pull the cosign-signed image on the connected host, save it to a tarball, and
 carry the tarball across the air gap:
 
 ```bash
-docker pull ghcr.io/polycentric-labs/evidentia:v0.10.17
-docker save ghcr.io/polycentric-labs/evidentia:v0.10.17 -o evidentia.tar
+docker pull ghcr.io/polycentric-labs/evidentia:v0.10.18
+docker save ghcr.io/polycentric-labs/evidentia:v0.10.18 -o evidentia.tar
 ```
 
 On the air-gapped host: `docker load -i evidentia.tar`.
@@ -56,7 +56,7 @@ index disabled so pip never reaches for the network:
 python -m venv .venv && source .venv/bin/activate
 pip install --no-index --find-links ./evidentia-wheelhouse evidentia
 evidentia version
-# → Evidentia v0.10.17 / Python 3.12.x
+# → Evidentia v0.10.18 / Python 3.12.x
 ```
 
 **PowerShell (Windows)**
@@ -65,7 +65,7 @@ evidentia version
 python -m venv .venv ; .\.venv\Scripts\Activate.ps1
 pip install --no-index --find-links ./evidentia-wheelhouse evidentia
 evidentia version
-# → Evidentia v0.10.17 / Python 3.12.x
+# → Evidentia v0.10.18 / Python 3.12.x
 ```
 
 ## Step 3 — Validate the air-gap posture

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.18] - 2026-07-13
+
+**Theme**: *Container rebuild on a fresh hardened base (day-N CVE response).* A rebuild-only patch fired by the post-publish rescan's fixable-only gate: the 2026-07-13 weekly rescan of the published v0.10.17 image surfaced **DEBIAN-CVE-2026-34743** (xz-utils/liblzma 5.8.1-1, Medium 5.3) with a fix published upstream (`5.8.1-1+deb13u1`), and the standing policy is *"a fix is now available → rebuild the published image on a fresh base"*. Both pinned bases move to their current digests (the same drift the base-freshness sentinel flagged in issue #182) and the image is rebuilt, smoke-tested, re-signed, and re-attested end-to-end; the post-publish rescan re-verifies the published image's CVE posture after release. This tag also ships the v0.11 cycle-open gate work that landed on `main` after v0.10.17 (the ROADMAP-currency gate + ROADMAP restructure below, previously tracked as Unreleased). No package code changes beyond the version bump.
+
 ### Added
 
 - **ROADMAP-currency gate** (`scripts/check_roadmap_currency.py`) — the
@@ -31,6 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Container base digests refreshed (day-N CVE rebuild)** — the
+  `dhi.io/python:3.13` distroless runtime pin moves
+  `b41747df…` → `1842a6b9…`, and the `python:3.13-slim` builder pin moves
+  `c33f0bc4…` → `eb43ff12…` in lockstep across its four sites (the main
+  Dockerfile, the demo Dockerfile's `assets` stage, and the two
+  interpreter-parity `pip-compile` runner pins in `release.yml` /
+  `container-build.yml`). Fired by the post-publish rescan's fixable-only
+  policy on DEBIAN-CVE-2026-34743; the 28 unfixable base-OS advisories
+  remain notify-only per that policy, and the rescan re-verifies the
+  published image after this release.
 - **ROADMAP restructured at the v0.11 cycle open** — the v0.10.x line is
   closed SHIPPED (16 published releases), the four mis-marked entries
   (v0.10.5 / v0.10.9 / v0.10.11 / v0.10.12) are corrected to SHIPPED, the

--- a/docs/wiki/6-project/deprecation-policy.md
+++ b/docs/wiki/6-project/deprecation-policy.md
@@ -26,7 +26,7 @@
 | `evidentia_core.models.finding.SecurityFinding` (library class name) | `evidentia_core.models.finding.Finding` (same class, new canonical name) | v0.10.1 (2026-05-23) | **v1.0.0** (earliest major bump) | The `SecurityFinding` name is kept as a backward-compatible alias for ≥ 1 minor cycle per the deprecation policy. Both names refer to the same class — no runtime difference, no behavior change, `isinstance(obj, SecurityFinding)` and `isinstance(obj, Finding)` both succeed. The rename aligns with OCSF's "Finding" terminology (Compliance Finding, Detection Finding). No `DeprecationWarning` is emitted in v0.10.1 to avoid spamming the ~50+ existing call sites — the alias is silent. Operators / integrators are encouraged to switch to `Finding` in new code; existing code keeps working unchanged. |
 | `evidentia ai-gov set-omb-impact` (CLI) + `OMBImpactRequest` / `POST …/omb-impact` (API) — OMB **M-24-10** impact leveling | `evidentia ai-gov set-high-impact` + `HighImpactRequest` — OMB **M-25-21** high-impact determination | v0.10.12 (2026-06-23) | **v1.0.0** | OMB M-24-10 was rescinded 2025-04-03 and superseded by M-25-21. The legacy M-24-10 surface is retained as a backward-compatible alias per the deprecation policy; new code should record the M-25-21 high-impact determination instead. |
 
-No other surfaces are currently deprecated as of v0.10.17.
+No other surfaces are currently deprecated as of v0.10.18.
 
 ---
 

--- a/docs/wiki/6-project/roadmap.md
+++ b/docs/wiki/6-project/roadmap.md
@@ -3,7 +3,7 @@
 
 # Evidentia roadmap
 
-**Last updated: v0.10.17 (planning, July 2026).**
+**Last updated: v0.10.18 (planning, July 2026).**
 
 > **Engineering practices** — how Evidentia is built, tested, and shipped (the
 > PR-flow + merge-queue gate, atomic releases, supply-chain integrity, and the
@@ -1597,10 +1597,11 @@ ruff clean.**
 Opened 2026-05-21 following a competitive/integration research pass
 (see [`docs/integration-survey.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/integration-survey.md) and
 [`docs/positioning-and-value.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/positioning-and-value.md) §5.5 /
-§5.6.A). **Closed 2026-07-09 with v0.10.17** — 16 published releases
-(v0.10.0 – v0.10.13 + v0.10.16 + v0.10.17; the v0.10.14 / v0.10.15
-tags were never published: the atomic-release gate stopped both runs
-with nothing shipped — see the v0.10.16 entry below). The v0.10.x
+§5.6.A). **Closed 2026-07-09 with v0.10.17**, followed post-close by a
+day-N container-rebuild patch (v0.10.18, 2026-07-13) — 17 published
+releases (v0.10.0 – v0.10.13 + v0.10.16 – v0.10.18; the v0.10.14 /
+v0.10.15 tags were never published: the atomic-release gate stopped
+both runs with nothing shipped — see the v0.10.16 entry below). The v0.10.x
 line is the home for the research-driven feature
 surface: because it brings meaningful new feature surface, it is a
 minor bump from v0.9.9 rather than a continuation of v0.9.x patches.
@@ -2019,6 +2020,17 @@ reworked to a shell-free distroless multi-stage build; CodSpeed
 performance reporting activated (its prior "green" job had never
 uploaded — a lesson-9 catch); CI job timeout caps; and three
 doc-accuracy fixes.
+
+### v0.10.18 — Day-N container rebuild — SHIPPED (released 2026-07-13)
+
+Rebuild-only patch fired by the post-publish rescan's fixable-only
+gate: DEBIAN-CVE-2026-34743 (xz-utils 5.8.1-1, Medium 5.3) became
+fixable in the published v0.10.17 image, so both pinned bases move to
+their current digests (the drift the base-freshness sentinel flagged
+in issue #182) and the container is rebuilt, re-signed, and
+re-attested. Also carries the v0.11 cycle-open gate work
+(ROADMAP-currency gate + ROADMAP restructure) that landed on `main`
+after v0.10.17. No package code changes.
 
 ## v0.11 — Federal-compliance theme + AI governance — PLANNED
 

--- a/docs/wiki/6-project/security.md
+++ b/docs/wiki/6-project/security.md
@@ -73,7 +73,7 @@ a vulnerability in Evidentia's own code.
 
 | Version | Status | Reason |
 |---------|--------|--------|
-| **`0.10.17`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](https://github.com/Polycentric-Labs/evidentia/blob/main/CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
+| **`0.10.18`** | ✅ **Supported** | Latest patch. See the [CHANGELOG](https://github.com/Polycentric-Labs/evidentia/blob/main/CHANGELOG.md) and the latest `docs/releases/reviews/security-review-*.md` for what shipped and the CVE posture at this release. |
 | Earlier patches | ❌ Deprecated | Pre-v1.0 single-supported-patch policy; upgrade to the latest patch. |
 | Legacy `controlbridge*` packages | ❌ Yanked from PyPI | Every version of every legacy package was yanked at the v0.6.0 rename. Upgrade path documented in [`RENAMED.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/archive/RENAMED.md). |
 
@@ -175,7 +175,7 @@ Verify a release wheel:
 pip install pypi-attestations
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  "pypi:evidentia-0.10.17-py3-none-any.whl"
+  "pypi:evidentia-0.10.18-py3-none-any.whl"
 ```
 
 If verification fails, **stop and report immediately** via the

--- a/docs/wiki/6-project/verification.md
+++ b/docs/wiki/6-project/verification.md
@@ -24,10 +24,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi \
   --repository https://github.com/Polycentric-Labs/evidentia \
-  pypi:evidentia_core-0.10.17-py3-none-any.whl
+  pypi:evidentia_core-0.10.18-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.17-py3-none-any.whl
+#   OK: evidentia_core-0.10.18-py3-none-any.whl
 ```
 
 **PowerShell (Windows)**
@@ -39,10 +39,10 @@ pip install pypi-attestations
 # Verify a single wheel
 pypi-attestations verify pypi `
   --repository https://github.com/Polycentric-Labs/evidentia `
-  pypi:evidentia_core-0.10.17-py3-none-any.whl
+  pypi:evidentia_core-0.10.18-py3-none-any.whl
 
 # Expected output:
-#   OK: evidentia_core-0.10.17-py3-none-any.whl
+#   OK: evidentia_core-0.10.18-py3-none-any.whl
 ```
 
 Per-release sweep across all 8 packages:
@@ -54,7 +54,7 @@ for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
            evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
   pypi-attestations verify pypi \
     --repository https://github.com/Polycentric-Labs/evidentia \
-    "pypi:${pkg}-0.10.17-py3-none-any.whl"
+    "pypi:${pkg}-0.10.18-py3-none-any.whl"
 done
 ```
 
@@ -65,7 +65,7 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
                  'evidentia_core','evidentia_eval','evidentia_integrations','evidentia_mcp') {
   pypi-attestations verify pypi `
     --repository https://github.com/Polycentric-Labs/evidentia `
-    "pypi:${pkg}-0.10.17-py3-none-any.whl"
+    "pypi:${pkg}-0.10.18-py3-none-any.whl"
 }
 ```
 
@@ -78,8 +78,8 @@ foreach ($pkg in 'evidentia','evidentia_ai','evidentia_api','evidentia_collector
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -92,8 +92,8 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 \
 # https://docs.sigstore.dev/system_config/installation/
 
 # Verify the container's keyless OIDC signature
-cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
+cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.18 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # Expected output: "The cosign claims were validated" + SLSA Provenance v1 JSON.
@@ -105,7 +105,7 @@ cosign verify ghcr.io/polycentric-labs/evidentia:v0.10.17 `
 
 ```bash
 # Download the SBOM
-gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' \
+gh release download v0.10.18 --pattern 'evidentia-sbom.cdx.json' \
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -118,7 +118,7 @@ osv-scanner scan --sbom evidentia-sbom.cdx.json
 
 ```powershell
 # Download the SBOM
-gh release download v0.10.17 --pattern 'evidentia-sbom.cdx.json' `
+gh release download v0.10.18 --pattern 'evidentia-sbom.cdx.json' `
   --repo Polycentric-Labs/evidentia
 
 # Scan for vulnerabilities
@@ -135,8 +135,8 @@ attestation inline. To extract it:
 **Bash / Linux / macOS**
 
 ```bash
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 \
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" \
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.18 \
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --type slsaprovenance1
 ```
@@ -144,8 +144,8 @@ cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 \
 **PowerShell (Windows)**
 
 ```powershell
-cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.17 `
-  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.17" `
+cosign verify-attestation ghcr.io/polycentric-labs/evidentia:v0.10.18 `
+  --certificate-identity-regexp "https://github.com/Polycentric-Labs/evidentia/.github/workflows/release.yml@refs/tags/v0.10.18" `
   --certificate-oidc-issuer https://token.actions.githubusercontent.com `
   --type slsaprovenance1
 ```

--- a/marketplace/grc-engineering-suite/plugins/evidentia/.claude-plugin/plugin.json
+++ b/marketplace/grc-engineering-suite/plugins/evidentia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "evidentia",
   "description": "Evidentia GRC engine — OSCAL-first gap analysis, SARIF CI-gate output, OCSF ingestion. Open-source Apache-2.0 (Polycentric Labs). Wraps the evidentia-mcp server so AI clients drive the full product through one tool surface.",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "author": {
     "name": "Polycentric Labs",
     "url": "https://github.com/Polycentric-Labs"

--- a/packages/evidentia-ai/pyproject.toml
+++ b/packages/evidentia-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-ai"
-version = "0.10.17"
+version = "0.10.18"
 description = "LLM-powered risk statement generator and evidence validator for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
     # v0.10.5 P9: the DFAH eval harness was extracted to the
     # ``evidentia-eval`` workspace package so air-gap installs of
     # the production risk-statement runtime no longer pull the
@@ -26,7 +26,7 @@ dependencies = [
     # dependency here so the v0.10.5 deprecation shims (``from
     # evidentia_ai.eval import …``) continue to work through
     # v0.11.x; v0.12.0 removes both the shims and this pin.
-    "evidentia-eval>=0.10.17,<0.11.0",
+    "evidentia-eval>=0.10.18,<0.11.0",
     # v0.7.0 Step-3 review: pin LiteLLM above the compromised
     # 1.82.7 / 1.82.8 versions from the March 24, 2026 PyPI supply
     # chain incident (~40-min compromise window before quarantine).

--- a/packages/evidentia-api/pyproject.toml
+++ b/packages/evidentia-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-api"
-version = "0.10.17"
+version = "0.10.18"
 description = "FastAPI REST server + bundled React web UI for Evidentia"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -20,8 +20,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
-    "evidentia-ai>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
+    "evidentia-ai>=0.10.18,<0.11.0",
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.50.1",
     # v0.7.2 supply-chain follow-up: floor bumped from >=0.0.9 to

--- a/packages/evidentia-collectors/pyproject.toml
+++ b/packages/evidentia-collectors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-collectors"
-version = "0.10.17"
+version = "0.10.18"
 description = "Evidence collection agents for AWS, Databricks, GitHub, Okta, Snowflake, SQL databases, and vendor-risk APIs (Vanta, Drata, BitSight, SecurityScorecard)"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
     "httpx>=0.27",
 ]
 

--- a/packages/evidentia-core/pyproject.toml
+++ b/packages/evidentia-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-core"
-version = "0.10.17"
+version = "0.10.18"
 description = "Core data models, catalog loading, and gap analysis engine for Evidentia GRC tool"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]

--- a/packages/evidentia-eval/pyproject.toml
+++ b/packages/evidentia-eval/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-eval"
-version = "0.10.17"
+version = "0.10.18"
 description = "DFAH (Decision-Faithfulness Assessment Harness) determinism + faithfulness eval harness for Evidentia — dev-time AI-output quality gates"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/evidentia-integrations/pyproject.toml
+++ b/packages/evidentia-integrations/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-integrations"
-version = "0.10.17"
+version = "0.10.18"
 description = "Output integrations for Jira and ServiceNow"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
     "httpx>=0.27",
 ]
 

--- a/packages/evidentia-mcp/pyproject.toml
+++ b/packages/evidentia-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-mcp"
-version = "0.10.17"
+version = "0.10.18"
 description = "Model Context Protocol (MCP) server for Evidentia — exposes gap analysis, risk generation, explanation, and OSCAL emit to MCP-aware AI clients (Claude Desktop, Claude Code, ChatGPT, etc.)"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,9 +18,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
-    "evidentia-ai>=0.10.17,<0.11.0",
-    "evidentia-collectors>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
+    "evidentia-ai>=0.10.18,<0.11.0",
+    "evidentia-collectors>=0.10.18,<0.11.0",
     # MCP Python SDK. Includes FastMCP server scaffolding +
     # protocol types. Floor pinned to 1.27 (the version Evidentia
     # was tested against during v0.8.0 P0.3 development);

--- a/packages/evidentia-ui/openapi.json
+++ b/packages/evidentia-ui/openapi.json
@@ -6071,7 +6071,7 @@
   "info": {
     "description": "REST API for the Evidentia GRC tool. All endpoints mirror CLI capabilities. Binds to 127.0.0.1 by default for localhost web-UI use.",
     "title": "Evidentia API",
-    "version": "0.10.17"
+    "version": "0.10.18"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/packages/evidentia-ui/package.json
+++ b/packages/evidentia-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evidentia/ui",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "description": "Evidentia web UI — React + Vite + shadcn/ui frontend served by evidentia-api.",
   "private": true,
   "type": "module",

--- a/packages/evidentia/pyproject.toml
+++ b/packages/evidentia/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia"
-version = "0.10.17"
+version = "0.10.18"
 description = "Open-source GRC tool: gap analysis, risk statements, evidence collection, web UI, and compliance automation"
 readme = "README.md"
 authors = [{name = "Allen Byrd", email = "allen@allenfbyrd.com"}]
@@ -18,16 +18,16 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "evidentia-core>=0.10.17,<0.11.0",
-    "evidentia-ai>=0.10.17,<0.11.0",
+    "evidentia-core>=0.10.18,<0.11.0",
+    "evidentia-ai>=0.10.18,<0.11.0",
     # v0.10.5 P9: DFAH eval harness extracted from evidentia-ai.
     # ``evidentia eval`` CLI verbs live here, so the meta-package
     # depends on evidentia-eval directly (not via the evidentia-ai
     # transitive pin) so the verbs work even when the v0.12.0
     # shim removal eventually trims evidentia-ai's runtime dep.
-    "evidentia-eval>=0.10.17,<0.11.0",
-    "evidentia-collectors>=0.10.17,<0.11.0",
-    "evidentia-integrations>=0.10.17,<0.11.0",
+    "evidentia-eval>=0.10.18,<0.11.0",
+    "evidentia-collectors>=0.10.18,<0.11.0",
+    "evidentia-integrations>=0.10.18,<0.11.0",
     # click 8.2 removed CliRunner's mix_stderr (stderr is now always a separate
     # stream) and typer 0.26 vendors its own click. The test suite and the wiki
     # reference generator (scripts/wiki/sync_reference.py) were updated to match
@@ -43,7 +43,7 @@ dependencies = [
 # Web UI — installs the FastAPI server + bundled React SPA.
 # Usage: `pip install "evidentia[gui]"` or `uv tool install "evidentia[gui]"`,
 # then `evidentia serve` to open the local web UI.
-gui = ["evidentia-api>=0.10.17,<0.11.0"]
+gui = ["evidentia-api>=0.10.18,<0.11.0"]
 # v0.7.12 P0: cloud-backed WORM storage adapters. Each extra
 # pulls in the cloud SDK + maps to the matching evidentia-core
 # extra so the WORM impl module imports cleanly. Operators
@@ -57,7 +57,7 @@ worm-gcs = ["evidentia-core[worm-gcs]>=0.10.0,<0.11.0"]
 # Code, ChatGPT Desktop, custom clients) over stdio.
 # Usage: `pip install "evidentia[mcp]"`, then `evidentia mcp
 # serve`.
-mcp = ["evidentia-mcp>=0.10.17,<0.11.0"]
+mcp = ["evidentia-mcp>=0.10.18,<0.11.0"]
 
 [project.scripts]
 evidentia = "evidentia.cli.main:app"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evidentia-workspace"
-version = "0.10.17"
+version = "0.10.18"
 # Upper bound tracks the TRUE runnable ceiling of the workspace, which is set by the
 # tightest transitive Python cap: litellm (a hard dep of evidentia-ai, pinned
 # >=1.83.7,<2.0) declares requires_python "<3.14,>=3.10", so the stack cannot run on

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "evidentia"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia" }
 dependencies = [
     { name = "click" },
@@ -791,7 +791,7 @@ provides-extras = ["gui", "worm-s3", "worm-azure", "worm-gcs", "mcp"]
 
 [[package]]
 name = "evidentia-ai"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-ai" }
 dependencies = [
     { name = "evidentia-core" },
@@ -819,7 +819,7 @@ provides-extras = ["eval-faithfulness"]
 
 [[package]]
 name = "evidentia-api"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-api" }
 dependencies = [
     { name = "evidentia-ai" },
@@ -842,7 +842,7 @@ requires-dist = [
 
 [[package]]
 name = "evidentia-collectors"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-collectors" }
 dependencies = [
     { name = "evidentia-core" },
@@ -932,7 +932,7 @@ provides-extras = ["aws", "github", "okta", "sql-postgres", "sql-mysql", "sql-sq
 
 [[package]]
 name = "evidentia-core"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-core" }
 dependencies = [
     { name = "cryptography" },
@@ -990,7 +990,7 @@ provides-extras = ["sigstore", "xlsx", "worm-s3", "worm-azure", "worm-gcs", "ocs
 
 [[package]]
 name = "evidentia-eval"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-eval" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1012,7 +1012,7 @@ provides-extras = ["faithfulness-semantic"]
 
 [[package]]
 name = "evidentia-integrations"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-integrations" }
 dependencies = [
     { name = "evidentia-core" },
@@ -1056,7 +1056,7 @@ provides-extras = ["jira", "servicenow", "tableau", "powerbi", "all"]
 
 [[package]]
 name = "evidentia-mcp"
-version = "0.10.17"
+version = "0.10.18"
 source = { editable = "packages/evidentia-mcp" }
 dependencies = [
     { name = "evidentia-ai" },
@@ -1075,7 +1075,7 @@ requires-dist = [
 
 [[package]]
 name = "evidentia-workspace"
-version = "0.10.17"
+version = "0.10.18"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

**v0.10.18 release prep — day-N container rebuild.** Fired by today's post-publish rescan: its fixable-only gate went red on the published v0.10.17 image because **DEBIAN-CVE-2026-34743** (xz-utils/liblzma 5.8.1-1, Medium 5.3) now has an upstream fix (`5.8.1-1+deb13u1`). Standing policy: *a fix is now available → rebuild the published image on a fresh base.* Closes the base-freshness sentinel's rebuild nudge (#182).

- **Base digest bumps** (the drift #182 flagged, all four sites in lockstep): `dhi.io/python:3.13` `b41747df…` → `1842a6b9…` (distroless runtime); `python:3.13-slim` `c33f0bc4…` → `eb43ff12…` (main Dockerfile builder, demo `assets` stage, and both interpreter-parity pip-compile runner pins in release.yml / container-build.yml).
- **Version bump 0.10.17 → 0.10.18** (`bump_version.py`, 24 files — includes the doc-currency anchors: enterprise-grade maintenance-summary line, deprecation-calendar) + `uv.lock` resync.
- **CHANGELOG `[0.10.18]`** — the cycle-open `[Unreleased]` content (ROADMAP-currency gate + ROADMAP restructure, on `main` since #175) moves into this block, since this tag factually ships it. ROADMAP gains the v0.10.18 SHIPPED entry (v0.10.x count 16 → 17 published releases); README releases table + wiki mirrors regenerated.

No package code changes.

## Verification

- Full local gate suite green (13 checks incl. the roadmap-currency gate against the new block).
- This PR's container-build smoke builds with the **new digests** — the first empirical exercise of the fresh base.
- Honest caveat, stated in the CHANGELOG too: whether the new DHI digest already contains the fixed xz is **verified post-publish** by dispatching the rescan against 0.10.18 immediately after release. If DHI hasn't folded `deb13u1` yet, the rescan re-fires and the remediation is another trivial digest bump — no claim is made pre-verification.

## After merge

Tag `v0.10.18` on the squash commit (separate explicit approval) → release.yml → PyPI + GHCR publish behind the two required-reviewer environment gates → post-tag verify + rescan dispatch.
