### PR TITLE
Fix(ci): Bump verify-recipes cosign to v2.6.3 for referrer-stored attestation discovery

### DIFF
--- a/.github/workflows/verify-recipes.yml
+++ b/.github/workflows/verify-recipes.yml
@@ -61,7 +61,13 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
         with:
-          cosign-release: 'v2.4.1'
+          # cosign >= 2.6 is required to DISCOVER the SLSA provenance
+          # attestation that actions/attest-build-provenance stores via the
+          # OCI 1.1 referrers API (Recipe 3). cosign 2.4.x verifies the image
+          # signature fine but returns "no matching attestations" for the
+          # referrer-stored attestation. gh attestation verify (any version)
+          # also finds it; this recipe uses cosign, so pin a version that can.
+          cosign-release: 'v2.6.3'
 
       # Same pinned scanner the osv gate / rescan use (version + SHA256).
       - name: Install osv-scanner (v2.4.0, checksum-verified)

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -129,6 +129,13 @@ osv-scanner scan source -L evidentia-sbom.cdx.json
 The container's `cosign verify` output above includes the SLSA Provenance v1
 attestation inline. To extract it:
 
+> **Requires cosign ≥ 2.6.** The provenance attestation is stored via the
+> OCI 1.1 referrers API (pushed by `actions/attest-build-provenance`); cosign
+> 2.4.x can verify the image signature but returns `no matching attestations`
+> for the referrer-stored attestation. If you are pinned to an older cosign,
+> use the tool-native `gh attestation verify oci://ghcr.io/polycentric-labs/evidentia:v0.11.0 -R Polycentric-Labs/evidentia`
+> instead (any `gh` version finds it).
+
 **Bash / Linux / macOS**
 
 ```bash

--- a/docs/wiki/6-project/verification.md
+++ b/docs/wiki/6-project/verification.md
@@ -132,6 +132,13 @@ osv-scanner scan source -L evidentia-sbom.cdx.json
 The container's `cosign verify` output above includes the SLSA Provenance v1
 attestation inline. To extract it:
 
+> **Requires cosign ≥ 2.6.** The provenance attestation is stored via the
+> OCI 1.1 referrers API (pushed by `actions/attest-build-provenance`); cosign
+> 2.4.x can verify the image signature but returns `no matching attestations`
+> for the referrer-stored attestation. If you are pinned to an older cosign,
+> use the tool-native `gh attestation verify oci://ghcr.io/polycentric-labs/evidentia:v0.11.0 -R Polycentric-Labs/evidentia`
+> instead (any `gh` version finds it).
+
 **Bash / Linux / macOS**
 
 ```bash


### PR DESCRIPTION
## Second first-run verify-recipes defect — cosign too old to discover the SLSA attestation

The PEP 740 counting fix (#200) let the dispatched run reach **Recipe 3**, exposing a second, previously-masked defect: the pinned **cosign v2.4.1** cannot discover the SLSA provenance attestation that `actions/attest-build-provenance` stores via the **OCI 1.1 referrers API** — it verifies the image *signature* fine (Recipe 2 passed) but returns `no matching attestations` for the *attestation*.

**Empirical proof against the published v0.10.18 image:**
| Tool | Result |
|---|---|
| cosign **v2.4.1** (old CI pin) | ❌ `no matching attestations` |
| cosign **v2.6.3** (new pin) | ✅ exit 0, valid in-toto envelope, `json.load` assertion passes |
| `gh attestation verify oci://…` | ✅ exit 0 |

The attestation **exists and is valid** — only old-cosign discovery is broken. No release artifact is affected.

**Changes:** pin `cosign-release: v2.6.3` in `verify-recipes.yml` (with a why-comment); add a *requires cosign ≥ 2.6* note + the `gh attestation verify` fallback to `docs/verification.md` (+ wiki mirror).

**Validation:** full local simulation of **all 5 recipes** against the published v0.10.18 artifacts — PEP 740 8/8, cosign signature, cosign attestation, gh attestation, SBOM+osv — **all PASS**. `check_workflow_tools --strict` / `audit_workflow_permissions --strict` / zizmor / `check_docs_health --strict` green; recipe-drift guard tokens intact.