### PR TITLE
Fix(ci): verify-recipes PEP 740 sweep counts by exit code + date v0.11.0 as 2026-07-18

### DIFF
--- a/.github/workflows/verify-recipes.yml
+++ b/.github/workflows/verify-recipes.yml
@@ -130,11 +130,18 @@ jobs:
           ok=0
           for pkg in evidentia evidentia_ai evidentia_api evidentia_collectors \
                      evidentia_core evidentia_eval evidentia_integrations evidentia_mcp; do
-            out=$(uvx --from pypi-attestations==0.0.29 pypi-attestations verify pypi \
+            # Key off the verifier's EXIT CODE, not its printed text: as of
+            # pypi-attestations 0.0.29 the "OK:" line is written to stderr,
+            # so a stdout-only capture + grep silently counts 0/8. The exit
+            # code (0 = verified) is the reliable signal and is robust to
+            # future output-format changes. 2>&1 keeps the OK/error line in
+            # the job log.
+            if out=$(uvx --from pypi-attestations==0.0.29 pypi-attestations verify pypi \
               --repository https://github.com/Polycentric-Labs/evidentia \
-              "pypi:${pkg}-${VERSION}-py3-none-any.whl")
+              "pypi:${pkg}-${VERSION}-py3-none-any.whl" 2>&1); then
+              ok=$((ok + 1))
+            fi
             echo "$out"
-            echo "$out" | grep -q "^OK: ${pkg}-${VERSION}-py3-none-any.whl" && ok=$((ok + 1))
           done
           if [ "$ok" -ne 8 ]; then
             echo "::error::PEP 740 sweep verified ${ok}/8 wheels — coverage assertion failed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet on the v0.11.x development branch._
 
-## [0.11.0] - 2026-07-16
+## [0.11.0] - 2026-07-18
 
 **Theme**: *The federal wave — three verified federal firsts on machine-readable rails.* v0.11.0 ships the re-cut Wave 1-2 scope of the v0.11 plan: **FedRAMP CR26 Security Decision Record emission** — `evidentia conmon ksi` emits the SDR `keySecurityIndicators` block (10 families / 46 KSIs) conformant to FedRAMP's official 2026-06-24 schemas, vendored at pinned upstream SHAs (re-verified at the schemas' 1.0.0 graduation) and drift-watched weekly — the **first production-grade open-source emitter** of the CR26 SDR format, and the first from any established tool; **OMB M-25-21 minimum-practice tracking** — structured per-practice status for the memo's seven §4(b) practices with CAIO waiver objects carrying the annual re-certification and 30-day OMB-report clocks, structure the federal AI Use Case Inventory lacks entirely; and **OMB M-25-22 acquisition-lifecycle tracking** — Evidentia's first procurement surface, modeling the memo's six §4 phases as auditable records with the §4(a) high-impact determination tie-in. The cycle's OSCAL 1.2.1 → 1.2.2 evaluation closed with a ratified **DEFER-WITH-TRIGGER** verdict (emitted documents stay on 1.2.1; adoption triggers armed), and a pre-release **claim-accuracy sweep** re-verified every public claim against primary sources (parity restated at the live 93.4%; machine-gated counts; first-mover registry updated with explicit caveats). Test suite: 4,947 passed; mypy strict clean; ruff clean.
 
-**Deferred (ratified v0.12 plan re-cut, 2026-07-16 — see [`docs/releases/plans/v0.12-plan.md`](docs/releases/plans/v0.12-plan.md))**: Wave 4 phase 3 (EU-AI-Act ↔ ISO 42001 crosswalk) → v0.12-if-capacity; Wave 4 phases 1/2/4, Wave 3 DORA, and the medical-device traceability enrichment → v1.1; Waves 5-6 (OpenVEX/VSA, SARIF collector, auto-review) → post-1.0; arXiv preprint timing = open decision. The GUI parity pass for the five federal api-only verbs leads v0.12.
+**Deferred (ratified v0.12 plan re-cut, 2026-07-18 — see [`docs/releases/plans/v0.12-plan.md`](docs/releases/plans/v0.12-plan.md))**: Wave 4 phase 3 (EU-AI-Act ↔ ISO 42001 crosswalk) → v0.12-if-capacity; Wave 4 phases 1/2/4, Wave 3 DORA, and the medical-device traceability enrichment → v1.1; Waves 5-6 (OpenVEX/VSA, SARIF collector, auto-review) → post-1.0; arXiv preprint timing = open decision. The GUI parity pass for the five federal api-only verbs leads v0.12.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ See it first, no install — a self-hosted [asciinema](https://asciinema.org/) r
 
 ## Recent Releases
 
-**v0.11.0 (2026-07-16)** — *The federal wave — three verified federal firsts on machine-readable rails*. **OMB M-25-22 AI acquisition-lifecycle tracking, `evidentia ai-gov acquisition`** (#196) (v0.11 Wave 2; spec ratified 2026-07-14, lifecycle phases verified verbatim against the memo text): Evidentia's first procurement surface.
+**v0.11.0 (2026-07-18)** — *The federal wave — three verified federal firsts on machine-readable rails*. **OMB M-25-22 AI acquisition-lifecycle tracking, `evidentia ai-gov acquisition`** (#196) (v0.11 Wave 2; spec ratified 2026-07-14, lifecycle phases verified verbatim against the memo text): Evidentia's first procurement surface.
 
 **v0.10.18 (2026-07-14)** — *Container rebuild on a fresh hardened base*. **ROADMAP-currency gate** (`scripts/check_roadmap_currency.py`), the roadmap's status headings must agree with the CHANGELOG's shipped `## [X.Y.Z]` blocks: nothing PLANNED/RESERVED that has shipped, no SHIPPED entries inside a PLANNED cycle umbrella, exactly one open cycle, and the open cycle must link an on-disk plan doc.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2040,20 +2040,20 @@ v0.11.0's boundary re-cuts to Waves 1–2. No package
 
 ## v0.11 — Federal-compliance theme + AI governance — SHIPPED
 
-Opened 2026-07-09; **closed 2026-07-16 with v0.11.0** (the re-cut
+Opened 2026-07-09; **closed 2026-07-18 with v0.11.0** (the re-cut
 Wave 1–2 scope per the 2026-07-14 boundary re-cut — Wave 0 + the
 hygiene track H1–H6 had shipped early inside v0.10.18). Full plan:
 [`v0.11-plan.md`](releases/plans/v0.11-plan.md) — wave sequencing, the
 cycle-hygiene track (the 2026-07 practice-delta adoptions + the
 v0.10.17 deferred queue), the medical-device row split, and the
 ratification record. The remaining planned waves carry the **ratified
-2026-07-16 disposition** in
+2026-07-18 disposition** in
 [`v0.12-plan.md`](releases/plans/v0.12-plan.md) (Wave 4 phase 3 →
 v0.12-if-capacity; Wave 4 phases 1/2/4 + Wave 3 DORA + medical-device
 traceability → v1.1; Waves 5–6 → post-1.0; arXiv preprint = open
 decision).
 
-### v0.11.0 — The federal wave — SHIPPED (released 2026-07-16)
+### v0.11.0 — The federal wave — SHIPPED (released 2026-07-18)
 
 Three verified federal firsts on machine-readable rails: **FedRAMP
 CR26 SDR emission** (`evidentia conmon ksi` — the SDR
@@ -2263,7 +2263,7 @@ engineering-hardening batch addressed all three:
   maintainer — checked at PRR Row 21). P3 FIPS container variant stays gated on
   the federal-SI OpenPGP-interop answer.
 
-### Medical-device GRC feature line (v1.1+; re-cut 2026-07-16 from v0.11) — RESERVED (web-grounded research 2026-06-17)
+### Medical-device GRC feature line (v1.1+; re-cut 2026-07-18 from v0.11) — RESERVED (web-grounded research 2026-06-17)
 
 The medical-device-security direction the v0.10.10 FDA Section 524B catalogs opened, scanned + validated in a multi-angle web-grounded research pass. **Each feature gets a dedicated `polycentric-labcoat` research fleet at build-time** — the entries below are the high-level scan + positioning, not build specs. Effort and tier are planning-grade. The throughline: **don't rebuild commodity layers (STRIDE authoring, CBOM scanners) — ingest them; the uncontested slice is the open, signed, OSCAL/BOM-emitting evidence wrapper.**
 
@@ -2308,7 +2308,7 @@ Items deferred from Phase B audit v3 + integration plan §"v1.1+":
 
 ## v0.12 — Pre-1.0 hardening + GUI parity — PLANNED
 
-**The open cycle** (ratified 2026-07-16 at the v0.11.0 release prep).
+**The open cycle** (ratified 2026-07-18 at the v0.11.0 release prep).
 Full plan: [`v0.12-plan.md`](releases/plans/v0.12-plan.md) — the
 ratified disposition of the remaining v0.11 waves plus the LEAN v0.12
 scope: (1) the GUI parity pass for the five v0.11 federal api-only

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -13,7 +13,7 @@
 
 ---
 
-## Re-validation snapshot — 2026-07-16 (v0.11.0 PRE-TAG) — the federal wave
+## Re-validation snapshot — 2026-07-18 (v0.11.0 PRE-TAG) — the federal wave
 
 v0.11.0 ships the re-cut Wave 1–2 scope: FedRAMP CR26 SDR emission, OMB
 M-25-21 minimum-practice tracking, and OMB M-25-22 acquisition-lifecycle

--- a/docs/cli-gui-parity.yaml
+++ b/docs/cli-gui-parity.yaml
@@ -37,7 +37,7 @@
 # (The "~30% GUI reaches the CLI" figure was API breadth: 55/98 leaves have an
 #  API; 13 are now surfaced as a dedicated GUI screen.)
 #
-# Current distribution (2026-07-16, post-v0.11 Wave 2): 99 full / 7 api-only /
+# Current distribution (2026-07-18, post-v0.11 Wave 2): 99 full / 7 api-only /
 # 0 cli-only / 11 exempt (117 leaves) = 93.4% GUI coverage. The 7 api-only rows
 # are the five v0.11 federal AI-governance verbs (`ai-gov set-practice` +
 # `ai-gov acquisition *`) pending their console pass, plus the two

--- a/docs/releases/plans/v0.12-plan.md
+++ b/docs/releases/plans/v0.12-plan.md
@@ -1,6 +1,6 @@
 # v0.12 plan — Pre-1.0 hardening + GUI parity
 
-**Status: RATIFIED 2026-07-16** (scope disposition approved as proposed; the
+**Status: RATIFIED 2026-07-18** (scope disposition approved as proposed; the
 arXiv-preprint timing remains an explicitly open decision, to be settled at
 detailed v0.12 planning). This plan RE-CUTS the ratified 2026-07-09 v0.11
 plan: v0.11.0 shipped the re-cut Wave 1–2 scope (per the 2026-07-14 boundary
@@ -15,7 +15,7 @@ line.
 
 ---
 
-## Disposition of remaining v0.11 waves (ratified 2026-07-16)
+## Disposition of remaining v0.11 waves (ratified 2026-07-18)
 
 | Ratified v0.11 item | New home | Rationale |
 |---|---|---|
@@ -51,7 +51,7 @@ line.
    the next SDR block after `keySecurityIndicators`; skip if upstream churn
    makes it rework-prone inside the window.
 5. **CR26-fragility watches wired in** — (a) FedRAMP/schemas PR #4 merge →
-   drop the vendored `$ref` delta + re-pin (the 2026-07-16 re-vendor at the
+   drop the vendored `$ref` delta + re-pin (the 2026-07-18 re-vendor at the
    SDR 1.0.0 graduation retained it — upstream left the defect in place);
    (b) watch for upstream `additionalProperties` tightening (the emitted
    metadata block's validity depends on its absence); (c) a NEW dated
@@ -72,6 +72,6 @@ while v0.12 builds.
 
 ---
 
-*Plan ratified at v0.11.0 release prep (2026-07-16); it also satisfies the
+*Plan ratified at v0.11.0 release prep (2026-07-18); it also satisfies the
 roadmap-currency gate (exactly-one-PLANNED-h2 + plan-doc-exists). Detailed
 wave/sequencing planning follows after v0.11.0 ships.*

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -3408,7 +3408,7 @@ by this entry.
 
 ---
 
-## v0.11.0 attack-surface delta — the federal wave (PRE-TAG 2026-07-16)
+## v0.11.0 attack-surface delta — the federal wave (PRE-TAG 2026-07-18)
 
 v0.11.0 adds three surface families; none opens a new network listener
 or credential path.

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No changes yet on the v0.11.x development branch._
 
-## [0.11.0] - 2026-07-16
+## [0.11.0] - 2026-07-18
 
 **Theme**: *The federal wave — three verified federal firsts on machine-readable rails.* v0.11.0 ships the re-cut Wave 1-2 scope of the v0.11 plan: **FedRAMP CR26 Security Decision Record emission** — `evidentia conmon ksi` emits the SDR `keySecurityIndicators` block (10 families / 46 KSIs) conformant to FedRAMP's official 2026-06-24 schemas, vendored at pinned upstream SHAs (re-verified at the schemas' 1.0.0 graduation) and drift-watched weekly — the **first production-grade open-source emitter** of the CR26 SDR format, and the first from any established tool; **OMB M-25-21 minimum-practice tracking** — structured per-practice status for the memo's seven §4(b) practices with CAIO waiver objects carrying the annual re-certification and 30-day OMB-report clocks, structure the federal AI Use Case Inventory lacks entirely; and **OMB M-25-22 acquisition-lifecycle tracking** — Evidentia's first procurement surface, modeling the memo's six §4 phases as auditable records with the §4(a) high-impact determination tie-in. The cycle's OSCAL 1.2.1 → 1.2.2 evaluation closed with a ratified **DEFER-WITH-TRIGGER** verdict (emitted documents stay on 1.2.1; adoption triggers armed), and a pre-release **claim-accuracy sweep** re-verified every public claim against primary sources (parity restated at the live 93.4%; machine-gated counts; first-mover registry updated with explicit caveats). Test suite: 4,947 passed; mypy strict clean; ruff clean.
 
-**Deferred (ratified v0.12 plan re-cut, 2026-07-16 — see [`docs/releases/plans/v0.12-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.12-plan.md))**: Wave 4 phase 3 (EU-AI-Act ↔ ISO 42001 crosswalk) → v0.12-if-capacity; Wave 4 phases 1/2/4, Wave 3 DORA, and the medical-device traceability enrichment → v1.1; Waves 5-6 (OpenVEX/VSA, SARIF collector, auto-review) → post-1.0; arXiv preprint timing = open decision. The GUI parity pass for the five federal api-only verbs leads v0.12.
+**Deferred (ratified v0.12 plan re-cut, 2026-07-18 — see [`docs/releases/plans/v0.12-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.12-plan.md))**: Wave 4 phase 3 (EU-AI-Act ↔ ISO 42001 crosswalk) → v0.12-if-capacity; Wave 4 phases 1/2/4, Wave 3 DORA, and the medical-device traceability enrichment → v1.1; Waves 5-6 (OpenVEX/VSA, SARIF collector, auto-review) → post-1.0; arXiv preprint timing = open decision. The GUI parity pass for the five federal api-only verbs leads v0.12.
 
 ### Changed
 

--- a/docs/wiki/6-project/roadmap.md
+++ b/docs/wiki/6-project/roadmap.md
@@ -2043,20 +2043,20 @@ v0.11.0's boundary re-cuts to Waves 1–2. No package
 
 ## v0.11 — Federal-compliance theme + AI governance — SHIPPED
 
-Opened 2026-07-09; **closed 2026-07-16 with v0.11.0** (the re-cut
+Opened 2026-07-09; **closed 2026-07-18 with v0.11.0** (the re-cut
 Wave 1–2 scope per the 2026-07-14 boundary re-cut — Wave 0 + the
 hygiene track H1–H6 had shipped early inside v0.10.18). Full plan:
 [`v0.11-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.11-plan.md) — wave sequencing, the
 cycle-hygiene track (the 2026-07 practice-delta adoptions + the
 v0.10.17 deferred queue), the medical-device row split, and the
 ratification record. The remaining planned waves carry the **ratified
-2026-07-16 disposition** in
+2026-07-18 disposition** in
 [`v0.12-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.12-plan.md) (Wave 4 phase 3 →
 v0.12-if-capacity; Wave 4 phases 1/2/4 + Wave 3 DORA + medical-device
 traceability → v1.1; Waves 5–6 → post-1.0; arXiv preprint = open
 decision).
 
-### v0.11.0 — The federal wave — SHIPPED (released 2026-07-16)
+### v0.11.0 — The federal wave — SHIPPED (released 2026-07-18)
 
 Three verified federal firsts on machine-readable rails: **FedRAMP
 CR26 SDR emission** (`evidentia conmon ksi` — the SDR
@@ -2266,7 +2266,7 @@ engineering-hardening batch addressed all three:
   maintainer — checked at PRR Row 21). P3 FIPS container variant stays gated on
   the federal-SI OpenPGP-interop answer.
 
-### Medical-device GRC feature line (v1.1+; re-cut 2026-07-16 from v0.11) — RESERVED (web-grounded research 2026-06-17)
+### Medical-device GRC feature line (v1.1+; re-cut 2026-07-18 from v0.11) — RESERVED (web-grounded research 2026-06-17)
 
 The medical-device-security direction the v0.10.10 FDA Section 524B catalogs opened, scanned + validated in a multi-angle web-grounded research pass. **Each feature gets a dedicated `polycentric-labcoat` research fleet at build-time** — the entries below are the high-level scan + positioning, not build specs. Effort and tier are planning-grade. The throughline: **don't rebuild commodity layers (STRIDE authoring, CBOM scanners) — ingest them; the uncontested slice is the open, signed, OSCAL/BOM-emitting evidence wrapper.**
 
@@ -2311,7 +2311,7 @@ Items deferred from Phase B audit v3 + integration plan §"v1.1+":
 
 ## v0.12 — Pre-1.0 hardening + GUI parity — PLANNED
 
-**The open cycle** (ratified 2026-07-16 at the v0.11.0 release prep).
+**The open cycle** (ratified 2026-07-18 at the v0.11.0 release prep).
 Full plan: [`v0.12-plan.md`](https://github.com/Polycentric-Labs/evidentia/blob/main/docs/releases/plans/v0.12-plan.md) — the
 ratified disposition of the remaining v0.11 waves plus the LEAN v0.12
 scope: (1) the GUI parity pass for the five v0.11 federal api-only

--- a/packages/evidentia-core/src/evidentia_core/fedramp/schemas/README.md
+++ b/packages/evidentia-core/src/evidentia_core/fedramp/schemas/README.md
@@ -23,7 +23,7 @@ JSON Pointer in the URI **path** (`...json/$defs/x`) instead of the **fragment**
 (`...json#/$defs/x`), so no conforming JSON Schema 2020-12 validator can
 resolve them (upstream [issue #3](https://github.com/FedRAMP/schemas/issues/3),
 fix [PR #4](https://github.com/FedRAMP/schemas/pull/4) — still unmerged at the
-2026-07-16 re-vendor; the SDR schema's 0.1.0 → 1.0.0 graduation fixed the
+2026-07-18 re-vendor; the SDR schema's 0.1.0 → 1.0.0 graduation fixed the
 draft's vacuous `items` wrapper nesting and added proper **local** `#/$defs`
 refs, but left the one cross-document ref malformed). The vendored SDR schema
 carries exactly **one** such rewrite. When the

--- a/packages/evidentia-core/src/evidentia_core/fedramp/schemas/UPSTREAM.json
+++ b/packages/evidentia-core/src/evidentia_core/fedramp/schemas/UPSTREAM.json
@@ -1,6 +1,6 @@
 {
   "comment": "Provenance pins for the vendored FedRAMP CR26 artifacts. Single source of truth for scripts/check_fedramp_upstream_drift.py (the fedramp-schema-watch sentinel baseline) and for scripts/catalogs/gen_fedramp_ksi.py (the KSI catalog generator pin). Update ONLY via a deliberate re-sync: re-vendor, re-verify, and re-run the generator together. See README.md in this directory.",
-  "verified_at": "2026-07-16",
+  "verified_at": "2026-07-18",
   "rules": {
     "repo": "FedRAMP/rules",
     "commit": "12fe1b60f578ab448c26d143baac99d16d8bfe14",
@@ -33,7 +33,7 @@
       "fedramp-security-decision-record-schema-2026-06-24.json": {
         "blob_sha": "31d2b7207ec04037fb7537392375c7bb045ced9a",
         "sha256_upstream": "d598637cd4bb0f52425d7186ddc6f9463dcdda02734533623322e031d9b97b1a",
-        "local_delta": "One cross-document $ref rewritten from '...json/$defs/certificationPackageOverviewUri' to '...json#/$defs/certificationPackageOverviewUri' (JSON Pointer moved into the URI fragment, as JSON Schema 2020-12 requires). Upstream defect: FedRAMP/schemas issue #3, fix PR #4 (still unmerged at the 2026-07-16 re-vendor; the 1.0.0 graduation did NOT include it — re-verified). Drop this delta when the upstream fix merges and re-vendor byte-identical."
+        "local_delta": "One cross-document $ref rewritten from '...json/$defs/certificationPackageOverviewUri' to '...json#/$defs/certificationPackageOverviewUri' (JSON Pointer moved into the URI fragment, as JSON Schema 2020-12 requires). Upstream defect: FedRAMP/schemas issue #3, fix PR #4 (still unmerged at the 2026-07-18 re-vendor; the 1.0.0 graduation did NOT include it — re-verified). Drop this delta when the upstream fix merges and re-vendor byte-identical."
       },
       "fedramp-common-definitions-schema-2026-06-24.json": {
         "blob_sha": "534853e39c2863997ccf03245fcadbc293bcc5b3",


### PR DESCRIPTION
## verify-recipes first-run fix + release-date correction

**verify-recipes' first scheduled run (2026-07-17) failed** — the PEP 740 sweep reported `0/8` wheels verified even though `pypi-attestations` verified all 8. Root cause: as of pypi-attestations 0.0.29 the `OK:` line goes to **stderr**, so the step's stdout-only capture (`out=$(...)`) was empty and the `grep "^OK:"` counter matched nothing. The attestations are valid — only the sentinel's counting was wrong (confirmed empirically: the verify command exits 0 and prints OK to stderr).

**Fix:** count by the verifier's **exit code** (`if out=$(... 2>&1); then ok=$((ok+1)); fi`) — robust to stream placement and format changes; `2>&1` keeps the OK/error line in the job log. Verified locally against the published v0.10.18 wheels (counts correctly). `check_workflow_tools --strict` + `audit_workflow_permissions --strict` + zizmor all clean.

**Also — date v0.11.0 as 2026-07-18** (the actual ship date) across CHANGELOG, README recent-releases, ROADMAP, capability-matrix, threat-model, cli-gui-parity, and the v0.12 plan. Re-ran the FedRAMP drift probe fresh at the tag gate (**clean** — pins still match live upstream) and stamped `UPSTREAM.json` `verified_at` + the re-vendor provenance notes 2026-07-18.

**Verification:** full suite **4,947 passed**; ruff, mypy, docs-health --strict 0 FAIL, doc-counts, parity, version-consistency, roadmap-currency, mirrors --check all green; no package code change.