### PR TITLE
Fix(readme): Correct four stale claims, and gate the parity badge so …

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://pypi.org/project/evidentia/"><img src="https://img.shields.io/pypi/v/evidentia.svg" alt="PyPI version"></a>
   <a href="https://github.com/Polycentric-Labs/evidentia/actions/workflows/test.yml"><img src="https://github.com/Polycentric-Labs/evidentia/actions/workflows/test.yml/badge.svg?branch=main" alt="tests"></a>
   <a href="https://codecov.io/gh/Polycentric-Labs/evidentia"><img src="https://codecov.io/gh/Polycentric-Labs/evidentia/branch/main/graph/badge.svg" alt="codecov"></a>
-  <a href="docs/parity-coverage.md"><img src="https://img.shields.io/badge/CLI%E2%86%94GUI%20parity-93%25-brightgreen.svg" alt="CLI↔GUI parity"></a>
+  <a href="docs/parity-coverage.md"><img src="https://img.shields.io/badge/CLI%E2%86%94GUI%20parity-100%25-brightgreen.svg" alt="CLI↔GUI parity"></a>
 </p>
 
 <p>
@@ -115,8 +115,8 @@ See it first, no install — a self-hosted [asciinema](https://asciinema.org/) r
 | Inter-framework crosswalks | 16 |
 | Evidence collectors | 14 |
 | MCP tools | 13 |
-| OSCAL serializations | 1 (OpenSSF OSPS Baseline; more on the v0.11+ roadmap) |
-| Test suite | 4,900+ tests; mypy strict; ruff clean |
+| OSCAL serializations | 1 (OpenSSF OSPS Baseline; more on the roadmap) |
+| Test suite | 5,000+ tests; mypy strict; ruff clean |
 
 ## Documentation
 

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -43,6 +43,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import sys
@@ -203,6 +204,65 @@ def load_code_counts() -> dict[str, int]:
 # ─────────────────────────────── main ────────────────────────────────────
 
 
+_PARITY_BADGE_RE = re.compile(
+    r"CLI%E2%86%94GUI%20parity-(?P<pct>\d+(?:\.\d+)?)%25"
+)
+
+
+def check_parity_badge(readme_text: str) -> list[str]:
+    """Assert the README's CLI<->GUI parity badge matches the live parity number.
+
+    The badge is a hand-written literal in the README header. It was set to 93%
+    during the pre-v0.11.0 claim sweep, when parity really was 93.4%. Parity
+    reached 100% in v0.12 batch 2 and the badge did not move, because nothing
+    compared the two: this script gated catalogs, crosswalks, collectors and MCP
+    tools, and ``check_parity.py`` never looked at the README. So the most
+    prominent number on the project's most public surface understated a shipped
+    capability by seven points, silently, for a full release.
+
+    That is the same defect class the v0.12.0 review was written to catch, so it
+    gets the same treatment: the claim is derived from the code and compared,
+    rather than trusted because someone typed it once.
+
+    Rounding: the badge carries whole percent (``100%``), while
+    ``check_parity.py`` reports a float (``100.0``). Compare on the rounded
+    integer so a 93.4 -> 93 badge stays legal.
+    """
+    m = _PARITY_BADGE_RE.search(readme_text)
+    if m is None:
+        return [
+            "README.md has no CLI<->GUI parity badge matching the expected "
+            "shields.io pattern; the badge was removed or reformatted, so the "
+            "gate can no longer verify it"
+        ]
+
+    # Derive from docs/cli-gui-parity.yaml, the same source of truth
+    # check_parity.py uses. NOT from docs/parity-coverage.md: that file is
+    # generated on demand and is itself drift-gated by nothing, so comparing
+    # to it would chain one ungated claim to another.
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "check_parity_for_badge", SCRIPTS_DIR / "check_parity.py"
+        )
+        if spec is None or spec.loader is None:  # pragma: no cover - import guard
+            raise ImportError("cannot load scripts/check_parity.py")
+        parity = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(parity)
+        rows = parity.load_manifest()["commands"]
+        live = parity.coverage_pct(parity.status_counts(rows))
+    except Exception as exc:  # pragma: no cover - import/IO guard
+        return [f"cannot compute live parity coverage for the badge check: {exc}"]
+
+    badge = float(m.group("pct"))
+    if round(badge) != round(live):
+        return [
+            f"README parity badge says {m.group('pct')}%, but check_parity.py "
+            f"reports {live:.1f}%. Update the badge in README.md (and re-run "
+            "scripts/wiki/sync_mirrors.py if a mirror carries it)."
+        ]
+    return []
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -213,7 +273,8 @@ def main(argv: list[str] | None = None) -> int:
 
     code = load_code_counts()
     readme = parse_readme_counts(README_PATH.read_text(encoding="utf-8"))
-    errors = compare_counts(code, readme)
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    errors = compare_counts(code, readme) + check_parity_badge(readme_text)
 
     if args.json:
         print(
@@ -229,6 +290,8 @@ def main(argv: list[str] | None = None) -> int:
         cval = code.get(key, "?")
         rval = readme.get(key, "?")
         print(f"  {key:<11} code={cval!s:>4}  readme={rval!s:>4}")
+    badge = _PARITY_BADGE_RE.search(readme_text)
+    print(f"  {'parity badge':<11} readme={badge.group('pct') + '%' if badge else '?':>5}")
     print()
     if errors:
         print(f"check_doc_counts: FAIL ({len(errors)} issue(s)).")

--- a/tests/scripts/test_check_doc_counts.py
+++ b/tests/scripts/test_check_doc_counts.py
@@ -134,3 +134,71 @@ def test_count_collector_endpoints_excludes_ocsf_ingest() -> None:
         }
     }
     assert c.count_collector_endpoints(openapi) == 1
+
+
+# ── parity badge (v0.12.1) ────────────────────────────────────────────────
+
+_BADGE = (
+    '<a href="docs/parity-coverage.md"><img src="https://img.shields.io/badge/'
+    'CLI%E2%86%94GUI%20parity-{pct}%25-brightgreen.svg" alt="CLI↔GUI parity"></a>'
+)
+
+
+def _patch_live_pct(monkeypatch, pct: float) -> None:
+    """Stand in for the check_parity import so the test needs no manifest."""
+    import types
+
+    fake = types.SimpleNamespace(
+        load_manifest=lambda *a, **k: {"commands": []},
+        status_counts=lambda rows: {},
+        coverage_pct=lambda counts: pct,
+    )
+
+    class _Loader:
+        @staticmethod
+        def exec_module(mod) -> None:
+            mod.load_manifest = fake.load_manifest
+            mod.status_counts = fake.status_counts
+            mod.coverage_pct = fake.coverage_pct
+
+    class _Spec:
+        loader = _Loader()
+
+    monkeypatch.setattr(
+        c.importlib.util, "spec_from_file_location", lambda *a, **k: _Spec()
+    )
+    monkeypatch.setattr(
+        c.importlib.util, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+
+def test_parity_badge_passes_when_it_matches_live(monkeypatch) -> None:
+    _patch_live_pct(monkeypatch, 100.0)
+    assert c.check_parity_badge(_BADGE.format(pct=100)) == []
+
+
+def test_parity_badge_fails_on_the_real_v0120_drift(monkeypatch) -> None:
+    """The exact defect: badge frozen at 93 while parity reached 100.
+
+    The badge was hardcoded during the pre-v0.11.0 claim sweep and nothing
+    compared it to the live number, so it understated a shipped capability by
+    seven points on the project's most public surface for a full release.
+    """
+    _patch_live_pct(monkeypatch, 100.0)
+    errs = c.check_parity_badge(_BADGE.format(pct=93))
+    assert len(errs) == 1
+    assert "93%" in errs[0] and "100.0%" in errs[0]
+
+
+def test_parity_badge_tolerates_rounding(monkeypatch) -> None:
+    """A whole-percent badge may legally round a fractional coverage number."""
+    _patch_live_pct(monkeypatch, 93.4)
+    assert c.check_parity_badge(_BADGE.format(pct=93)) == []
+
+
+def test_parity_badge_fails_when_the_badge_is_missing(monkeypatch) -> None:
+    """A removed or reformatted badge must fail loudly, not silently pass."""
+    _patch_live_pct(monkeypatch, 100.0)
+    errs = c.check_parity_badge("# Evidentia\n\nNo badge here.\n")
+    assert len(errs) == 1
+    assert "no CLI<->GUI parity badge" in errs[0]


### PR DESCRIPTION
…it cannot drift again

The v0.12.0 README understated a shipped capability on the project's most public surface, and nothing was watching.

The CLI<->GUI parity badge read 93%. Actual coverage is 100.0%, per check_parity.py and docs/parity-coverage.md ("104 of 104 coverable CLI leaves"). The badge was hardcoded at ac62466 during the pre-v0.11.0 claim sweep, when parity really was 93.4%. Parity reached 100% in v0.12 batch 2 and the badge did not move, because nothing compared the two: check_doc_counts.py gated catalogs, crosswalks, collectors and MCP tools but not the badge, and check_parity.py never looked at the README.

So the fix is not the digit. check_doc_counts.py now derives live coverage from docs/cli-gui-parity.yaml, the same source of truth check_parity.py uses, and fails when the badge disagrees. It deliberately does NOT compare against docs/parity-coverage.md: that file is generated on demand and is itself gated by nothing, so trusting it would chain one ungated claim to another. Whole- percent rounding is tolerated so a 93.4 -> 93 badge stays legal, and a removed or reformatted badge fails loudly rather than silently passing.

Negative-tested: restoring the 93% badge produces
  "README parity badge says 93%, but check_parity.py reports 100.0%"
and exit 1. Four unit tests pin the behaviour, including the exact v0.12.0 drift and the missing-badge case.

Three other stale claims, found in the same read-through:

  - "4,900+ tests" understated a suite that now runs 5,103. The floor idiom is kept, raised to "5,000+".
  - "more on the v0.11+ roadmap" still pointed forward at a release that shipped on 2026-07-18.
  - (No change) The at-a-glance counts, the 1,196 NIST controls, the container tag and the Python floor were all verified accurate and left alone.

Verified: full gate suite 14/14 green, 5,103 passed / 14 skipped, README 10,692 bytes against the 11,300 guard.