### PR TITLE
Feat(sbom): NTIA minimum-elements gate + first-party SBOM enrichment (v0.11 H4 + #17)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,22 @@ jobs:
           echo "SBOM generated:"
           ls -la evidentia-sbom.cdx.json
 
+      # #17: cyclonedx-py environment emits the first-party surface anonymous
+      # (no metadata.supplier; evidentia* components carry no purl, so
+      # osv-scanner skips them). Deterministic post-process fills supplier +
+      # publisher + purl + vcs ref for the root and the 8 first-party
+      # components; third-party components are never touched.
+      - name: Enrich release SBOM with first-party identity
+        run: uv run python scripts/enrich_release_sbom.py evidentia-sbom.cdx.json
+
+      # H4: NTIA minimum-elements gate — fail the build (BEFORE any publish)
+      # if the release SBOM is structurally present but useless (missing
+      # supplier / version / unique-ID / dependency graph). First-party
+      # checker because ntia-conformance-checker is SPDX-only (v5.0.3) and
+      # cannot parse CycloneDX; rationale in the script docstring.
+      - name: NTIA minimum-elements gate on the release SBOM
+        run: uv run python scripts/check_sbom_ntia.py evidentia-sbom.cdx.json
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 

--- a/scripts/check_sbom_ntia.py
+++ b/scripts/check_sbom_ntia.py
@@ -1,0 +1,154 @@
+"""NTIA minimum-elements gate for the release-asset CycloneDX SBOM (H4).
+
+Fails the release build when the generated + enriched release SBOM
+(``evidentia-sbom.cdx.json``) is structurally present but useless — the
+"SBOM theater" failure mode: a file ships, but a consumer's tooling can't
+identify who supplied what at which version.
+
+Checks the NTIA minimum elements (NTIA "The Minimum Elements For a
+Software Bill of Materials", 2021-07-12) as they map onto CycloneDX JSON:
+
+HARD (exit 1):
+  1. Author of SBOM data  — ``metadata.supplier.name`` or
+     ``metadata.authors`` non-empty.
+  2. Timestamp            — ``metadata.timestamp`` present.
+  3. Supplier name        — ``metadata.supplier.name`` present, and every
+     FIRST-PARTY (evidentia*) component + the root component carries a
+     ``supplier.name`` (the identity this project actually controls).
+  4. Component name       — every component has ``name``.
+  5. Component version    — every component has ``version``.
+  6. Other unique IDs     — every component has a ``purl``.
+  7. Dependency relationship — top-level ``dependencies`` non-empty.
+
+ADVISORY (reported, never fails):
+  - Third-party components missing ``supplier`` — PyPI packaging metadata
+    carries no supplier identity, so cyclonedx-py cannot populate it and
+    inventing one would be fabrication. The unique ID (purl) + complete
+    dependency graph are the elements a consumer's tooling resolves those
+    components by. Reported as a count so the gap stays visible.
+
+Why a first-party checker instead of the planned ``ntia-conformance-
+checker``: that tool is SPDX-only ("Check SPDX SBOM for NTIA minimum
+elements", v5.0.3 PyPI metadata, verified 2026-07-10) and cannot parse
+this project's CycloneDX SBOMs. The alternative third-party checker
+(interlynk-io/sbomqs, a Go binary) would add a new pinned supply-chain
+dependency for what is a fixed, documented list of deterministic JSON
+assertions — the same trade this repo already makes with its other
+first-party gate scripts. Swap for sbomqs later if an external
+conformance stamp becomes worth the dependency.
+
+Stdlib only. Usage: python scripts/check_sbom_ntia.py <sbom.cdx.json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _is_first_party(component: dict) -> bool:
+    name = component.get("name", "")
+    return name == "evidentia" or name.startswith("evidentia-")
+
+
+def check(doc: dict) -> tuple[list[str], list[str]]:
+    """Return (hard_failures, advisories) for the NTIA minimum elements."""
+    failures: list[str] = []
+    advisories: list[str] = []
+
+    metadata = doc.get("metadata", {})
+
+    # 1. Author of SBOM data.
+    supplier_name = (metadata.get("supplier") or {}).get("name")
+    authors = metadata.get("authors") or []
+    if not supplier_name and not authors:
+        failures.append(
+            "metadata.supplier.name / metadata.authors missing — no SBOM author"
+        )
+
+    # 2. Timestamp.
+    if not metadata.get("timestamp"):
+        failures.append("metadata.timestamp missing")
+
+    # 3. Supplier name (document-level + the identity we control).
+    if not supplier_name:
+        failures.append("metadata.supplier.name missing")
+
+    components = list(doc.get("components", []))
+    root = metadata.get("component")
+    labeled: list[tuple[str, dict]] = []
+    if isinstance(root, dict):
+        labeled.append(("(root)", root))
+    labeled.extend(("", c) for c in components)
+
+    third_party_missing_supplier = 0
+    for label, comp in labeled:
+        name = comp.get("name")
+        where = f"{label} {name or comp.get('bom-ref', '<unnamed>')}".strip()
+        # 4. Component name.
+        if not name:
+            failures.append(f"component {where}: name missing")
+        # 5. Component version.
+        if not comp.get("version"):
+            failures.append(f"component {where}: version missing")
+        # 6. Unique ID.
+        if not comp.get("purl"):
+            failures.append(f"component {where}: purl (unique ID) missing")
+        # 3. Supplier — hard for first-party + root, advisory for third-party.
+        has_supplier = bool((comp.get("supplier") or {}).get("name"))
+        if label == "(root)" or _is_first_party(comp):
+            if not has_supplier:
+                failures.append(f"component {where}: supplier missing (first-party)")
+        elif not has_supplier:
+            third_party_missing_supplier += 1
+
+    # 7. Dependency relationships.
+    if not doc.get("dependencies"):
+        failures.append("top-level dependencies array missing/empty")
+
+    if third_party_missing_supplier:
+        advisories.append(
+            f"{third_party_missing_supplier} third-party component(s) carry no "
+            "supplier (PyPI metadata has none; identified by purl instead)"
+        )
+    return failures, advisories
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sbom", help="path to the CycloneDX JSON SBOM to check")
+    args = parser.parse_args(argv)
+
+    path = Path(args.sbom)
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: cannot read SBOM {path}: {exc}", file=sys.stderr)
+        return 1
+    if doc.get("bomFormat") != "CycloneDX":
+        print(f"ERROR: {path} is not a CycloneDX SBOM", file=sys.stderr)
+        return 1
+
+    failures, advisories = check(doc)
+    n_components = len(doc.get("components", []))
+    for adv in advisories:
+        print(f"ADVISORY: {adv}")
+    if failures:
+        print(
+            f"NTIA GATE: FAIL — {len(failures)} finding(s) across "
+            f"{n_components} components:",
+            file=sys.stderr,
+        )
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print(
+        f"NTIA GATE: PASS — {n_components} components carry name/version/purl; "
+        "supplier + author + timestamp + dependency graph present."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/enrich_release_sbom.py
+++ b/scripts/enrich_release_sbom.py
@@ -1,0 +1,127 @@
+"""Enrich the release-asset CycloneDX SBOM with first-party identity (#17).
+
+``cyclonedx-py environment`` (release.yml "Generate CycloneDX SBOM") emits
+an SBOM whose FIRST-PARTY surface is anonymous: no ``metadata.supplier``,
+and the workspace's own ``evidentia*`` components carry no ``purl`` (the
+local-wheel install path yields no registry metadata), so the 8 first-party
+packages look like opaque local artifacts — osv-scanner even reports
+"Neither CPE nor PURL found" for each of them and skips them entirely
+(observed against the published v0.10.17 SBOM). Third-party components are
+fine (purl + version from PyPI metadata).
+
+This script post-processes the generated SBOM in place, deterministically:
+
+- ``metadata.supplier`` + ``metadata.authors`` — Polycentric Labs (the
+  same SUPPLIER identity ``gen_package_sboms.py`` stamps into the PEP 770
+  per-wheel SBOMs, so the two SBOM surfaces agree).
+- ``metadata.component`` (the root) and every ``evidentia*`` component:
+  ``supplier``, ``publisher``, a ``pkg:pypi/<name>@<version>`` purl, and a
+  ``vcs`` external reference to the canonical repo (added only if absent).
+
+Pedigree/evidence enrichment was considered and deliberately skipped:
+CycloneDX ``pedigree`` describes ancestry/variant lineage, which these
+first-party components do not have; the SLSA provenance attestation
+already binds the wheels to repo + commit, and a decorative pedigree block
+would claim lineage data we do not track. The substantive #17 gap is
+supplier + unique-ID (purl), which this closes.
+
+Stdlib only. Usage: python scripts/enrich_release_sbom.py <sbom.cdx.json>
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SUPPLIER = {"name": "Polycentric Labs", "url": ["https://polycentriclabs.com"]}
+PUBLISHER = "Polycentric Labs"
+REPO_URL = "https://github.com/Polycentric-Labs/evidentia"
+
+
+def _is_first_party(component: dict) -> bool:
+    name = component.get("name", "")
+    return name == "evidentia" or name.startswith("evidentia-")
+
+
+def _enrich_component(component: dict) -> list[str]:
+    """Add supplier/publisher/purl/vcs-ref to one first-party component.
+
+    Returns the list of field names actually added (idempotent: existing
+    values are never overwritten, so re-running is a no-op).
+    """
+    added: list[str] = []
+    if not component.get("supplier"):
+        component["supplier"] = SUPPLIER
+        added.append("supplier")
+    if not component.get("publisher"):
+        component["publisher"] = PUBLISHER
+        added.append("publisher")
+    name = component.get("name")
+    version = component.get("version")
+    if not component.get("purl") and name and version:
+        component["purl"] = f"pkg:pypi/{name}@{version}"
+        added.append("purl")
+    refs = component.setdefault("externalReferences", [])
+    if not any(r.get("type") == "vcs" for r in refs):
+        refs.append({"type": "vcs", "url": REPO_URL})
+        added.append("vcs-ref")
+    return added
+
+
+def enrich(doc: dict) -> dict[str, list[str]]:
+    """Enrich ``doc`` in place; return {component-name: [fields added]}."""
+    report: dict[str, list[str]] = {}
+    metadata = doc.setdefault("metadata", {})
+    doc_added: list[str] = []
+    if not metadata.get("supplier"):
+        metadata["supplier"] = SUPPLIER
+        doc_added.append("metadata.supplier")
+    if not metadata.get("authors"):
+        metadata["authors"] = [{"name": PUBLISHER}]
+        doc_added.append("metadata.authors")
+    if doc_added:
+        report["(document)"] = doc_added
+
+    root = metadata.get("component")
+    if isinstance(root, dict):
+        added = _enrich_component(root)
+        if added:
+            report[f"(root) {root.get('name', '?')}"] = added
+
+    for component in doc.get("components", []):
+        if _is_first_party(component):
+            added = _enrich_component(component)
+            if added:
+                report[component.get("name", "?")] = added
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sbom", help="path to the CycloneDX JSON SBOM to enrich")
+    args = parser.parse_args(argv)
+
+    path = Path(args.sbom)
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: cannot read SBOM {path}: {exc}", file=sys.stderr)
+        return 1
+    if doc.get("bomFormat") != "CycloneDX":
+        print(f"ERROR: {path} is not a CycloneDX SBOM", file=sys.stderr)
+        return 1
+
+    report = enrich(doc)
+    path.write_text(json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if report:
+        for name, fields in sorted(report.items()):
+            print(f"enriched {name}: {', '.join(fields)}")
+    else:
+        print("SBOM already fully enriched (no-op).")
+    print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_sbom_enrich_and_ntia.py
+++ b/tests/unit/test_release_sbom_enrich_and_ntia.py
@@ -1,0 +1,125 @@
+"""Tests for scripts/enrich_release_sbom.py + scripts/check_sbom_ntia.py (H4/#17)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_sbom_ntia as ntia  # noqa: E402
+import enrich_release_sbom as enrich  # noqa: E402
+
+
+def _bare_environment_sbom() -> dict:
+    """Shape cyclonedx-py environment actually emits (v0.10.17 observed):
+    no metadata.supplier, first-party components without purl."""
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "metadata": {
+            "timestamp": "2026-07-09T20:35:10+00:00",
+            "tools": [],
+            "component": {
+                "bom-ref": "root-component",
+                "type": "application",
+                "name": "evidentia-core",
+                "version": "0.10.17",
+            },
+        },
+        "components": [
+            {
+                "bom-ref": "evidentia==0.10.17",
+                "type": "library",
+                "name": "evidentia",
+                "version": "0.10.17",
+            },
+            {
+                "bom-ref": "Jinja2==3.1.6",
+                "type": "library",
+                "name": "Jinja2",
+                "version": "3.1.6",
+                "purl": "pkg:pypi/jinja2@3.1.6",
+            },
+        ],
+        "dependencies": [{"ref": "root-component"}],
+    }
+
+
+def test_enrich_fills_first_party_identity() -> None:
+    doc = _bare_environment_sbom()
+    report = enrich.enrich(doc)
+    assert doc["metadata"]["supplier"]["name"] == "Polycentric Labs"
+    assert doc["metadata"]["authors"] == [{"name": "Polycentric Labs"}]
+    root = doc["metadata"]["component"]
+    assert root["purl"] == "pkg:pypi/evidentia-core@0.10.17"
+    assert root["supplier"]["name"] == "Polycentric Labs"
+    fp = doc["components"][0]
+    assert fp["purl"] == "pkg:pypi/evidentia@0.10.17"
+    assert fp["supplier"]["name"] == "Polycentric Labs"
+    assert any(r["type"] == "vcs" for r in fp["externalReferences"])
+    # Third-party untouched.
+    assert "supplier" not in doc["components"][1]
+    assert "(document)" in report
+
+
+def test_enrich_is_idempotent() -> None:
+    doc = _bare_environment_sbom()
+    enrich.enrich(doc)
+    first = json.dumps(doc, sort_keys=True)
+    report_second = enrich.enrich(doc)
+    assert json.dumps(doc, sort_keys=True) == first
+    assert report_second == {}
+
+
+def test_enrich_never_overwrites_existing_values() -> None:
+    doc = _bare_environment_sbom()
+    doc["components"][0]["supplier"] = {"name": "Someone Else"}
+    doc["components"][0]["purl"] = "pkg:pypi/evidentia@0.0.0"
+    enrich.enrich(doc)
+    assert doc["components"][0]["supplier"] == {"name": "Someone Else"}
+    assert doc["components"][0]["purl"] == "pkg:pypi/evidentia@0.0.0"
+
+
+def test_ntia_gate_fails_bare_sbom_and_passes_enriched() -> None:
+    doc = _bare_environment_sbom()
+    failures, _ = ntia.check(doc)
+    # Bare environment SBOM must FAIL: no supplier, first-party purls missing.
+    assert any("metadata.supplier" in f for f in failures)
+    assert any("purl" in f for f in failures)
+    enrich.enrich(doc)
+    failures, advisories = ntia.check(doc)
+    assert failures == []
+    # Jinja2 has no supplier -> advisory, never a failure.
+    assert advisories and "third-party" in advisories[0]
+
+
+def test_ntia_gate_hard_fails() -> None:
+    doc = _bare_environment_sbom()
+    enrich.enrich(doc)
+    del doc["metadata"]["timestamp"]
+    doc["components"][1].pop("version")
+    doc["dependencies"] = []
+    failures, _ = ntia.check(doc)
+    assert any("timestamp" in f for f in failures)
+    assert any("version missing" in f for f in failures)
+    assert any("dependencies" in f for f in failures)
+
+
+def test_cli_roundtrip(tmp_path: Path) -> None:
+    sbom = tmp_path / "sbom.cdx.json"
+    sbom.write_text(json.dumps(_bare_environment_sbom()), encoding="utf-8")
+    assert ntia.main([str(sbom)]) == 1  # bare -> gate red
+    assert enrich.main([str(sbom)]) == 0
+    assert ntia.main([str(sbom)]) == 0  # enriched -> gate green
+    # Enriched file is valid JSON with sorted keys (deterministic).
+    text = sbom.read_text(encoding="utf-8")
+    assert json.loads(text)["metadata"]["supplier"]["name"] == "Polycentric Labs"
+
+
+def test_non_cyclonedx_rejected(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"spdxVersion": "SPDX-2.3"}), encoding="utf-8")
+    assert enrich.main([str(bad)]) == 1
+    assert ntia.main([str(bad)]) == 1


### PR DESCRIPTION
## What

v0.11 hygiene **H4 + deferred #17** (one PR — same surface): the release-asset SBOM gets first-party identity enrichment, then an NTIA minimum-elements gate, both in `release.yml`'s `build` job **before any publish** (and both exercised by the preflight dispatch).

The gap was real and measured: the SBOM `cyclonedx-py environment` emits has **no `metadata.supplier`**, and the 8 first-party `evidentia*` components carry **no purl** — osv-scanner literally skips them ("Neither CPE nor PURL found", observed against the published v0.10.17 SBOM). The project's own packages were the least-identified components in its own SBOM.

## Two deterministic, stdlib-only scripts (7 unit tests)

- **`scripts/enrich_release_sbom.py` (#17)**: fills `metadata.supplier`/`authors` and `supplier`/`publisher`/`purl`/`vcs`-ref on the root + first-party components. Idempotent; never overwrites; never touches third-party components. Pedigree deliberately skipped — CycloneDX pedigree is ancestry/variant lineage this project doesn't track, and SLSA provenance already binds wheels to repo+commit; a decorative pedigree block would claim data we don't have.
- **`scripts/check_sbom_ntia.py` (H4)**: NTIA minimum elements — SBOM author, timestamp, supplier, per-component name/version/purl, dependency graph. Third-party missing-supplier is an **advisory count**, never a failure: PyPI metadata carries no supplier identity, and fabricating one would be worse than reporting the gap.

## Observed firing before the fix (lesson 9)

Against the real published v0.10.17 SBOM: gate exits 1 with **18 findings** → enrichment closes all 18 → gate passes with the 164-component third-party advisory intact.

## Plan deviation, surfaced

The plan named `ntia-conformance-checker`; that tool is **SPDX-only** ("Check SPDX SBOM for NTIA minimum elements", v5.0.3 PyPI metadata, verified 2026-07-10) and cannot parse this project's CycloneDX SBOMs. A first-party checker follows the repo's existing gate-script pattern instead of adding a new pinned Go binary; `interlynk-io/sbomqs` remains the swap-in if an external conformance stamp becomes worth the dependency.

## Verification

7 unit tests · ruff clean · zizmor on the edited release.yml: no findings · full local gate suite green.

**Merge-order note**: merge after H1 (both touch the release.yml SBOM step area; H4 inserts steps directly below the line H1 edits — rebase is trivial if the queue reports a conflict).
