### PR TITLE
Fix OSCAL emitters: omit empty optional arrays (unblocks trestle 5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The OSCAL emitters no longer write empty optional arrays: a zero-gap
+  Assessment Results omits `observations`/`findings`, and a POA&M whose
+  severity filter selects no gaps omits `observations`/`risks` (OSCAL
+  minItems=1 forbids the empty form; trestle >= 5.0 enforces what the 4.x
+  line tolerated, and the round-trip conformance test caught it the moment
+  the isolated trestle 5.0.0 bump arrived). Verified against both trestle
+  4.2 and a 5.0 overlay.
 - `check_roadmap_currency.py`'s A5 ordering key (V13-21): a bare cycle
   heading now ranks above its own concrete releases, matching the file's
   actual layout, and `vX.Y+` no longer collides with `vX.Y`.

--- a/docs/wiki/6-project/changelog.md
+++ b/docs/wiki/6-project/changelog.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The OSCAL emitters no longer write empty optional arrays: a zero-gap
+  Assessment Results omits `observations`/`findings`, and a POA&M whose
+  severity filter selects no gaps omits `observations`/`risks` (OSCAL
+  minItems=1 forbids the empty form; trestle >= 5.0 enforces what the 4.x
+  line tolerated, and the round-trip conformance test caught it the moment
+  the isolated trestle 5.0.0 bump arrived). Verified against both trestle
+  4.2 and a 5.0 overlay.
 - `check_roadmap_currency.py`'s A5 ordering key (V13-21): a bare cycle
   heading now ranks above its own concrete releases, matching the file's
   actual layout, and `vX.Y+` no longer collides with `vX.Y`.

--- a/packages/evidentia-core/src/evidentia_core/oscal/exporter.py
+++ b/packages/evidentia-core/src/evidentia_core/oscal/exporter.py
@@ -162,6 +162,35 @@ def gap_report_to_oscal_ar(
     findings_output = [_gap_to_finding(gap) for gap in report.gaps]
     observations = [_gap_to_observation(gap, resource_by_control) for gap in report.gaps]
 
+    result_entry: dict[str, Any] = {
+        "uuid": result_uuid,
+        "title": "Evidentia Gap Analysis Result",
+        "description": (
+            f"Automated gap analysis of {report.organization} "
+            f"against {', '.join(report.frameworks_analyzed)}."
+        ),
+        "start": report.analyzed_at.isoformat(),
+        "end": report.analyzed_at.isoformat(),
+        "reviewed-controls": {
+            "control-selections": [
+                {
+                    "description": (f"Controls from {fw}"),
+                    "include-all": {},
+                }
+                for fw in report.frameworks_analyzed
+            ],
+        },
+    }
+    # OSCAL minItems=1: ``observations`` and ``findings`` are OPTIONAL
+    # arrays that must be OMITTED when empty, never emitted as ``[]``.
+    # Trestle 4.2 tolerated the empty form; trestle >= 5.0 enforces the
+    # schema and rejects it (caught by the round-trip conformance test
+    # when the isolated 5.0.0 bump arrived, 2026-08-29).
+    if observations:
+        result_entry["observations"] = observations
+    if findings_output:
+        result_entry["findings"] = findings_output
+
     ar_doc: dict[str, Any] = {
         "assessment-results": {
             "uuid": ar_uuid,
@@ -208,35 +237,14 @@ def gap_report_to_oscal_ar(
             "import-ap": {
                 "href": "#assessment-plan-placeholder",
             },
-            "results": [
-                {
-                    "uuid": result_uuid,
-                    "title": "Evidentia Gap Analysis Result",
-                    "description": (
-                        f"Automated gap analysis of {report.organization} "
-                        f"against {', '.join(report.frameworks_analyzed)}."
-                    ),
-                    "start": report.analyzed_at.isoformat(),
-                    "end": report.analyzed_at.isoformat(),
-                    "reviewed-controls": {
-                        "control-selections": [
-                            {
-                                "description": (f"Controls from {fw}"),
-                                "include-all": {},
-                            }
-                            for fw in report.frameworks_analyzed
-                        ],
-                    },
-                    "observations": observations,
-                    "findings": findings_output,
-                }
-            ],
+            "results": [result_entry],
         }
     }
 
-    # OSCAL 1.1.2 allows an optional top-level ``back-matter`` alongside
-    # ``results``. Only emit it when there are resources to attach —
-    # empty arrays are valid OSCAL but add noise to the diff.
+    # ``back-matter`` is optional alongside ``results``; emit it only when
+    # there are resources to attach. Like observations/findings above, an
+    # empty ``resources`` array would violate OSCAL's minItems constraint
+    # (the earlier claim here that empty arrays are valid OSCAL was wrong).
     if back_matter_resources:
         ar_doc["assessment-results"]["back-matter"] = {
             "resources": back_matter_resources,

--- a/packages/evidentia-core/src/evidentia_core/oscal/poam_exporter.py
+++ b/packages/evidentia-core/src/evidentia_core/oscal/poam_exporter.py
@@ -180,11 +180,20 @@ def gap_report_to_oscal_poam(
             "import-ssp": {
                 "href": "#system-security-plan-placeholder",
             },
-            "observations": observations,
-            "risks": risks,
             "poam-items": poam_items,
         }
     }
+
+    # OSCAL minItems=1: ``observations`` and ``risks`` are OPTIONAL arrays
+    # that must be OMITTED when the severity filter selects no gaps, never
+    # emitted as ``[]`` (trestle >= 5.0 enforces what the 4.x line
+    # tolerated). ``poam-items`` is REQUIRED and stays unconditional: a
+    # POA&M with nothing materialized failing schema validation is correct
+    # signal, not a shape to paper over.
+    if observations:
+        doc["plan-of-action-and-milestones"]["observations"] = observations
+    if risks:
+        doc["plan-of-action-and-milestones"]["risks"] = risks
 
     if back_matter_resources:
         doc["plan-of-action-and-milestones"]["back-matter"] = {

--- a/tests/unit/test_oscal/test_exporter.py
+++ b/tests/unit/test_oscal/test_exporter.py
@@ -489,3 +489,35 @@ def test_vendor_resource_with_findings_coexist() -> None:
             h["algorithm"] == "SHA-256"
             for h in r["rlinks"][0]["hashes"]
         )
+
+
+class TestEmptyArrayOmission:
+    """OSCAL minItems=1: optional arrays are OMITTED when empty, never
+    emitted as ``[]``. Trestle 4.2 tolerated an empty observations/findings
+    array; trestle >= 5.0 enforces the schema and rejects it, which is how
+    the isolated compliance-trestle 5.0.0 bump exposed the defect (V13
+    cycle, 2026-08-29)."""
+
+    def _zero_gap_report(self) -> GapAnalysisReport:
+        return _make_report().model_copy(
+            update={
+                "gaps": [],
+                "total_gaps": 0,
+                "high_gaps": 0,
+                "medium_gaps": 0,
+                "prioritized_roadmap": [],
+                "coverage_percentage": 100.0,
+            }
+        )
+
+    def test_zero_gap_ar_omits_observations_and_findings(self) -> None:
+        result = gap_report_to_oscal_ar(self._zero_gap_report())
+        res = result["assessment-results"]["results"][0]
+        assert "observations" not in res
+        assert "findings" not in res
+
+    def test_gapful_ar_keeps_observations_and_findings(self) -> None:
+        result = gap_report_to_oscal_ar(_make_report())
+        res = result["assessment-results"]["results"][0]
+        assert len(res["observations"]) == 2
+        assert len(res["findings"]) == 2

--- a/tests/unit/test_oscal/test_poam_exporter.py
+++ b/tests/unit/test_oscal/test_poam_exporter.py
@@ -346,3 +346,29 @@ class TestDeterminism:
         # (Other top-level UUIDs differ between emits — only the
         # back-matter digest is integrity-bound to the record.)
         assert digest1 == digest2
+
+
+class TestEmptyArrayOmission:
+    """OSCAL minItems=1: the optional ``observations`` and ``risks`` arrays
+    are OMITTED when the severity filter selects no gaps, never emitted as
+    ``[]`` (trestle >= 5.0 rejects empty arrays the 4.x line tolerated).
+    ``poam-items`` is a REQUIRED field and stays as-is: a POA&M with no
+    materialized items failing schema validation is correct signal, not a
+    shape to paper over."""
+
+    def test_filtered_to_empty_poam_omits_optional_arrays(self) -> None:
+        # MEDIUM-only gaps: the default CRITICAL+HIGH filter selects none.
+        report = _make_report([_make_gap(severity=GapSeverity.MEDIUM)])
+        doc = gap_report_to_oscal_poam(report)
+        poam = doc["plan-of-action-and-milestones"]
+        assert "observations" not in poam
+        assert "risks" not in poam
+        assert poam["poam-items"] == []
+
+    def test_selected_gaps_keep_observations_and_risks(self) -> None:
+        report = _make_report([_make_gap(severity=GapSeverity.HIGH)])
+        doc = gap_report_to_oscal_poam(report)
+        poam = doc["plan-of-action-and-milestones"]
+        assert len(poam["observations"]) == 1
+        assert len(poam["risks"]) == 1
+        assert len(poam["poam-items"]) == 1


### PR DESCRIPTION
OSCAL gives observations, findings, and risks minItems=1: an empty array is invalid and the field must be omitted. Trestle 4.2 tolerated the empty form, 5.0 enforces the schema, and the round-trip conformance test caught our defect the moment the isolated trestle 5.0.0 bump (#266) arrived. The defect is ours, and fixing it improves shipped output regardless of the bump.

gap_report_to_oscal_ar includes observations/findings only when a report has gaps; gap_report_to_oscal_poam includes observations/risks only when the severity filter selects gaps; poam-items is required and stays unconditional. Written red-first, verified against BOTH oracles (pinned 4.2 and a 5.0 overlay: 465 tests green on each), full suite 5,122 passed / 14 skipped.

Also settled while investigating: trestle 5.0.0 ships OSCAL_VERSION_REGEX ^1\.2\.[0-1]$, so the recorded OSCAL 1.2.2 DEFER-WITH-TRIGGER has NOT fired.