### PR TITLE
Fix(fedramp): Re-vendor CR26 schemas at the upstream 1.0.0 SDR graduation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **FedRAMP CR26 vendored schemas re-synced to the upstream 1.0.0 graduation**
+  (`FedRAMP/schemas` @ `ae0dc43e`, 2026-07-15 — caught by a manual drift probe
+  inside the weekly sentinel's blind window): the Security Decision Record
+  schema's `$schemaVersion` moved 0.1.0 → **1.0.0**, fixing the Public-Preview
+  draft's vacuous `items` wrapper nesting so the per-KSI constraints now
+  actually enforce — constraints `evidentia conmon ksi` output already
+  satisfies (emitted documents re-validated against upstream 1.0.0, zero
+  emitter changes). `fedramp-common-definitions` re-vendored byte-identical at
+  0.1.1; `UPSTREAM.json` pins refreshed (all 11 tracked `$schemaVersion`s).
+  The documented one-line cross-document `$ref` delta is retained — upstream
+  fix PR #4 remains unmerged; the 1.0.0 graduation did not include it.
+
 - **Claim-accuracy sweep across the public docs** (pre-v0.11.0; every change
   traced to the 2026-07-15 primary-source verification pass): CLI↔GUI parity
   claims recomputed from the manifest (98% → **93.4%**, 99 full / 7 api-only /

--- a/docs/releases/plans/v0.11-plan.md
+++ b/docs/releases/plans/v0.11-plan.md
@@ -154,7 +154,10 @@ DEFER-WITH-TRIGGER — emitted documents stay on 1.2.1.**
   deleted; FedRAMP/docs renamed docs-legacy). The live target is the
   `keySecurityIndicators` block of the CR26 **Security Decision Record**
   per `fedramp-security-decision-record-schema-2026-06-24.json`
-  (`FedRAMP/schemas`, `$schemaVersion` 0.1.0), populated from the KSI
+  (`FedRAMP/schemas`, `$schemaVersion` 0.1.0 at ratification; graduated
+  to 1.0.0 upstream 2026-07-15 and re-vendored pre-release — the 1.0.0
+  change enforces the per-item constraints the emitter already met),
+  populated from the KSI
   catalog in `fedramp-consolidated-rules.json` (`FedRAMP/rules` — 10
   families / 46 indicators, all `stable` and unchanged since the
   2026-06-24 CR26 launch). Obligation anchor: SDR-CSO-FRR (SDR in JSON is

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **FedRAMP CR26 vendored schemas re-synced to the upstream 1.0.0 graduation**
+  (`FedRAMP/schemas` @ `ae0dc43e`, 2026-07-15 — caught by a manual drift probe
+  inside the weekly sentinel's blind window): the Security Decision Record
+  schema's `$schemaVersion` moved 0.1.0 → **1.0.0**, fixing the Public-Preview
+  draft's vacuous `items` wrapper nesting so the per-KSI constraints now
+  actually enforce — constraints `evidentia conmon ksi` output already
+  satisfies (emitted documents re-validated against upstream 1.0.0, zero
+  emitter changes). `fedramp-common-definitions` re-vendored byte-identical at
+  0.1.1; `UPSTREAM.json` pins refreshed (all 11 tracked `$schemaVersion`s).
+  The documented one-line cross-document `$ref` delta is retained — upstream
+  fix PR #4 remains unmerged; the 1.0.0 graduation did not include it.
+
 - **Claim-accuracy sweep across the public docs** (pre-v0.11.0; every change
   traced to the 2026-07-15 primary-source verification pass): CLI↔GUI parity
   claims recomputed from the manifest (98% → **93.4%**, 99 full / 7 api-only /

--- a/packages/evidentia-core/src/evidentia_core/fedramp/schemas/README.md
+++ b/packages/evidentia-core/src/evidentia_core/fedramp/schemas/README.md
@@ -22,8 +22,11 @@ As published, every cross-document `$ref` in the CR26 schema set places the
 JSON Pointer in the URI **path** (`...json/$defs/x`) instead of the **fragment**
 (`...json#/$defs/x`), so no conforming JSON Schema 2020-12 validator can
 resolve them (upstream [issue #3](https://github.com/FedRAMP/schemas/issues/3),
-fix [PR #4](https://github.com/FedRAMP/schemas/pull/4) — unmerged at vendor
-time). The vendored SDR schema carries exactly **one** such rewrite. When the
+fix [PR #4](https://github.com/FedRAMP/schemas/pull/4) — still unmerged at the
+2026-07-16 re-vendor; the SDR schema's 0.1.0 → 1.0.0 graduation fixed the
+draft's vacuous `items` wrapper nesting and added proper **local** `#/$defs`
+refs, but left the one cross-document ref malformed). The vendored SDR schema
+carries exactly **one** such rewrite. When the
 upstream fix merges, re-vendor byte-identical and clear the `local_delta` note
 in `UPSTREAM.json`. The `fedramp-schema-watch` sentinel flags upstream movement
 on these files, so the merge will surface on its own.

--- a/packages/evidentia-core/src/evidentia_core/fedramp/schemas/UPSTREAM.json
+++ b/packages/evidentia-core/src/evidentia_core/fedramp/schemas/UPSTREAM.json
@@ -1,6 +1,6 @@
 {
   "comment": "Provenance pins for the vendored FedRAMP CR26 artifacts. Single source of truth for scripts/check_fedramp_upstream_drift.py (the fedramp-schema-watch sentinel baseline) and for scripts/catalogs/gen_fedramp_ksi.py (the KSI catalog generator pin). Update ONLY via a deliberate re-sync: re-vendor, re-verify, and re-run the generator together. See README.md in this directory.",
-  "verified_at": "2026-07-14",
+  "verified_at": "2026-07-16",
   "rules": {
     "repo": "FedRAMP/rules",
     "commit": "12fe1b60f578ab448c26d143baac99d16d8bfe14",
@@ -14,30 +14,30 @@
   },
   "schemas": {
     "repo": "FedRAMP/schemas",
-    "commit": "d6f69b81392ef369bc216c228bde51713209a6bf",
+    "commit": "ae0dc43ecfc7287d557f16681f49d98d72e3d94d",
     "ruleset_date": "2026-06-24",
     "schema_versions": {
       "fedramp-accepted-vulnerability-info-schema-2026-06-24.json": "0.1.0",
-      "fedramp-advisor-information-schema-2026-06-24.json": "0.1.0",
-      "fedramp-assessor-information-schema-2026-06-24.json": "0.1.0",
-      "fedramp-certification-package-overview-schema-2026-06-24.json": "0.1.1",
-      "fedramp-common-definitions-schema-2026-06-24.json": "0.1.0",
+      "fedramp-advisor-information-schema-2026-06-24.json": "0.1.1",
+      "fedramp-assessor-information-schema-2026-06-24.json": "0.1.1",
+      "fedramp-certification-package-overview-schema-2026-06-24.json": "0.1.2",
+      "fedramp-common-definitions-schema-2026-06-24.json": "0.1.1",
       "fedramp-historical-ver-activity-schema-2026-06-24.json": "0.1.0",
-      "fedramp-incident-report-schema-2026-06-24.json": "0.1.0",
-      "fedramp-ongoing-certification-report-schema-2026-06-24.json": "0.1.0",
-      "fedramp-security-decision-record-schema-2026-06-24.json": "0.1.0",
-      "fedramp-significant-change-notifications-schema-2026-06-24.json": "0.1.0",
+      "fedramp-incident-report-schema-2026-06-24.json": "0.1.1",
+      "fedramp-ongoing-certification-report-schema-2026-06-24.json": "0.1.1",
+      "fedramp-security-decision-record-schema-2026-06-24.json": "1.0.0",
+      "fedramp-significant-change-notifications-schema-2026-06-24.json": "0.1.1",
       "fedramp-vulnerability-detail-report-schema-2026-06-24.json": "0.1.0"
     },
     "vendored": {
       "fedramp-security-decision-record-schema-2026-06-24.json": {
-        "blob_sha": "e35c7862b97da9654b83048781ab8ed435be5d9c",
-        "sha256_upstream": "968b887431d5c9e3b5c3d0b62d836113061b190893ceca6f2fd3d14f0c7dd517",
-        "local_delta": "One cross-document $ref rewritten from '...json/$defs/certificationPackageOverviewUri' to '...json#/$defs/certificationPackageOverviewUri' (JSON Pointer moved into the URI fragment, as JSON Schema 2020-12 requires). Upstream defect: FedRAMP/schemas issue #3, fix PR #4 (unmerged at vendor time). Drop this delta when the upstream fix merges and re-vendor byte-identical."
+        "blob_sha": "31d2b7207ec04037fb7537392375c7bb045ced9a",
+        "sha256_upstream": "d598637cd4bb0f52425d7186ddc6f9463dcdda02734533623322e031d9b97b1a",
+        "local_delta": "One cross-document $ref rewritten from '...json/$defs/certificationPackageOverviewUri' to '...json#/$defs/certificationPackageOverviewUri' (JSON Pointer moved into the URI fragment, as JSON Schema 2020-12 requires). Upstream defect: FedRAMP/schemas issue #3, fix PR #4 (still unmerged at the 2026-07-16 re-vendor; the 1.0.0 graduation did NOT include it — re-verified). Drop this delta when the upstream fix merges and re-vendor byte-identical."
       },
       "fedramp-common-definitions-schema-2026-06-24.json": {
-        "blob_sha": "db532e342230b01a531b3cb66dbae7f4f7a0dba6",
-        "sha256_upstream": "26e637a9ee0cde2c4b6794d3f4cb3d56cc026780227c3e92fcab98dc2e354083",
+        "blob_sha": "534853e39c2863997ccf03245fcadbc293bcc5b3",
+        "sha256_upstream": "b6cffd3632ba524cc5a5e44f6c62e6fdcae7993221e558d32761f15d212117c1",
         "local_delta": null
       }
     }

--- a/packages/evidentia-core/src/evidentia_core/fedramp/schemas/fedramp-common-definitions-schema-2026-06-24.json
+++ b/packages/evidentia-core/src/evidentia_core/fedramp/schemas/fedramp-common-definitions-schema-2026-06-24.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://fedramp.gov/schemas/fedramp-common-definitions-schema-2026-06-24.json",
-  "$schemaVersion": "0.1.0",
+  "$schemaVersion": "0.1.1",
   "title": "FedRAMP Common Definitions",
   "description": "Shared type definitions referenced by other FedRAMP schemas.",
   "$defs": {
@@ -161,14 +161,14 @@
             "properties": {
               "isOverdue": {
                 "title": "Is Overdue",
-              "description": "True if the vulnerability is overdue.",
+                "description": "True if the vulnerability is overdue.",
                 "const": true
               }
             }
           },
           "then": {
             "title": "Explanation",
-              "description": "Reason for the overdue status.",
+            "description": "Reason for the overdue status.",
             "required": [
               "explanation"
             ]

--- a/packages/evidentia-core/src/evidentia_core/fedramp/schemas/fedramp-security-decision-record-schema-2026-06-24.json
+++ b/packages/evidentia-core/src/evidentia_core/fedramp/schemas/fedramp-security-decision-record-schema-2026-06-24.json
@@ -1,14 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://fedramp.gov/schemas/fedramp-security-decision-record-schema-2026-06-24.json",
-  "$schemaVersion": "0.1.0",
+  "$schemaVersion": "1.0.0",
   "type": "object",
   "title": "FedRAMP Security Decision Record (SDR-CSO-FRR)",
   "description": "JSON Schema for Cloud Service Provider (CSP) system submission for FedRAMP certification per SDR-CSO-FRR.",
-  "required": [
-    "certificationPackageOverviewUri",
-    "fedRampRequirements"
-  ],
+  "required": ["certificationPackageOverviewUri", "fedRampRequirements"],
   "properties": {
     "certificationPackageOverviewUri": {
       "$ref": "https://fedramp.gov/schemas/fedramp-common-definitions-schema-2026-06-24.json#/$defs/certificationPackageOverviewUri"
@@ -20,33 +17,33 @@
       "items": {
         "type": "object",
         "title": "Port and Protocol",
-        "description": "Port and protocol exposed by the Cloud Service Offering"
-      },
-      "properties": {
-        "serviceName": {
-          "type": "string",
-          "title": "Service Name",
-          "description": "Name of the service exposed on this port."
-        },
-        "portNumber": {
-          "type": "string",
-          "title": "Port Number",
-          "description": "Port number used by the service. For services that operate on a range of ports, provide the range in the format 'start-end'."
-        },
-        "transportProtocol": {
-          "type": "string",
-          "title": "Transport Protocol",
-          "description": "Transport protocol used by the service"
-        },
-        "encryption": {
-          "type": "string",
-          "title": "Encryption",
-          "description": "Encryption method used by the service (e.g., TLS, SSL, None)."
-        },
-        "purpose": {
-          "type": "string",
-          "title": "Purpose",
-          "description": "Provide a general description of how it is used in the Cloud Service Offering (e.g., Web access, database connection)."
+        "description": "Port and protocol exposed by the Cloud Service Offering",
+        "properties": {
+          "serviceName": {
+            "type": "string",
+            "title": "Service Name",
+            "description": "Name of the service exposed on this port."
+          },
+          "portNumber": {
+            "type": "string",
+            "title": "Port Number",
+            "description": "Port number used by the service. For services that operate on a range of ports, provide the range in the format 'start-end'."
+          },
+          "transportProtocol": {
+            "type": "string",
+            "title": "Transport Protocol",
+            "description": "Transport protocol used by the service"
+          },
+          "encryption": {
+            "type": "string",
+            "title": "Encryption",
+            "description": "Encryption method used by the service (e.g., TLS, SSL, None)."
+          },
+          "purpose": {
+            "type": "string",
+            "title": "Purpose",
+            "description": "Provide a general description of how it is used in the Cloud Service Offering (e.g., Web access, database connection)."
+          }
         }
       }
     },
@@ -55,61 +52,49 @@
       "title": "NIST 800-53 Security Controls",
       "description": "Describe the security controls for the system.",
       "items": {
-        "nistSecurityControl": {
-          "type": "object",
-          "description": "NIST 800-53 Security Control",
-          "properties": {
-            "controlId": {
-              "type": "string",
-              "description": "NIST 800-53 Control ID",
-              "examples": [
-                "AC-1",
-                "AC-2",
-                "AC-3"
-              ],
-              "title": "NIST 800-53 Control ID"
-            },
-            "parameterValues": {
-              "type": "array",
-              "title": "Parameter Values",
-              "description": "Parameter values for the control",
-              "items": {
-                "type": "object",
-                "required": [
-                  "parameterId",
-                  "parameterValue"
-                ],
-                "title": "Parameter Value",
-                "description": "Parameter value for the control",
-                "properties": {
-                  "parameterId": {
-                    "type": "string",
-                    "title": "Parameter ID",
-                    "description": "The parameter ID as defined in the NIST 800-53 Control Implementation Guide."
-                  },
-                  "parameterValue": {
-                    "type": "string",
-                    "title": "Parameter Value",
-                    "description": "The parameter value selected by the Cloud Service Provider. If the parameter is a boolean, provide 'true' or 'false'. If the parameter is a list, provide a comma-separated list of values."
-                  }
+        "type": "object",
+        "title": "NIST 800-53 Security Control",
+        "description": "NIST 800-53 Security Control",
+        "properties": {
+          "controlId": {
+            "type": "string",
+            "title": "NIST 800-53 Control ID",
+            "description": "NIST 800-53 Control ID",
+            "examples": ["AC-1", "AC-2", "AC-3"]
+          },
+          "parameterValues": {
+            "type": "array",
+            "title": "Parameter Values",
+            "description": "Parameter values for the control",
+            "items": {
+              "type": "object",
+              "title": "Parameter Value",
+              "description": "Parameter value for the control",
+              "required": ["parameterId", "parameterValue"],
+              "properties": {
+                "parameterId": {
+                  "type": "string",
+                  "title": "Parameter ID",
+                  "description": "The parameter ID as defined in the NIST 800-53 Control Implementation Guide."
+                },
+                "parameterValue": {
+                  "type": "string",
+                  "title": "Parameter Value",
+                  "description": "The parameter value selected by the Cloud Service Provider. If the parameter is a boolean, provide 'true' or 'false'. If the parameter is a list, provide a comma-separated list of values."
                 }
               }
-            },
-            "controlImplementationStatus": {
-              "type": "string",
-              "title": "Control Implementation Status",
-              "description": "Status of the control implementation",
-              "enum": [
-                "Implemented",
-                "Not Implemented",
-                "Partially Implemented"
-              ]
-            },
-            "controlImplementationDescription": {
-              "type": "string",
-              "title": "Control Implementation Description",
-              "description": "Description of the control implementation. May use Markdown for formatting."
             }
+          },
+          "controlImplementationStatus": {
+            "type": "string",
+            "title": "Control Implementation Status",
+            "description": "Status of the control implementation",
+            "enum": ["Implemented", "Not Implemented", "Partially Implemented"]
+          },
+          "controlImplementationDescription": {
+            "type": "string",
+            "title": "Control Implementation Description",
+            "description": "Description of the control implementation. May use Markdown for formatting."
           }
         }
       }
@@ -119,130 +104,115 @@
       "title": "FedRAMP Requirements",
       "description": "Describe how any applicable FedRAMP required processes are met.",
       "items": {
-        "fedRAMPRequirement": {
-          "type": "object",
-          "title": "FedRAMP Requirement",
-          "description": "FedRAMP requirement",
-          "required": [
-            "frrID",
-            "frrImplementation"
-          ],
-          "properties": {
-            "frrID": {
-              "type": "string",
-              "title": "FedRAMP Requirement ID",
-              "description": "FedRAMP requirement ID"
-            },
-            "frrImplementationStatus": {
-              "title": "Requirement Implementation Status",
-              "description": "Status of the requirement implementation.",
-              "type": "string",
-              "enum": [
-                "Implemented",
-                "Not Implemented",
-                "Partially Implemented"
-              ]
-            },
-            "frrImplementation": {
-              "type": "array",
-              "title": "Requirement Implementation Statements",
-              "description": "Description of the requirement implementation. May use Markdown for formatting.",
-              "items": {
-                "$ref": "#/$defs/implementationStatement"
-              }
-            },
-            "frrValidation": {
-              "type": "array",
-              "title": "Requirement Validation Statements",
-              "description": "Description of the requirement validation. May use Markdown for formatting.",
-              "items": {
-                "$ref": "#/$defs/validationStatement"
-              }
-            },
-            "frrAssessment": {
-              "type": "array",
-              "title": "Requirement Assessment Statements",
-              "description": "Description of the requirement assessment. May use Markdown for formatting.",
-              "items": {
-                "$ref": "#/$defs/assessmentStatement"
-              }
+        "type": "object",
+        "title": "FedRAMP Requirement",
+        "description": "FedRAMP requirement",
+        "required": ["frrID", "frrImplementation"],
+        "properties": {
+          "frrID": {
+            "type": "string",
+            "title": "FedRAMP Requirement ID",
+            "description": "FedRAMP requirement ID"
+          },
+          "frrImplementationStatus": {
+            "type": "string",
+            "title": "Requirement Implementation Status",
+            "description": "Status of the requirement implementation.",
+            "enum": ["Implemented", "Not Implemented", "Partially Implemented"]
+          },
+          "frrImplementation": {
+            "type": "array",
+            "title": "Requirement Implementation Statements",
+            "description": "Description of the requirement implementation. May use Markdown for formatting.",
+            "items": {
+              "$ref": "#/$defs/implementationStatement"
+            }
+          },
+          "frrValidation": {
+            "type": "array",
+            "title": "Requirement Validation Statements",
+            "description": "Description of the requirement validation. May use Markdown for formatting.",
+            "items": {
+              "$ref": "#/$defs/validationStatement"
+            }
+          },
+          "frrAssessment": {
+            "type": "array",
+            "title": "Requirement Assessment Statements",
+            "description": "Description of the requirement assessment. May use Markdown for formatting.",
+            "items": {
+              "$ref": "#/$defs/assessmentStatement"
             }
           }
         }
       }
     },
     "keySecurityIndicators": {
+      "type": "array",
       "title": "FedRAMP Key Security Indicators",
       "description": "Describe how the system meets the FedRAMP Key Security Indicators (KSI).",
-      "type": "array",
       "items": {
-        "keySecurityIndicator": {
-          "type": "object",
-          "title": "FedRAMP Key Security Indicator",
-          "description": "How the Key Security Indictor objective is achieved and monitored",
-          "required": [
-            "ksiId",
-            "ksiImplementation",
-            "ksiValidation",
-            "ksiAssessment",
-            "ksiTests",
-            "ksiEvidence"
-          ],
-          "properties": {
-            "ksiId": {
-              "type": "string",
-              "title": "FedRAMP KSI ID",
-              "description": "FedRAMP KSI ID"
-            },
-            "ksiImplementationStatus": {
-              "title": "KSI Implementation Status",
-              "description": "Status of the KSI implementation.",
-              "type": "string",
-              "enum": [
-                "Implemented",
-                "Not Implemented",
-                "Partially Implemented"
-              ]
-            },
-            "ksiImplementation": {
-              "type": "array",
-              "title": "KSI Implementation Statements",
-              "description": "Description of the requirement implementation. May use Markdown for formatting.",
-              "items": {
-                "$ref": "#/$defs/implementationStatement"
-              }
-            },
-            "ksiValidation": {
-              "type": "array",
-              "title": "KSI Validation Statements",
-              "description": "Description of the requirement validation. May use Markdown for formatting.",
-              "items": {
-                "$ref": "#/$defs/validationStatement"
-              }
-            },
-            "ksiAssessment": {
-              "type": "array",
-              "title": "KSI Assessment Statements",
-              "description": "Description of the requirement assessment. May use Markdown for formatting.",
-              "items": {
-                "$ref": "#/$defs/assessmentStatement"
-              }
-            },
-            "ksiTests": {
-              "type": "array",
-              "title": "KSI Tests",
-              "description": "List of tests used to validate the KSI implementation.",
-              "items": {
-                "type": "string"
-              }
-            },
-            "ksiEvidence": {
-              "type": "array",
-              "title": "KSI Evidence",
-              "description": "Results of the security test used to validate the KSI implementation.",
-              "items": {
-                "$ref": "#/$defs/evidence"
-              }
+        "type": "object",
+        "title": "FedRAMP Key Security Indicator",
+        "description": "How the Key Security Indictor objective is achieved and monitored",
+        "required": [
+          "ksiId",
+          "ksiImplementation",
+          "ksiValidation",
+          "ksiAssessment",
+          "ksiTests",
+          "ksiEvidence"
+        ],
+        "properties": {
+          "ksiId": {
+            "type": "string",
+            "title": "FedRAMP KSI ID",
+            "description": "FedRAMP KSI ID"
+          },
+          "ksiImplementationStatus": {
+            "type": "string",
+            "title": "KSI Implementation Status",
+            "description": "Status of the KSI implementation.",
+            "enum": ["Implemented", "Not Implemented", "Partially Implemented"]
+          },
+          "ksiImplementation": {
+            "type": "array",
+            "title": "KSI Implementation Statements",
+            "description": "Description of the requirement implementation. May use Markdown for formatting.",
+            "items": {
+              "$ref": "#/$defs/implementationStatement"
+            }
+          },
+          "ksiValidation": {
+            "type": "array",
+            "title": "KSI Validation Statements",
+            "description": "Description of the requirement validation. May use Markdown for formatting.",
+            "items": {
+              "$ref": "#/$defs/validationStatement"
+            }
+          },
+          "ksiAssessment": {
+            "type": "array",
+            "title": "KSI Assessment Statements",
+            "description": "Description of the requirement assessment. May use Markdown for formatting.",
+            "items": {
+              "$ref": "#/$defs/assessmentStatement"
+            }
+          },
+          "ksiTests": {
+            "type": "array",
+            "title": "KSI Tests",
+            "description": "List of tests used to validate the KSI implementation.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ksiEvidence": {
+            "type": "array",
+            "title": "KSI Evidence",
+            "description": "Results of the security test used to validate the KSI implementation.",
+            "items": {
+              "$ref": "#/$defs/evidence"
             }
           }
         }
@@ -252,11 +222,13 @@
   "$defs": {
     "evidence": {
       "type": "object",
-      "description": "Results of the security test",
       "title": "Evidence",
+      "description": "Results of the security test",
       "properties": {
         "evidenceType": {
           "type": "string",
+          "title": "Evidence Type",
+          "description": "Type of evidence provided",
           "enum": [
             "Log",
             "Report",
@@ -265,9 +237,7 @@
             "Policy",
             "Procedure",
             "Audit Record"
-          ],
-          "title": "Evidence Type",
-          "description": "Type of evidence provided"
+          ]
         },
         "evidenceDescription": {
           "type": "string",


### PR DESCRIPTION
## Re-vendor FedRAMP CR26 schemas at the upstream 1.0.0 SDR graduation

`FedRAMP/schemas` moved on 2026-07-15 at 17:43 UTC — 8.5 hours **after** the
weekly `fedramp-schema-watch` sentinel ran green that morning (the sentinel's
documented ~7-day blind window). A manual pre-release drift probe caught it:
the **Security Decision Record schema graduated `$schemaVersion` 0.1.0 →
1.0.0** (MAJOR per our severity model); every other tracked schema took a
minor bump. Same dated fileset (no CR27).

### Impact analysis (verified against upstream `ae0dc43e`)

- The 1.0.0 change **fixes the draft's vacuous `items` wrapper nesting** so
  the intended per-KSI constraints now actually enforce — exactly the shape
  `evidentia conmon ksi` already emits. Emitted documents re-validate cleanly
  against the upstream 1.0.0 schema; **zero emitter code changes**.
- No `additionalProperties` tightening — the SDR-CSO-MTD metadata block
  remains schema-permitted.
- The cross-document `$ref` defect is **not** fixed by the graduation
  (upstream [PR #4](https://github.com/FedRAMP/schemas/pull/4) still open),
  so the documented one-line fragment delta is retained.

### Changes

- SDR schema re-vendored at 1.0.0 (+ retained `$ref` delta);
  common-definitions re-vendored byte-identical at 0.1.1.
- `UPSTREAM.json`: commit pin → `ae0dc43e`; all 11 tracked
  `$schemaVersion`s refreshed; new blob/sha256 pins; `verified_at`
  2026-07-16. KSI rules pin unchanged (rules content untouched upstream).
- `schemas/README.md` delta note + `v0.11-plan.md` Wave-2 record updated;
  CHANGELOG entry under Unreleased.

### Verification

- Drift probe **clean** against the new pins (next Wednesday's sentinel
  stays green instead of firing MAJOR).
- Emitted-SDR validation against upstream 1.0.0: **passes**.
- 60 scoped emitter/catalog/conmon tests + the full suite green;
  `gen_fedramp_ksi.py --check` OK; ruff / mypy / docs-health --strict /
  version-consistency / roadmap-currency all green.
