### PR TITLE
Fix Dependabot config: default-days cooldown for the actions and docker ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -177,10 +177,14 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    # Dependabot's validator (observed 2026-08-28) rejects the per-semver
+    # cooldown keys for this ecosystem; only default-days is supported here.
+    # 7 days replaces the old 7/3/2 split at its conservative end: a settle
+    # window before adopting a freshly published action release is a
+    # supply-chain control (the compromised-release class), and the weekly
+    # grouped schedule means it costs at most one cycle.
     cooldown:
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 2
+      default-days: 7
     groups:
       github-actions:
         applies-to: version-updates
@@ -211,10 +215,15 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    # Dependabot's validator (observed 2026-08-28) rejects the per-semver
+    # cooldown keys for this ecosystem; only default-days is supported here.
+    # 3 days replaces the old 14/7/3 split at its fast end deliberately:
+    # python base VERSION bumps are blocked by the ignore rules below (the
+    # real #83-class guard, with the build smoke test), so what actually
+    # flows is digest bumps carrying CVE fixes, which should not sit in a
+    # two-week cooldown.
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 3
     groups:
       docker:
         applies-to: version-updates


### PR DESCRIPTION
Dependabot's config validator now rejects the per-semver cooldown keys for the github-actions and docker ecosystems (check run 99014357899 on main 0c13af3; the docs' cooldown support table confirms only default-days + include/exclude apply there). The keys were valid when v0.12 introduced them; the validator tightened upstream, and the parse failure halts every Dependabot run, including the batch regeneration expected after this morning's pre-fix PR closures.

Collapse keeps each block's intent: actions default-days 7 (settle window before adopting a fresh action release; weekly grouping means it costs at most one cycle); docker default-days 3 (version bumps are already blocked by the ignore rules, so what flows is digest bumps carrying CVE fixes). uv and npm keep their valid per-semver splits.