### PR TITLE
Docs(about): Add DSSE to the evidence-integrity parenthetical

### DIFF
--- a/.github/repo-description.txt
+++ b/.github/repo-description.txt
@@ -1,1 +1,1 @@
-Open-source Python GRC tool: gap analysis, AI risk statements, OSCAL-first compliance automation. Enterprise-grade evidence integrity (Sigstore + GPG), CycloneDX SBOM, PyPI Trusted Publisher OIDC + PEP 740 attestations.
+Open-source Python GRC tool: gap analysis, AI risk statements, OSCAL-first compliance automation. Enterprise-grade evidence integrity (Sigstore + GPG + DSSE), CycloneDX SBOM, PyPI Trusted Publisher OIDC + PEP 740 attestations.


### PR DESCRIPTION
Per the post-v0.11.0 editorial call: the About copy is unchanged except the evidence-integrity parenthetical, which gains **DSSE** — the air-gapped DSSE/in-toto signing path has shipped since v0.10.16, so the description now names all three signing rails: **Sigstore + GPG + DSSE**.

The live GitHub About gets re-asserted from this tracked file after merge (`gh repo edit --description "$(cat .github/repo-description.txt)"`), per the release-checklist Step 7 managed-as-code convention. 220 → 227 chars, no version literal.