### PR TITLE
Ci(sentinel): Watch for uv audit / UV_MALWARE_CHECK graduation (v0.11 H5)

### DIFF
--- a/.github/workflows/uv-pilot-watch.yml
+++ b/.github/workflows/uv-pilot-watch.yml
@@ -1,0 +1,77 @@
+# Pilot-graduation watcher for the uv preview features this repo runs as
+# observe-first pilots (v0.11 hygiene H5). test.yml's `uv-audit` +
+# `uv-malware-check` jobs are continue-on-error BECAUSE the features are
+# preview (Astral, 2026-06-08); their own comments promise "graduate to
+# fail-closed once GA + observed stable" — but nothing watched for GA. A
+# pilot that never graduates is noise. This sentinel NUDGES (opens/updates
+# a single tracking issue) when either feature graduates: a functional
+# probe (`uv audit` without its preview flag stops warning "experimental")
+# plus a uv-CHANGELOG stabilization-language scan for the malware-check
+# path, which is silently ignored without its flag and so cannot be probed
+# functionally. Detect-and-nudge only: it never edits workflows. Clones the
+# python-ceiling-watch.yml pattern; its own liveness is covered by the G10
+# dead-trigger detector (base-freshness.yml).
+name: uv pilot watch
+
+on:
+  schedule:
+    - cron: "53 8 * * 5"   # Fridays 08:53 UTC (Mon rescan / Tue base-freshness / Wed python-ceiling / Thu dast / Fri 10:07 verify-recipes)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: uv-pilot-watch
+  cancel-in-progress: false
+
+jobs:
+  sentinel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Single-job workflow — write scope lives at the job level, not repeated
+    # at the workflow level (zizmor excessive-permissions).
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      # `version: latest` deliberately: the probe asks "has CURRENT uv
+      # graduated the pilots", so it must run the newest uv, not a pin.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v8.3.0
+        with:
+          version: "latest"
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Probe uv pilot graduation (audit + malware-check)
+        run: |
+          python scripts/check_uv_pilot_graduation.py \
+            --output graduation-findings.md
+
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -s graduation-findings.md ]; then
+            echo "No graduation findings — pilots stay observe-first."
+            exit 0
+          fi
+          TITLE="uv audit / UV_MALWARE_CHECK graduated from preview — promote the pilots"
+          BODY=$(printf '%s\n\n%s\n' \
+            "$(cat graduation-findings.md)" \
+            "Action: drop the --preview-features flags in test.yml (uv-audit / uv-malware-check jobs) + .pre-commit-config.yaml, then decide per pilot whether it leaves continue-on-error (the audit pilot) / moves onto the required sync steps (the malware check). This is a scheduled sentinel — not a gate.")
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title \"$TITLE\"" --json number -q '.[0].number' || echo "")
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+            echo "Updated issue #$existing"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body "$BODY"
+          fi

--- a/scripts/check_uv_pilot_graduation.py
+++ b/scripts/check_uv_pilot_graduation.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Pilot-graduation watcher for ``uv audit`` / ``UV_MALWARE_CHECK`` (H5).
+
+Both uv features run in this repo as OBSERVE-FIRST pilots (test.yml
+``uv-audit`` + ``uv-malware-check`` jobs, continue-on-error, plus the
+advisory pre-commit hook) because Astral ships them as preview
+(astral.sh blog, 2026-06-08: "Both of these features are in preview for
+now"). The graduation plan is written into the pilots' own comments —
+"Graduate to fail-closed ... once the feature is GA + observed stable" —
+but nothing WATCHED for GA. A pilot that never graduates is noise; this
+sentinel mechanizes the exit condition (same doctrine as
+``check_python_ceiling.py``: detect-and-nudge, never a gate).
+
+Two probes, deliberately different mechanisms:
+
+1. FUNCTIONAL (audit): run ``uv audit --locked`` WITHOUT
+   ``--preview-features audit``. Today uv emits ``warning: `uv audit` is
+   experimental and may change without warning`` (observed on uv 0.11.6).
+   When that warning disappears while the command still runs, audit has
+   graduated -> nudge.
+2. TEXTUAL (malware-check + audit backstop): scan uv's CHANGELOG for
+   stabilization language near "audit" / "malware". The malware-check
+   path cannot be probed functionally — ``UV_MALWARE_CHECK=1`` without
+   its preview flag is silently ignored on a dry-run sync (observed), so
+   only Astral's own release notes reliably announce its graduation.
+
+Fail-soft (lesson 2 — a chronically-red sentinel trains people to ignore
+it): a network failure, a missing uv binary, or unclassifiable output is
+"can't tell yet, don't nudge" on that probe; the script still exits 0.
+Exit 1 only on internal errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+UV_CHANGELOG_URL = (
+    "https://raw.githubusercontent.com/astral-sh/uv/main/CHANGELOG.md"
+)
+
+# Stabilization phrasing near the feature name, on one changelog line
+# (either order — lookaheads). Kept deliberately loose: release-notes
+# wording is not an API. A false nudge costs one human look; a missed
+# nudge costs a stale pilot.
+_STABILIZE = (
+    r"(?:stabiliz\w*|no longer (?:in )?preview|no longer experimental|"
+    r"out of preview|now stable|is stable)"
+)
+# Feature names matched as substrings (no \b): `UV_MALWARE_CHECK` has no
+# word boundary around "malware" (underscores are word chars), and the
+# stabilization-phrasing co-occurrence already filters noise.
+_GRADUATION_RE = re.compile(
+    rf"(?im)^(?=.*(?:audit|malware))(?=.*{_STABILIZE}).*$"
+)
+
+_PREVIEW_MARKERS = ("experimental", "preview")
+
+
+def classify_audit_probe(
+    returncode: int, stdout: str, stderr: str
+) -> str:
+    """Classify a no-preview-flag ``uv audit --locked`` run.
+
+    Returns one of:
+      - ``"preview"``    — ran, still carries the experimental/preview warning.
+      - ``"graduated"``  — ran (audit output present), no preview warning.
+      - ``"indeterminate"`` — could not tell (didn't run / unrecognized shape).
+
+    ``uv audit`` exits non-zero when advisories exist, so the exit code is
+    NOT the ran/didn't-run signal — the output shape is.
+    """
+    combined = f"{stdout}\n{stderr}".lower()
+    ran = "resolved" in combined or "known vulnerabilit" in combined
+    if not ran:
+        return "indeterminate"
+    if any(marker in combined for marker in _PREVIEW_MARKERS):
+        return "preview"
+    return "graduated"
+
+
+def run_audit_probe() -> str:
+    """Execute the functional audit probe. Fail-soft to ``indeterminate``."""
+    if shutil.which("uv") is None:
+        print("WARN: uv not on PATH — audit probe skipped", file=sys.stderr)
+        return "indeterminate"
+    try:
+        proc = subprocess.run(
+            ["uv", "audit", "--locked"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=300,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"WARN: audit probe failed to run: {exc}", file=sys.stderr)
+        return "indeterminate"
+    return classify_audit_probe(proc.returncode, proc.stdout or "", proc.stderr or "")
+
+
+def changelog_graduation_hits(text: str) -> list[str]:
+    """Changelog lines that read like an audit/malware stabilization note."""
+    hits: list[str] = []
+    for match in _GRADUATION_RE.finditer(text):
+        line = match.group(0).strip()
+        if line and line not in hits:
+            hits.append(line)
+    return hits
+
+
+def fetch_changelog(
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> str | None:
+    """GET uv's CHANGELOG.md. FAIL-SOFT: any error returns None."""
+    req = urllib.request.Request(
+        UV_CHANGELOG_URL, headers={"Accept": "text/plain"}
+    )
+    try:
+        # Fixed https host (raw.githubusercontent.com); 30s covers connect,
+        # read-phase stalls raise bare TimeoutError — caught as OSError.
+        with opener(req, timeout=30) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except (OSError, ValueError) as exc:
+        print(f"WARN: uv changelog fetch failed: {exc}", file=sys.stderr)
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output", required=True, help="nudge markdown path")
+    ap.add_argument(
+        "--skip-probe",
+        action="store_true",
+        help="skip the functional uv-audit probe (tests/offline use)",
+    )
+    ap.add_argument(
+        "--skip-fetch",
+        action="store_true",
+        help="skip the changelog fetch (tests/offline use)",
+    )
+    args = ap.parse_args(argv)
+
+    findings: list[str] = []
+
+    if not args.skip_probe:
+        status = run_audit_probe()
+        print(f"functional audit probe: {status}")
+        if status == "graduated":
+            findings.append(
+                "- **`uv audit` ran clean WITHOUT `--preview-features audit`** "
+                "(the experimental warning is gone) — the audit pilot can "
+                "graduate: drop the preview flag in test.yml's `uv-audit` job "
+                "and .pre-commit-config.yaml, and decide whether the job "
+                "leaves continue-on-error."
+            )
+
+    if not args.skip_fetch:
+        changelog = fetch_changelog()
+        if changelog is not None:
+            hits = changelog_graduation_hits(changelog)
+            for hit in hits[:5]:
+                findings.append(
+                    f"- **uv CHANGELOG stabilization note**: `{hit}` — check "
+                    "whether `uv audit` / `UV_MALWARE_CHECK` graduated; if so, "
+                    "promote the test.yml pilots (drop preview flags; decide "
+                    "fail-closed malware-check on the required sync steps)."
+                )
+            if not hits:
+                print("changelog probe: no stabilization language found")
+
+    Path(args.output).write_text(
+        "\n".join(findings) + ("\n" if findings else ""), encoding="utf-8"
+    )
+    for line in findings:
+        print(line)
+    print(f"check_uv_pilot_graduation: {len(findings)} finding(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_uv_pilot_graduation.py
+++ b/tests/unit/test_check_uv_pilot_graduation.py
@@ -1,0 +1,117 @@
+"""Tests for scripts/check_uv_pilot_graduation.py (H5 pilot-graduation watcher)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_uv_pilot_graduation as watcher  # noqa: E402
+
+# The exact shape uv 0.11.6 emits today (observed 2026-07-10).
+_PREVIEW_STDERR = (
+    "warning: `uv audit` is experimental and may change without warning. "
+    "Pass `--preview-features audit` to disable this warning.\n"
+)
+_AUDIT_STDOUT = (
+    "Resolved 257 packages in 14ms\n"
+    "Found 2 known vulnerabilities and no adverse project statuses "
+    "in 248 packages\n"
+)
+
+
+class TestClassifyAuditProbe:
+    def test_preview_warning_present(self) -> None:
+        assert (
+            watcher.classify_audit_probe(0, _AUDIT_STDOUT, _PREVIEW_STDERR)
+            == "preview"
+        )
+
+    def test_graduated_when_warning_gone(self) -> None:
+        assert watcher.classify_audit_probe(0, _AUDIT_STDOUT, "") == "graduated"
+
+    def test_nonzero_exit_with_advisories_still_classifies(self) -> None:
+        # `uv audit` exits non-zero when advisories exist — the exit code is
+        # not the ran/didn't-run signal.
+        assert watcher.classify_audit_probe(1, _AUDIT_STDOUT, "") == "graduated"
+        assert (
+            watcher.classify_audit_probe(1, _AUDIT_STDOUT, _PREVIEW_STDERR)
+            == "preview"
+        )
+
+    def test_unrecognized_output_is_indeterminate(self) -> None:
+        assert watcher.classify_audit_probe(2, "", "error: no lockfile") == (
+            "indeterminate"
+        )
+        assert watcher.classify_audit_probe(127, "", "") == "indeterminate"
+
+
+class TestChangelogGraduationHits:
+    def test_stabilize_phrasing_matches_either_order(self) -> None:
+        text = (
+            "## 0.12.0\n"
+            "- Stabilize `uv audit` (#12345)\n"
+            "- `UV_MALWARE_CHECK` is now stable and on by default\n"
+        )
+        hits = watcher.changelog_graduation_hits(text)
+        assert len(hits) == 2
+        assert "Stabilize `uv audit`" in hits[0]
+        assert "UV_MALWARE_CHECK" in hits[1]
+
+    def test_no_longer_preview_phrasing(self) -> None:
+        text = "- `uv audit` is no longer in preview\n"
+        assert len(watcher.changelog_graduation_hits(text)) == 1
+
+    def test_plain_feature_mentions_do_not_match(self) -> None:
+        text = (
+            "- Add `--ignore` flag to `uv audit` (#111)\n"
+            "- Fix malware-check false positive on yanked wheels (#222)\n"
+            "- Stabilize `uv python install` defaults (#333)\n"
+        )
+        assert watcher.changelog_graduation_hits(text) == []
+
+    def test_dedupes_repeated_lines(self) -> None:
+        line = "- Stabilize `uv audit`\n"
+        assert len(watcher.changelog_graduation_hits(line * 3)) == 1
+
+
+class TestFetchChangelogFailSoft:
+    def test_network_error_returns_none(self) -> None:
+        def opener(_req, timeout=30):
+            del timeout
+            raise OSError("boom")
+
+        assert watcher.fetch_changelog(opener=opener) is None
+
+
+class TestMain:
+    def test_offline_run_writes_empty_findings_and_exits_zero(
+        self, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "findings.md"
+        rc = watcher.main(
+            ["--output", str(out), "--skip-probe", "--skip-fetch"]
+        )
+        assert rc == 0
+        assert out.read_text(encoding="utf-8") == ""
+
+    def test_graduated_probe_produces_finding(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(watcher, "run_audit_probe", lambda: "graduated")
+        out = tmp_path / "findings.md"
+        rc = watcher.main(["--output", str(out), "--skip-fetch"])
+        assert rc == 0
+        text = out.read_text(encoding="utf-8")
+        assert "graduate" in text
+        assert "--preview-features audit" in text
+
+    def test_preview_probe_produces_no_finding(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(watcher, "run_audit_probe", lambda: "preview")
+        out = tmp_path / "findings.md"
+        rc = watcher.main(["--output", str(out), "--skip-fetch"])
+        assert rc == 0
+        assert out.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## What

v0.11 hygiene **H5**: `uv-pilot-watch.yml` + `scripts/check_uv_pilot_graduation.py` — a weekly sentinel (Fri 08:53 UTC) that nudges via a single tracking issue when `uv audit` / `UV_MALWARE_CHECK` graduate from preview. Mechanizes the exit condition the test.yml pilots promise in their own comments ("graduate to fail-closed once GA + observed stable"): *a pilot that never graduates is noise.* Clones the `python-ceiling-watch.yml` pattern — detect-and-nudge, never a gate.

## Two probes, deliberately different mechanisms

- **Functional (audit)**: run `uv audit --locked` *without* `--preview-features audit`. uv 0.11.6 emits `warning: `uv audit` is experimental…` (observed 2026-07-10); when that warning disappears while the command still runs, audit graduated. The exit code is deliberately NOT the signal — audit exits non-zero on advisories.
- **Textual (malware-check + audit backstop)**: scan uv's CHANGELOG for stabilization language near audit/malware. `UV_MALWARE_CHECK=1` without its preview flag is **silently ignored** on a dry-run sync (observed), so only Astral's release notes reliably announce that graduation.

## Robustness

Fail-soft throughout (lesson 2 — a chronically-red sentinel trains people to ignore it): fetch/subprocess failures mean "can't tell yet, don't nudge", exit 0. 12 unit tests, including the regex trap that `UV_MALWARE_CHECK` has no word boundary around "malware" (underscores are word chars). Live run today: probe=`preview`, changelog=no hits, 0 findings — the pilots correctly stay observe-first.

## Verification

`audit_workflow_permissions.py --strict` PASS · zizmor: no findings · liveness covered by the existing G10 dead-trigger detector · full local gate suite green.
